### PR TITLE
feat(design-system): design tokens + Storybook previews (Material 3–inspired)

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,4 +1,5 @@
 import type { StorybookConfig } from "@storybook/nextjs-vite";
+import { vanillaExtractPlugin } from "@vanilla-extract/vite-plugin";
 
 const config: StorybookConfig = {
   "stories": [
@@ -18,6 +19,11 @@ const config: StorybookConfig = {
   },
   "staticDirs": [
     "..\\public"
-  ]
+  ],
+  // Ensure Vanilla Extract .css.ts files are processed by Vite in Storybook
+  viteFinal: async (config) => {
+    config.plugins = [...(config.plugins ?? []), vanillaExtractPlugin()];
+    return config;
+  }
 };
 export default config;

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,8 +21,9 @@ This roadmap defines incremental milestones for Bukie, each mapped to a set of a
 
 ### Design System & Layout
 * ✅ feat: custom Storybook setup
-* 🛠️ feat: minimal app shell
-* ⏳ feat: first UI component
+* ✅ feat: minimal app shell
+* ✅ feat: design tokens in Storybook (Material 3–inspired: 8pt spacing, rem typography, basic color roles)
+* 🛠️ feat: 12‑column grid primitives (Container/Grid/Column) aligned to Material breakpoints + stories
 * ⏳ docs: design system documentation
 
 ### Core Features
@@ -54,10 +55,8 @@ This roadmap defines incremental milestones for Bukie, each mapped to a set of a
 
 ## 📅 Next Steps
 
-The next milestone is focused on design system and UI tooling:
-* Set up a custom Storybook configuration for component development and documentation
-* Build a minimal app shell: SSR page with header "Bukie" only
-* Start building the first UI component
+The next milestone is focused on incremental design system foundations:
+* Add minimal 12‑column grid primitives aligned to Material breakpoints with a responsive story (in progress)
 * Document the design system and component workflow
 
 ---

--- a/src/design/tokens.css.ts
+++ b/src/design/tokens.css.ts
@@ -1,0 +1,113 @@
+import { createTheme, createThemeContract } from "@vanilla-extract/css";
+
+export const tokens = createThemeContract({
+  spacing: {
+    "0": null,
+    "0_5": null, // 4px
+    "1": null, // 8px
+    "1_5": null, // 12px
+    "2": null, // 16px
+    "3": null, // 24px
+    "4": null, // 32px
+    "6": null, // 48px
+    "8": null, // 64px
+  },
+  typography: {
+    xs: null,
+    sm: null,
+    md: null,
+    lg: null,
+    xl: null,
+    lineHeight: {
+      tight: null,
+      normal: null,
+      relaxed: null,
+    },
+  },
+  color: {
+    primary: null,
+    onPrimary: null,
+    surface: null,
+    onSurface: null,
+    background: null,
+    onBackground: null,
+    error: null,
+    onError: null,
+  },
+  radius: {
+    sm: null,
+    md: null,
+    lg: null,
+  },
+  elevation: {
+    "0": null,
+    "1": null,
+    "2": null,
+    "3": null,
+    "4": null,
+    "5": null,
+  },
+  breakpoints: {
+    xs: null,
+    sm: null,
+    md: null,
+    lg: null,
+    xl: null,
+  },
+});
+
+export const lightThemeClass = createTheme(tokens, {
+  spacing: {
+    "0": "0px",
+    "0_5": "0.25rem",
+    "1": "0.5rem",
+    "1_5": "0.75rem",
+    "2": "1rem",
+    "3": "1.5rem",
+    "4": "2rem",
+    "6": "3rem",
+    "8": "4rem",
+  },
+  typography: {
+    xs: "0.75rem",
+    sm: "0.875rem",
+    md: "1rem",
+    lg: "1.25rem",
+    xl: "1.5rem",
+    lineHeight: {
+      tight: "1.2",
+      normal: "1.5",
+      relaxed: "1.7",
+    },
+  },
+  color: {
+    primary: "#6750A4",
+    onPrimary: "#FFFFFF",
+    surface: "#FFFBFE",
+    onSurface: "#1C1B1F",
+    background: "#FFFFFF",
+    onBackground: "#1C1B1F",
+    error: "#B3261E",
+    onError: "#FFFFFF",
+  },
+  radius: {
+    sm: "4px",
+    md: "8px",
+    lg: "12px",
+  },
+  elevation: {
+    "0": "none",
+    "1": "0 1px 2px rgba(0,0,0,0.08)",
+    "2": "0 2px 4px rgba(0,0,0,0.10)",
+    "3": "0 4px 8px rgba(0,0,0,0.12)",
+    "4": "0 8px 16px rgba(0,0,0,0.14)",
+    "5": "0 12px 24px rgba(0,0,0,0.16)",
+  },
+  breakpoints: {
+    xs: "0px",
+    sm: "600px",
+    md: "905px",
+    lg: "1240px",
+    xl: "1440px",
+  },
+});

--- a/src/design/tokens.test.ts
+++ b/src/design/tokens.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { lightThemeClass, tokens } from "./tokens.css";
+
+describe("design tokens module", () => {
+  it("exports a theme class and a typed contract", () => {
+    expect(typeof lightThemeClass).toBe("string");
+    expect(tokens).toBeDefined();
+    // leaf values resolve to CSS var() references as strings
+    expect(typeof tokens.spacing["1"]).toBe("string");
+    expect(tokens.spacing["1"]).toMatch(/^var\(/);
+  });
+});

--- a/src/stories/Tokens.stories.tsx
+++ b/src/stories/Tokens.stories.tsx
@@ -4,6 +4,10 @@ import { useEffect, useRef, useState } from "react";
 import { lightThemeClass, tokens } from "../design/tokens.css";
 import { swatch } from "./tokens.css";
 
+// Shared token keys to avoid duplication
+const SPACING_KEYS = ["0", "0_5", "1", "1_5", "2", "3", "4", "6", "8"] as const;
+const TYPOGRAPHY_KEYS = ["xs", "sm", "md", "lg", "xl"] as const;
+
 const Stack: React.FC<{ gap?: string; children: React.ReactNode }> = ({
   gap = tokens.spacing["1"],
   children,
@@ -86,7 +90,7 @@ export const Spacing: StoryObj = {
     useEffect(() => {
       if (!ref.current) return;
       const el = ref.current;
-      const keys = ["0", "0_5", "1", "1_5", "2", "3", "4", "6", "8"] as const;
+      const keys = SPACING_KEYS;
       const next: Record<string, string> = {};
       for (const k of keys) {
         const v = tokens.spacing[k];
@@ -98,30 +102,28 @@ export const Spacing: StoryObj = {
     return (
       <div ref={ref}>
         <Stack>
-          {(["0", "0_5", "1", "1_5", "2", "3", "4", "6", "8"] as const).map(
-            (k) => (
+          {SPACING_KEYS.map((k) => (
+            <div
+              key={k}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: tokens.spacing["1"],
+              }}
+            >
               <div
-                key={k}
                 style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: tokens.spacing["1"],
+                  width: tokens.spacing[k],
+                  height: tokens.spacing[k],
+                  background: tokens.color.primary,
+                  opacity: 0.3,
                 }}
-              >
-                <div
-                  style={{
-                    width: tokens.spacing[k],
-                    height: tokens.spacing[k],
-                    background: tokens.color.primary,
-                    opacity: 0.3,
-                  }}
-                />
-                <code>
-                  spacing[{k}] = {resolved[k] ?? tokens.spacing[k]}
-                </code>
-              </div>
-            ),
-          )}
+              />
+              <code>
+                spacing[{k}] = {resolved[k] ?? tokens.spacing[k]}
+              </code>
+            </div>
+          ))}
         </Stack>
       </div>
     );
@@ -135,7 +137,7 @@ export const Typography: StoryObj = {
     useEffect(() => {
       if (!ref.current) return;
       const el = ref.current;
-      const keys = ["xs", "sm", "md", "lg", "xl"] as const;
+      const keys = TYPOGRAPHY_KEYS;
       const next: Record<string, string> = {};
       for (const k of keys) {
         const v = tokens.typography[k];
@@ -145,7 +147,7 @@ export const Typography: StoryObj = {
       // line height
       const lh = tokens.typography.lineHeight.normal;
       const lm = /^var\((--[^)]+)\)/.exec(lh);
-      next.lineHeight = lm
+      next["lineHeight"] = lm
         ? getComputedStyle(el).getPropertyValue(lm[1]).trim()
         : lh;
       setResolved(next);
@@ -153,12 +155,12 @@ export const Typography: StoryObj = {
     return (
       <div ref={ref}>
         <Stack>
-          {(["xs", "sm", "md", "lg", "xl"] as const).map((k) => (
+          {TYPOGRAPHY_KEYS.map((k) => (
             <div
               key={k}
               style={{
                 fontSize: tokens.typography[k],
-                lineHeight: String(tokens.typography.lineHeight.normal),
+                lineHeight: tokens.typography.lineHeight.normal,
               }}
             >
               The quick brown fox — {k} ({resolved[k] ?? tokens.typography[k]})

--- a/src/stories/Tokens.stories.tsx
+++ b/src/stories/Tokens.stories.tsx
@@ -1,0 +1,171 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type React from "react";
+import { useEffect, useRef, useState } from "react";
+import { lightThemeClass, tokens } from "../design/tokens.css";
+import { swatch } from "./tokens.css";
+
+const Stack: React.FC<{ gap?: string; children: React.ReactNode }> = ({
+  gap = tokens.spacing["1"],
+  children,
+}) => (
+  <div style={{ display: "flex", flexDirection: "column", gap }}>
+    {children}
+  </div>
+);
+
+const Row: React.FC<{ gap?: string; children: React.ReactNode }> = ({
+  gap = tokens.spacing["1"],
+  children,
+}) => (
+  <div
+    style={{ display: "flex", flexDirection: "row", gap, alignItems: "center" }}
+  >
+    {children}
+  </div>
+);
+
+const meta: Meta = {
+  title: "Design/Tokens",
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Foundational tokens inspired by Material 3. Apply the exported theme class (lightThemeClass) high in your app tree (e.g., on the layout wrapper) and reference token values in components/styles. Keep components small and use tokens via Vanilla Extract. This story previews colors, spacing, and type scale.",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div
+        className={lightThemeClass}
+        style={{
+          padding: tokens.spacing["2"],
+          background: tokens.color.background,
+          color: tokens.color.onBackground,
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+export const Colors: StoryObj = {
+  render: () => (
+    <Stack>
+      <Row>
+        <div className={swatch} style={{ background: tokens.color.primary }} />
+        <span>primary / onPrimary</span>
+      </Row>
+      <Row>
+        <div className={swatch} style={{ background: tokens.color.surface }} />
+        <span>surface / onSurface</span>
+      </Row>
+      <Row>
+        <div
+          className={swatch}
+          style={{ background: tokens.color.background }}
+        />
+        <span>background / onBackground</span>
+      </Row>
+      <Row>
+        <div className={swatch} style={{ background: tokens.color.error }} />
+        <span>error / onError</span>
+      </Row>
+    </Stack>
+  ),
+};
+
+export const Spacing: StoryObj = {
+  render: () => {
+    const ref = useRef<HTMLDivElement>(null);
+    const [resolved, setResolved] = useState<Record<string, string>>({});
+    useEffect(() => {
+      if (!ref.current) return;
+      const el = ref.current;
+      const keys = ["0", "0_5", "1", "1_5", "2", "3", "4", "6", "8"] as const;
+      const next: Record<string, string> = {};
+      for (const k of keys) {
+        const v = tokens.spacing[k];
+        const m = /^var\((--[^)]+)\)/.exec(v);
+        next[k] = m ? getComputedStyle(el).getPropertyValue(m[1]).trim() : v;
+      }
+      setResolved(next);
+    }, []);
+    return (
+      <div ref={ref}>
+        <Stack>
+          {(["0", "0_5", "1", "1_5", "2", "3", "4", "6", "8"] as const).map(
+            (k) => (
+              <div
+                key={k}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: tokens.spacing["1"],
+                }}
+              >
+                <div
+                  style={{
+                    width: tokens.spacing[k],
+                    height: tokens.spacing[k],
+                    background: tokens.color.primary,
+                    opacity: 0.3,
+                  }}
+                />
+                <code>
+                  spacing[{k}] = {resolved[k] ?? tokens.spacing[k]}
+                </code>
+              </div>
+            ),
+          )}
+        </Stack>
+      </div>
+    );
+  },
+};
+
+export const Typography: StoryObj = {
+  render: () => {
+    const ref = useRef<HTMLDivElement>(null);
+    const [resolved, setResolved] = useState<Record<string, string>>({});
+    useEffect(() => {
+      if (!ref.current) return;
+      const el = ref.current;
+      const keys = ["xs", "sm", "md", "lg", "xl"] as const;
+      const next: Record<string, string> = {};
+      for (const k of keys) {
+        const v = tokens.typography[k];
+        const m = /^var\((--[^)]+)\)/.exec(v);
+        next[k] = m ? getComputedStyle(el).getPropertyValue(m[1]).trim() : v;
+      }
+      // line height
+      const lh = tokens.typography.lineHeight.normal;
+      const lm = /^var\((--[^)]+)\)/.exec(lh);
+      next.lineHeight = lm
+        ? getComputedStyle(el).getPropertyValue(lm[1]).trim()
+        : lh;
+      setResolved(next);
+    }, []);
+    return (
+      <div ref={ref}>
+        <Stack>
+          {(["xs", "sm", "md", "lg", "xl"] as const).map((k) => (
+            <div
+              key={k}
+              style={{
+                fontSize: tokens.typography[k],
+                lineHeight: String(tokens.typography.lineHeight.normal),
+              }}
+            >
+              The quick brown fox — {k} ({resolved[k] ?? tokens.typography[k]})
+            </div>
+          ))}
+        </Stack>
+      </div>
+    );
+  },
+};

--- a/src/stories/tokens.css.ts
+++ b/src/stories/tokens.css.ts
@@ -1,0 +1,8 @@
+import { style } from "@vanilla-extract/css";
+
+export const swatch = style({
+  width: 48,
+  height: 24,
+  borderRadius: 4,
+  border: "1px solid #ddd",
+});


### PR DESCRIPTION
This PR introduces foundational design tokens and Storybook previews, aligned with our SSR-first and VE-only styling approach.

What’s included
- Vanilla Extract theme contract + light theme:
  - spacing (8pt), rem typography, color roles, radii, elevation, breakpoints
- Storybook tokens stories: colors, spacing (with resolved values), typography; story-only styles
- Storybook config: process .css.ts via @vanilla-extract/vite-plugin
- Unit test: tokens module import/shape
- Roadmap updated: minimal app shell + tokens done; 12‑column grid in progress

Notes
- Server components keep styles server-rendered; story-only styles remain local to stories.
- Future work: 12‑column grid primitives and docs.

Closes #30