### PR TITLE
feat(design-system): 12‑column grid primitives + docs/tests

### DIFF
--- a/docs/design-system/grid.md
+++ b/docs/design-system/grid.md
@@ -1,0 +1,62 @@
+# Grid primitives (12‑column)
+
+The grid provides a small set of primitives to create responsive layouts using a 12‑column system.
+It’s implemented with Vanilla Extract and uses design tokens for spacing and breakpoints.
+
+- Container: horizontally centers content; applies responsive max‑widths
+- Grid: defines a 12‑column CSS grid; gap variants map to tokens.spacing
+- Column: spans one or more columns; supports responsive spans per breakpoint
+
+## Quick start
+
+```tsx
+import { Container, Grid, Column } from "src/design/layout/grid";
+
+export default function Example() {
+  return (
+    <Container>
+      <Grid gap="md">
+        <Column span={{ base: 12, sm: 6, md: 4 }}>
+          {/* content */}
+        </Column>
+        <Column span={{ base: 12, sm: 6, md: 8 }}>
+          {/* content */}
+        </Column>
+      </Grid>
+    </Container>
+  );
+}
+```
+
+## What the numbers mean
+
+In the stories you’ll see blocks labeled 1..12. Each block shows its column span:
+- span={1} occupies 1/12 of the row width
+- span={6} occupies 6/12 (half the row)
+- span={12} occupies the full row
+
+Responsive spans accept an object per breakpoint:
+- span={{ base: 12, sm: 6, md: 4 }} means:
+  - base (mobile): full width
+  - ≥ sm: half width
+  - ≥ md: one third width
+
+Breakpoints are aligned to Material‑like ranges and mirrored from tokens.breakpoints.
+
+## Implementation overview
+
+- Styling lives in grid.css.ts and is compiled at build time with Vanilla Extract
+- A small helpers.ts module computes which CSS classes to apply for a given span
+- Media queries cannot read CSS variables, so we mirror numeric breakpoints inside the style module to generate responsive classes
+- Gaps are variant classes backed by tokens.spacing
+
+## Accessibility
+
+- Primitives are un-opinionated divs; avoid setting roles unless the content demands it
+- Ensure focus order and keyboard navigation are preserved by your content structure
+- Don’t encode meaning purely in span/gap; rely on semantics inside the columns
+
+## Testing
+
+- A unit test ensures the grid module exports build and basic APIs exist
+- Storybook tests (via @storybook/addon-vitest) can verify that stories render without errors

--- a/src/design/layout/grid/Column.tsx
+++ b/src/design/layout/grid/Column.tsx
@@ -1,0 +1,20 @@
+import type React from "react";
+import { type ResponsiveSpan, resolveSpanClasses } from "./helpers";
+
+export type ColumnProps = React.PropsWithChildren<{
+  span?: ResponsiveSpan;
+  className?: string;
+}>;
+
+export const Column: React.FC<ColumnProps> = ({
+  span = 12,
+  className,
+  children,
+}) => {
+  const spans = resolveSpanClasses(span);
+  return (
+    <div className={[...spans, className].filter(Boolean).join(" ")}>
+      {children}
+    </div>
+  );
+};

--- a/src/design/layout/grid/Container.tsx
+++ b/src/design/layout/grid/Container.tsx
@@ -1,0 +1,15 @@
+import type React from "react";
+import { container } from "./grid.css";
+
+export type ContainerProps = React.PropsWithChildren<{
+  className?: string;
+}>;
+
+export const Container: React.FC<ContainerProps> = ({
+  className,
+  children,
+}) => (
+  <div className={[container, className].filter(Boolean).join(" ")}>
+    {children}
+  </div>
+);

--- a/src/design/layout/grid/Grid.tsx
+++ b/src/design/layout/grid/Grid.tsx
@@ -1,0 +1,17 @@
+import type React from "react";
+import { gap, grid } from "./grid.css";
+
+export type GridProps = React.PropsWithChildren<{
+  gap?: keyof typeof gap;
+  className?: string;
+}>;
+
+export const Grid: React.FC<GridProps> = ({
+  gap: gapKey = "sm",
+  className,
+  children,
+}) => (
+  <div className={[grid, gap[gapKey], className].filter(Boolean).join(" ")}>
+    {children}
+  </div>
+);

--- a/src/design/layout/grid/grid.css.ts
+++ b/src/design/layout/grid/grid.css.ts
@@ -1,0 +1,85 @@
+import { style, styleVariants } from "@vanilla-extract/css";
+import { tokens } from "../../tokens.css";
+
+// Note: CSS variables cannot be used in media queries. We mirror the numeric
+// values from tokens.breakpoints here to generate media queries. Keep in sync.
+const bp = {
+  sm: 600,
+  md: 905,
+  lg: 1240,
+  xl: 1440,
+} as const;
+
+export const container = style({
+  marginLeft: "auto",
+  marginRight: "auto",
+  paddingLeft: tokens.spacing["2"],
+  paddingRight: tokens.spacing["2"],
+  width: "100%",
+  maxWidth: "100%",
+  "@media": {
+    [`screen and (min-width: ${bp.sm}px)`]: { maxWidth: "600px" },
+    [`screen and (min-width: ${bp.md}px)`]: { maxWidth: "905px" },
+    [`screen and (min-width: ${bp.lg}px)`]: { maxWidth: "1240px" },
+    [`screen and (min-width: ${bp.xl}px)`]: { maxWidth: "1440px" },
+  },
+});
+
+export const grid = style({
+  display: "grid",
+  gridTemplateColumns: "repeat(12, minmax(0, 1fr))",
+});
+
+export const gap = styleVariants({
+  none: { gap: tokens.spacing["0"] },
+  xs: { gap: tokens.spacing["0_5"] },
+  sm: { gap: tokens.spacing["1"] },
+  md: { gap: tokens.spacing["2"] },
+  lg: { gap: tokens.spacing["3"] },
+  xl: { gap: tokens.spacing["4"] },
+});
+
+const spanBase = Object.fromEntries(
+  Array.from({ length: 12 }, (_, i) => {
+    const n = (i + 1) as 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+    return [n, style({ gridColumn: `span ${n} / span ${n}` })];
+  }),
+) as Record<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12, string>;
+
+const spanAt = (minWidthPx: number) =>
+  Object.fromEntries(
+    Array.from({ length: 12 }, (_, i) => {
+      const n = (i + 1) as 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+      return [
+        n,
+        style({
+          "@media": {
+            [`screen and (min-width: ${minWidthPx}px)`]: {
+              gridColumn: `span ${n} / span ${n}`,
+            },
+          },
+        }),
+      ];
+    }),
+  ) as Record<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12, string>;
+
+const spanSm = spanAt(bp.sm);
+const spanMd = spanAt(bp.md);
+const spanLg = spanAt(bp.lg);
+const spanXl = spanAt(bp.xl);
+
+export const spanClasses = {
+  base: spanBase,
+  sm: spanSm,
+  md: spanMd,
+  lg: spanLg,
+  xl: spanXl,
+};
+
+export const boxHelper = style({
+  background: tokens.color.primary,
+  color: tokens.color.onPrimary,
+  padding: tokens.spacing["1"],
+  borderRadius: tokens.radius.sm,
+  textAlign: "center",
+});

--- a/src/design/layout/grid/grid.test.ts
+++ b/src/design/layout/grid/grid.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { Column } from "./Column";
+import { Container } from "./Container";
+import { Grid } from "./Grid";
+
+describe("grid primitives module", () => {
+  it("exports components", () => {
+    expect(Container).toBeDefined();
+    expect(Grid).toBeDefined();
+    expect(Column).toBeDefined();
+  });
+});

--- a/src/design/layout/grid/helpers.test.ts
+++ b/src/design/layout/grid/helpers.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { resolveSpanClasses } from "./helpers";
+
+describe("resolveSpanClasses", () => {
+  it("returns a single class for numeric span (base)", () => {
+    const span = 6;
+
+    const classes = resolveSpanClasses(span);
+
+    expect(Array.isArray(classes)).toBe(true);
+    expect(classes.length).toBe(1);
+    expect(typeof classes[0]).toBe("string");
+  });
+
+  it("returns classes for responsive object spans", () => {
+    const span = { base: 12, sm: 6, md: 4 } as const;
+
+    const classes = resolveSpanClasses(span);
+
+    expect(classes.length).toBe(3);
+    classes.forEach((c) => expect(typeof c).toBe("string"));
+  });
+});

--- a/src/design/layout/grid/helpers.ts
+++ b/src/design/layout/grid/helpers.ts
@@ -1,0 +1,40 @@
+import { spanClasses } from "./grid.css";
+
+export type ResponsiveSpan =
+  | number
+  | {
+      base?: number;
+      sm?: number;
+      md?: number;
+      lg?: number;
+      xl?: number;
+    };
+
+const clamp = (n: number) =>
+  (n < 1 ? 1 : n > 12 ? 12 : n) as
+    | 1
+    | 2
+    | 3
+    | 4
+    | 5
+    | 6
+    | 7
+    | 8
+    | 9
+    | 10
+    | 11
+    | 12;
+
+export const resolveSpanClasses = (span: ResponsiveSpan): string[] => {
+  const classes: string[] = [];
+  if (typeof span === "number") {
+    classes.push(spanClasses.base[clamp(span)]);
+    return classes;
+  }
+  if (span.base != null) classes.push(spanClasses.base[clamp(span.base)]);
+  if (span.sm != null) classes.push(spanClasses.sm[clamp(span.sm)]);
+  if (span.md != null) classes.push(spanClasses.md[clamp(span.md)]);
+  if (span.lg != null) classes.push(spanClasses.lg[clamp(span.lg)]);
+  if (span.xl != null) classes.push(spanClasses.xl[clamp(span.xl)]);
+  return classes;
+};

--- a/src/design/layout/grid/index.ts
+++ b/src/design/layout/grid/index.ts
@@ -1,0 +1,4 @@
+export { Column } from "./Column";
+export { Container } from "./Container";
+export { Grid } from "./Grid";
+export type { ResponsiveSpan } from "./helpers";

--- a/src/stories/Grid.stories.tsx
+++ b/src/stories/Grid.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Column, Container, Grid } from "../design/layout/grid";
+import { boxHelper } from "../design/layout/grid/grid.css";
+import { lightThemeClass, tokens } from "../design/tokens.css";
+
+const meta: Meta = {
+  title: "Design/Grid",
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "12-column grid primitives. Container centers content; Grid defines columns; Column spans. Gaps and breakpoints derive from tokens.",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className={lightThemeClass} style={{ padding: tokens.spacing["2"] }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+export default meta;
+
+export const Basic: StoryObj = {
+  render: () => (
+    <Container>
+      <Grid>
+        {Array.from({ length: 12 }, (_, i) => i + 1).map((n) => (
+          <Column key={n} span={1}>
+            <div className={boxHelper}>{n}</div>
+          </Column>
+        ))}
+      </Grid>
+    </Container>
+  ),
+};
+
+export const Gutters: StoryObj = {
+  render: () => (
+    <Container>
+      <Grid gap="md">
+        <Column span={6}>
+          <div className={boxHelper}>6</div>
+        </Column>
+        <Column span={6}>
+          <div className={boxHelper}>6</div>
+        </Column>
+        <Column span={4}>
+          <div className={boxHelper}>4</div>
+        </Column>
+        <Column span={4}>
+          <div className={boxHelper}>4</div>
+        </Column>
+        <Column span={4}>
+          <div className={boxHelper}>4</div>
+        </Column>
+      </Grid>
+    </Container>
+  ),
+};
+
+export const ResponsiveSpans: StoryObj = {
+  render: () => (
+    <Container>
+      <Grid gap="sm">
+        <Column span={{ base: 12, sm: 6, md: 4 }}>
+          <div className={boxHelper}>12 → 6 → 4</div>
+        </Column>
+        <Column span={{ base: 12, sm: 6, md: 4 }}>
+          <div className={boxHelper}>12 → 6 → 4</div>
+        </Column>
+        <Column span={{ base: 12, sm: 12, md: 4 }}>
+          <div className={boxHelper}>12 → 12 → 4</div>
+        </Column>
+      </Grid>
+    </Container>
+  ),
+};

--- a/src/stories/Tokens.stories.tsx
+++ b/src/stories/Tokens.stories.tsx
@@ -147,7 +147,7 @@ export const Typography: StoryObj = {
       // line height
       const lh = tokens.typography.lineHeight.normal;
       const lm = /^var\((--[^)]+)\)/.exec(lh);
-      next["lineHeight"] = lm
+      next.lineHeight = lm
         ? getComputedStyle(el).getPropertyValue(lm[1]).trim()
         : lh;
       setResolved(next);


### PR DESCRIPTION
This PR adds the initial 12‑column grid primitives aligned with our tokens and MD3-style breakpoints.

What’s included
- VE styles: container, grid, gap variants, span classes (1–12) with responsive media queries
- Components: Container, Grid, Column
- Helpers: resolve responsive span classes outside .css.ts (to satisfy vanilla-extract export rules)
- Storybook: Basic, Gutters, and Responsive spans stories
- Docs: docs/design-system/grid.md (how it works + usage)
- Tests: grid exports and helpers (AAA)

Notes
- Breakpoints are mirrored as numbers inside styles (media queries can’t read CSS vars). Keep in sync with tokens.

Closes #32