### PR TITLE
feat(books): add SSR item page with accessible UI + metadata

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,9 +5,9 @@ This roadmap defines incremental milestones for Bukie, each mapped to a set of a
 ## Milestones
 
 ### Initial Release
-* ✅ feat: define initial technical architecture (#1)
-* ✅ feat: add semantic-release (#5)
-* ✅ ci: add GitHub Actions workflow for semantic-release (#6)
+* ✅ feat: define initial technical architecture
+* ✅ feat: add semantic-release
+* ✅ ci: add GitHub Actions workflow for semantic-release
 
 ### Tooling & Quality
 * ✅ ci: add Biome for linting and formatting
@@ -39,11 +39,11 @@ This roadmap defines incremental milestones for Bukie, each mapped to a set of a
 * ✅ feat: replace mock data with real DB queries
 * ✅ feat: update book list UI to load from backend (SSR)
 * ✅ test: add basic API endpoint tests (AAA style)
-* ⏳ docs: document backend API and setup
-* ⏳ feat(db-postgres): add Postgres client and env-based DB provider selection for preview/prod
+* ✅ docs: document backend API and setup
+* ✅ feat(db-postgres): add Postgres client and env-based DB provider selection for preview/prod
 
 ### Core Features (DB-backed)
-* ⏳ feat: item page for books (SSR from backend)
+* 🛠️ feat: item page for books (SSR from backend)
 * ⏳ feat: basic search functionality (query DB)
 * ⏳ feat: authentication (Clerk or similar)
 * ⏳ feat: add book (CRUD: create, DB-backed)
@@ -69,10 +69,9 @@ This roadmap defines incremental milestones for Bukie, each mapped to a set of a
 * feat: all core features stable
 
 ## 📅 Next Steps
-
-The next milestone is focused on incremental design system foundations:
-* Add minimal 12‑column grid primitives aligned to Material breakpoints with a responsive story (in progress)
-* Document the design system and component workflow
+The next milestone is focused on Core Features (DB‑backed):
+* Build the item page for books (SSR from backend) 🛠️
+* Prepare basic search foundation (indexing and query shape)
 
 ---
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://localhost:3000',
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:3000',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -70,10 +70,13 @@ export default defineConfig({
     // },
   ],
 
-  /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run start',
-  //   url: 'http://localhost:3000',
-  //   reuseExistingServer: !process.env.CI,
-  // },
+  /* Run local server only when not targeting a deployed baseURL */
+  webServer: process.env.PLAYWRIGHT_BASE_URL
+    ? undefined
+    : {
+        command: 'bun run build && bun run start',
+        url: 'http://127.0.0.1:3000',
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+      },
 });

--- a/src/app/books/[id]/page.tsx
+++ b/src/app/books/[id]/page.tsx
@@ -1,0 +1,35 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { BookDetails } from "@/features/books/BookDetails";
+import { findBookById } from "@/features/books/repo";
+
+export const dynamic = "force-dynamic";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const book = await findBookById(id);
+  if (!book) return { title: "Book not found" };
+  return {
+    title: `${book.title} — ${book.author}`,
+    description: `Details for ${book.title} by ${book.author}`,
+  };
+}
+
+export default async function BookPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const book = await findBookById(id);
+  if (!book) notFound();
+  return (
+    <main>
+      <BookDetails book={book} />
+    </main>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,8 @@
+export default function NotFound() {
+  return (
+    <main>
+      <h1 style={{ fontSize: "1.25rem", margin: "2rem 0" }}>Not found</h1>
+      <p>The requested resource could not be found.</p>
+    </main>
+  );
+}

--- a/src/features/books/BookCard.tsx
+++ b/src/features/books/BookCard.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import Link from "next/link";
 import * as s from "./BookCard.css";
 import type { Book } from "./types";
 
@@ -7,15 +8,22 @@ export type BookCardProps = { book: Book };
 export function BookCard({ book }: BookCardProps) {
   return (
     <div className={s.card}>
-      <Image
-        src={book.cover}
-        alt={`Cover of ${book.title} by ${book.author}`}
-        width={120}
-        height={180}
-        className={s.image}
-        unoptimized
-      />
-      <h3 className={s.title}>{book.title}</h3>
+      <Link
+        href={`/books/${book.id}`}
+        aria-label={`View details for ${book.title}`}
+      >
+        <Image
+          src={book.cover}
+          alt={`Cover of ${book.title} by ${book.author}`}
+          width={120}
+          height={180}
+          className={s.image}
+          unoptimized
+        />
+      </Link>
+      <h3 className={s.title}>
+        <Link href={`/books/${book.id}`}>{book.title}</Link>
+      </h3>
       <p className={s.author}>{book.author}</p>
     </div>
   );

--- a/src/features/books/BookDetails.css.ts
+++ b/src/features/books/BookDetails.css.ts
@@ -1,0 +1,48 @@
+import { style } from "@vanilla-extract/css";
+import { tokens } from "@/design/tokens.css";
+
+export const page = style({
+  display: "block",
+  padding: tokens.spacing["3"],
+});
+
+export const layout = style({
+  display: "grid",
+  gap: tokens.spacing["3"],
+  gridTemplateColumns: "1fr",
+  alignItems: "start",
+  "@media": {
+    "screen and (min-width: 768px)": {
+      gridTemplateColumns: "auto 1fr",
+      gap: tokens.spacing["4"],
+    },
+  },
+});
+
+export const cover = style({
+  width: 180,
+  height: 270,
+  objectFit: "cover",
+  borderRadius: tokens.radius.md,
+  boxShadow: tokens.elevation["1"],
+});
+
+export const title = style({
+  margin: `0 0 ${tokens.spacing["1"]}`,
+  fontSize: tokens.typography.xl,
+  lineHeight: tokens.typography.lineHeight.tight,
+  color: tokens.color.onSurface,
+});
+
+export const author = style({
+  margin: 0,
+  fontSize: tokens.typography.md,
+  color: tokens.color.onSurface,
+  opacity: 0.8,
+});
+
+export const meta = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: tokens.spacing["1"],
+});

--- a/src/features/books/BookDetails.test.tsx
+++ b/src/features/books/BookDetails.test.tsx
@@ -1,0 +1,25 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { lightThemeClass } from "@/design/tokens.css";
+import { BookDetails } from "./BookDetails";
+
+describe("BookDetails UI", () => {
+  it("renders title and author", () => {
+    render(
+      <div className={lightThemeClass}>
+        <BookDetails
+          book={{
+            id: "1",
+            title: "Dune",
+            author: "Frank Herbert",
+            cover: "https://placehold.co/180x270",
+          }}
+        />
+      </div>,
+    );
+
+    expect(screen.getByRole("heading", { name: /dune/i })).toBeInTheDocument();
+    expect(screen.getByText(/frank herbert/i)).toBeInTheDocument();
+  });
+});

--- a/src/features/books/BookDetails.tsx
+++ b/src/features/books/BookDetails.tsx
@@ -1,0 +1,31 @@
+import Image from "next/image";
+import * as s from "./BookDetails.css";
+import type { Book } from "./types";
+
+export type BookDetailsProps = { book: Book };
+
+export function BookDetails({ book }: BookDetailsProps) {
+  return (
+    <article className={s.page} aria-labelledby="book-title">
+      <div className={s.layout}>
+        <Image
+          src={book.cover}
+          alt={`Cover of ${book.title} by ${book.author}`}
+          width={180}
+          height={270}
+          className={s.cover}
+          unoptimized
+        />
+        <section className={s.meta}>
+          <h1 id="book-title" className={s.title}>
+            {book.title}
+          </h1>
+          <p className={s.author}>
+            <span>by </span>
+            <span>{book.author}</span>
+          </p>
+        </section>
+      </div>
+    </article>
+  );
+}

--- a/tests/book-item.spec.ts
+++ b/tests/book-item.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from "@playwright/test";
+
+// This test assumes seed creates books with id = "1" ... "50".
+// If running against a fresh dev DB, run: bun run db:seed
+
+test.describe("Book item page", () => {
+  test("navigates from home to item and shows content", async ({ page }) => {
+    await page.goto("/");
+    const firstCardLink = page.locator('a[href="/books/1"]');
+    await firstCardLink.first().click();
+    await expect(page).toHaveURL(/\/books\/1$/);
+    await expect(page.getByRole("heading")).toBeVisible();
+  });
+});


### PR DESCRIPTION
Implements the 🛠️ Core Feature from the roadmap: item page for books (SSR from backend).

What’s included
- Route: Server Component at src/app/books/[id]/page.tsx with generateMetadata
- UI: BookDetails component + Vanilla Extract styles
- UX: BookCard now links to /books/[id]
- Routing: not-found page for missing items
- Tests: unit test for BookDetails; e2e that navigates from list to item
- E2E config: support PLAYWRIGHT_BASE_URL to run against Vercel preview

How to test locally
- bun run build && bun run start
- bun run test           # unit
- bun run test:playwright

Notes
- Keeps server data fetching (SSR); no client fetches
- Accessible semantics for the detail view (heading, labelled image)

Closes #44