### PR TITLE
feat(books): single-star rating and book page polish + Storybook lucide fix

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-import { BookOpen } from "lucide-react";
+import BookOpen from "lucide-react/dist/esm/icons/book-open.js";
 import { cookies } from "next/headers";
 import Script from "next/script";
 import { Container } from "@/design/layout/grid";

--- a/src/design/theme/ThemeToggle.tsx
+++ b/src/design/theme/ThemeToggle.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Moon, Sun } from "lucide-react";
+import Moon from "lucide-react/dist/esm/icons/moon.js";
+import Sun from "lucide-react/dist/esm/icons/sun.js";
 import { useEffect, useState, useTransition } from "react";
 import { setTheme } from "./actions";
 import * as s from "./toggle.css";

--- a/src/features/books/BookCard.css.ts
+++ b/src/features/books/BookCard.css.ts
@@ -12,7 +12,7 @@ export const card = style({
   alignItems: "stretch",
   gap: tokens.spacing["1"],
   // Fix card height so all cards align uniformly across rows
-  height: 420,
+  height: 430,
   overflow: "hidden",
   transition:
     "box-shadow 200ms ease, transform 200ms ease, border-color 200ms ease",
@@ -30,13 +30,15 @@ export const media = style({
   position: "relative",
   width: "100%",
   // Slightly taller media area to match reference composition
-  height: 280,
+  height: 290,
 });
 
 export const image = style({
   borderRadius: 0,
   width: "100%",
-  height: "100%",
+  // Increase the top offset between card top and image for nicer composition
+  height: `calc(100% - ${tokens.spacing["2"]})`,
+  marginTop: tokens.spacing["2"],
   objectFit: "cover",
   objectPosition: "top",
   display: "block",
@@ -141,6 +143,29 @@ export const starIcon = style({
   height: 12,
   display: "inline-block",
   color: tokens.color.star,
+});
+
+// Single rating row with star + value + optional count
+export const ratingRow = style({
+  display: "inline-flex",
+  alignItems: "center",
+  gap: tokens.spacing["0_5"],
+});
+
+export const ratingsCount = style({
+  opacity: 0.8,
+});
+
+export const srOnly = style({
+  position: "absolute",
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: "hidden",
+  clip: "rect(0, 0, 0, 0)",
+  whiteSpace: "nowrap",
+  border: 0,
 });
 
 export const body = style({

--- a/src/features/books/BookCard.test.tsx
+++ b/src/features/books/BookCard.test.tsx
@@ -11,6 +11,7 @@ const book = {
   cover: "/42.jpg",
   genre: "Sci-Fi",
   rating: 4.5,
+  ratingsCount: 12847,
   year: 1979,
 };
 
@@ -31,7 +32,7 @@ describe("BookCard", () => {
     expect(img).toBeInTheDocument();
   });
 
-  it("renders optional badge, rating and year when provided", () => {
+  it("renders optional badge, rating (single-star) with one decimal and formatted count, and year", () => {
     render(
       <div className={lightThemeClass}>
         <BookCard book={book} />
@@ -40,6 +41,7 @@ describe("BookCard", () => {
 
     expect(screen.getByText(/sci-fi/i)).toBeInTheDocument();
     expect(screen.getByText("4.5")).toBeInTheDocument();
+    expect(screen.getByText("(12,847)")).toBeInTheDocument();
     expect(screen.getByText(/1979/)).toBeInTheDocument();
   });
 
@@ -81,11 +83,18 @@ describe("BookCard", () => {
     expect(screen.queryByText(/\d\.\d/)).not.toBeInTheDocument();
   });
 
-  it("clamps and formats stars (half-star case visible as 5.5 label here)", () => {
+  it("clamps rating to [0,5] and shows one decimal only", () => {
     const base = { id: "st", title: "Starry", author: "Sky", cover: "/c.jpg" };
-    render(<BookCard book={{ ...base, rating: -10 }} />);
-    render(<BookCard book={{ ...base, rating: 5.5 }} />);
-    expect(screen.getByText("5.5")).toBeInTheDocument();
+    const { rerender } = render(<BookCard book={{ ...base, rating: -10 }} />);
+    expect(screen.getByText("0.0")).toBeInTheDocument();
+    rerender(<BookCard book={{ ...base, rating: 5.5 }} />);
+    expect(screen.getByText("5.0")).toBeInTheDocument();
+  });
+
+  it("renders exactly one star icon for rating row", () => {
+    const { container } = render(<BookCard book={book} />);
+    const stars = container.querySelectorAll('svg[class*="starIcon"]');
+    expect(stars.length).toBe(1);
   });
 
   describe("Image unoptimized flag branches", () => {

--- a/src/features/books/BookCard.tsx
+++ b/src/features/books/BookCard.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import * as s from "./BookCard.css";
+import { formatCount, formatOneDecimal } from "./rating";
 import type { Book } from "./types";
 
 export type BookCardProps = { book: Book };
@@ -42,9 +43,9 @@ export function BookCard({ book }: BookCardProps) {
           <div className={s.meta}>
             {typeof book.rating === "number" ? (
               <span className={s.ratingRow}>
-                <span className={s.srOnly}>{`Rating ${formatOneDecimal(
-                  book.rating,
-                )} out of 5${
+                <span
+                  className={s.srOnly}
+                >{`Rating ${formatOneDecimal(book.rating)} out of 5$${
                   typeof book.ratingsCount === "number"
                     ? ` based on ${formatCount(book.ratingsCount)} reviews`
                     : ""
@@ -77,13 +78,4 @@ function SingleStarIcon() {
       />
     </svg>
   );
-}
-
-function formatOneDecimal(n: number): string {
-  const clamped = Math.max(0, Math.min(5, n));
-  return clamped.toFixed(1);
-}
-
-function formatCount(n: number): string {
-  return new Intl.NumberFormat(undefined).format(n);
 }

--- a/src/features/books/BookCard.tsx
+++ b/src/features/books/BookCard.tsx
@@ -1,6 +1,5 @@
 import Image from "next/image";
 import Link from "next/link";
-import type { ReactNode } from "react";
 import * as s from "./BookCard.css";
 import type { Book } from "./types";
 
@@ -42,10 +41,22 @@ export function BookCard({ book }: BookCardProps) {
         {(book.rating != null || book.year != null) && (
           <div className={s.meta}>
             {typeof book.rating === "number" ? (
-              <>
-                <span className={s.stars}>{renderStars(book.rating)}</span>
-                <span>{book.rating.toFixed(1)}</span>
-              </>
+              <span className={s.ratingRow}>
+                <span className={s.srOnly}>{`Rating ${formatOneDecimal(
+                  book.rating,
+                )} out of 5${
+                  typeof book.ratingsCount === "number"
+                    ? ` based on ${formatCount(book.ratingsCount)} reviews`
+                    : ""
+                }`}</span>
+                <SingleStarIcon />
+                <span>{formatOneDecimal(book.rating)}</span>
+                {typeof book.ratingsCount === "number" ? (
+                  <span className={s.ratingsCount}>
+                    ({formatCount(book.ratingsCount)})
+                  </span>
+                ) : null}
+              </span>
             ) : null}
             {book.year != null ? <span>{book.year}</span> : null}
           </div>
@@ -55,46 +66,24 @@ export function BookCard({ book }: BookCardProps) {
   );
 }
 
-function renderStars(value: number) {
-  const clamped = Math.max(0, Math.min(5, value));
-  const full = Math.floor(clamped);
-  const half = clamped - full >= 0.5 ? 1 : 0;
-  const empty = 5 - full - half;
-  const icons: ReactNode[] = [];
-  for (let i = 0; i < full; i++)
-    icons.push(<Star key={`f-${i}`} variant="full" />);
-  if (half) icons.push(<Star key="h" variant="half" />);
-  for (let i = 0; i < empty; i++)
-    icons.push(<Star key={`e-${i}`} variant="empty" />);
-  return icons;
-}
-
-function Star({ variant }: { variant: "full" | "half" | "empty" }) {
-  const fill = variant === "empty" ? "none" : "currentColor";
-  const defs = variant === "half";
+function SingleStarIcon() {
   return (
     <svg viewBox="0 0 24 24" className={s.starIcon} aria-hidden="true">
-      {defs ? (
-        <defs>
-          <linearGradient
-            id="halfGrad"
-            x1="0"
-            y1="0"
-            x2="24"
-            y2="0"
-            gradientUnits="userSpaceOnUse"
-          >
-            <stop offset="50%" stopColor="currentColor" />
-            <stop offset="50%" stopColor="transparent" />
-          </linearGradient>
-        </defs>
-      ) : null}
       <path
         d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
-        fill={variant === "half" ? "url(#halfGrad)" : fill}
+        fill="currentColor"
         stroke="currentColor"
         strokeWidth="1"
       />
     </svg>
   );
+}
+
+function formatOneDecimal(n: number): string {
+  const clamped = Math.max(0, Math.min(5, n));
+  return clamped.toFixed(1);
+}
+
+function formatCount(n: number): string {
+  return new Intl.NumberFormat(undefined).format(n);
 }

--- a/src/features/books/BookCard.tsx
+++ b/src/features/books/BookCard.tsx
@@ -45,7 +45,7 @@ export function BookCard({ book }: BookCardProps) {
               <span className={s.ratingRow}>
                 <span
                   className={s.srOnly}
-                >{`Rating ${formatOneDecimal(book.rating)} out of 5$${
+                >{`Rating ${formatOneDecimal(book.rating)} out of 5${
                   typeof book.ratingsCount === "number"
                     ? ` based on ${formatCount(book.ratingsCount)} reviews`
                     : ""

--- a/src/features/books/BookDetails.css.ts
+++ b/src/features/books/BookDetails.css.ts
@@ -69,6 +69,8 @@ export const cover = style({
   width: "100%",
   height: "100%",
   objectFit: "cover",
+  // Add a visible top offset between the card and the cover image for nicer composition
+  marginTop: tokens.spacing["2"],
   borderRadius: tokens.radius.md,
   boxShadow: tokens.elevation["1"],
 });

--- a/src/features/books/BookDetails.test.tsx
+++ b/src/features/books/BookDetails.test.tsx
@@ -70,45 +70,29 @@ describe("BookDetails UI", () => {
     expect(screen.queryByText(/\d+ pages/i)).not.toBeInTheDocument();
   });
 
-  it("renders rating with stars and sr-only text (half star)", () => {
-    render(wrap(<BookDetails book={{ ...base, rating: 3.5 }} />));
-    const sr = screen.getByText(/rating: 3\.5 out of 5/i);
-    expect(sr.parentElement).not.toBeNull();
-    const starWrap = sr.parentElement as HTMLElement; // span that wraps stars
-    // 5 star paths rendered
-    const starPaths = starWrap.querySelectorAll("path");
-    expect(starPaths.length).toBe(5);
-    // Half star uses gradient url fill
-    const hasGradient = Array.from(starPaths).some((p) =>
-      (p.getAttribute("fill") || "").startsWith("url("),
+  it("renders rating with a single star and formatted value/count", () => {
+    render(
+      wrap(
+        <BookDetails book={{ ...base, rating: 3.5, ratingsCount: 12847 }} />,
+      ),
     );
-    expect(hasGradient).toBe(true);
-    // Numeric rating is visible alongside
+    // Screen-reader text present
+    expect(screen.getByText(/rating 3\.5 out of 5/i)).toBeInTheDocument();
+    // Visible: one decimal and formatted count
     expect(screen.getByText("3.5")).toBeInTheDocument();
+    expect(screen.getByText("(12,847)")).toBeInTheDocument();
+    // Exactly one star icon
+    const starSvgs = document.querySelectorAll('svg[class*="starIcon"]');
+    expect(starSvgs.length).toBe(1);
   });
 
-  it("renders full and empty star fills at edges (0 and 1)", () => {
-    let utils = render(wrap(<BookDetails book={{ ...base, rating: 0 }} />));
-    let sr = screen.getByText(/rating: 0\.0 out of 5/i);
-    expect(sr.parentElement).not.toBeNull();
-    let starWrap = sr.parentElement as HTMLElement;
-    let starPaths = starWrap.querySelectorAll("path");
-    expect(starPaths.length).toBe(5);
-    expect(starPaths[0].getAttribute("fill")).toBe("none");
-
-    utils.unmount();
-    utils = render(wrap(<BookDetails book={{ ...base, rating: 1 }} />));
-    sr = screen.getByText(/rating: 1\.0 out of 5/i);
-    expect(sr.parentElement).not.toBeNull();
-    starWrap = sr.parentElement as HTMLElement;
-    starPaths = starWrap.querySelectorAll("path");
-    expect(starPaths.length).toBe(5);
-    // At least one full star has currentColor fill
-    expect(
-      Array.from(starPaths).some(
-        (p) => p.getAttribute("fill") === "currentColor",
-      ),
-    ).toBe(true);
+  it("clamps rating to [0,5] and shows one decimal only", () => {
+    const { rerender } = render(
+      wrap(<BookDetails book={{ ...base, rating: -5 }} />),
+    );
+    expect(screen.getByText("0.0")).toBeInTheDocument();
+    rerender(wrap(<BookDetails book={{ ...base, rating: 5.6 }} />));
+    expect(screen.getByText("5.0")).toBeInTheDocument();
   });
 
   it("shows year and pages (from mock when id=1)", () => {

--- a/src/features/books/BookDetails.tsx
+++ b/src/features/books/BookDetails.tsx
@@ -1,7 +1,9 @@
-import { BookOpen, Calendar, User } from "lucide-react";
+import BookOpen from "lucide-react/dist/esm/icons/book-open.js";
+import Calendar from "lucide-react/dist/esm/icons/calendar.js";
+import User from "lucide-react/dist/esm/icons/user.js";
 import Image from "next/image";
-import { type ReactNode, useId } from "react";
 import * as s from "./BookDetails.css";
+import { formatCount, formatOneDecimal } from "./rating";
 import type { Book } from "./types";
 
 export type BookDetailsProps = { book: Book };
@@ -75,13 +77,22 @@ export function BookDetails({ book }: BookDetailsProps) {
                 <div className={s.info}>
                   {typeof book.rating === "number" ? (
                     <span className={s.stars}>
-                      <span
-                        className={s.srOnly}
-                      >{`Rating: ${book.rating.toFixed(1)} out of 5`}</span>
-                      {renderStars(book.rating)}
+                      <span className={s.srOnly}>{`Rating ${formatOneDecimal(
+                        book.rating,
+                      )} out of 5${
+                        typeof book.ratingsCount === "number"
+                          ? ` based on ${formatCount(book.ratingsCount)} reviews`
+                          : ""
+                      }`}</span>
+                      <SingleStarIcon />
                       <span className={s.iconTextSpacing}>
-                        {book.rating.toFixed(1)}
+                        {formatOneDecimal(book.rating)}
                       </span>
+                      {typeof book.ratingsCount === "number" ? (
+                        <span className={s.iconTextSpacing}>
+                          ({formatCount(book.ratingsCount)})
+                        </span>
+                      ) : null}
                     </span>
                   ) : null}
                   {book.year != null ? (
@@ -153,44 +164,12 @@ export function BookDetails({ book }: BookDetailsProps) {
   );
 }
 
-function renderStars(value: number) {
-  const clamped = Math.max(0, Math.min(5, value));
-  const full = Math.floor(clamped);
-  const half = clamped - full >= 0.5 ? 1 : 0;
-  const empty = 5 - full - half;
-  const icons: ReactNode[] = [];
-  for (let i = 0; i < full; i++)
-    icons.push(<Star key={`f-${i}`} variant="full" />);
-  if (half) icons.push(<Star key="h" variant="half" />);
-  for (let i = 0; i < empty; i++)
-    icons.push(<Star key={`e-${i}`} variant="empty" />);
-  return icons;
-}
-
-function Star({ variant }: { variant: "full" | "half" | "empty" }) {
-  const fill = variant === "empty" ? "none" : "currentColor";
-  const showDefs = variant === "half";
-  const gradId = useId();
+function SingleStarIcon() {
   return (
     <svg viewBox="0 0 24 24" className={s.starIcon} aria-hidden="true">
-      {showDefs ? (
-        <defs>
-          <linearGradient
-            id={gradId}
-            x1="0"
-            y1="0"
-            x2="24"
-            y2="0"
-            gradientUnits="userSpaceOnUse"
-          >
-            <stop offset="50%" stopColor="currentColor" />
-            <stop offset="50%" stopColor="transparent" />
-          </linearGradient>
-        </defs>
-      ) : null}
       <path
         d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
-        fill={variant === "half" ? `url(#${gradId})` : fill}
+        fill="currentColor"
         stroke="currentColor"
         strokeWidth="1"
       />

--- a/src/features/books/BookList.css.ts
+++ b/src/features/books/BookList.css.ts
@@ -1,5 +1,5 @@
 import { style } from "@vanilla-extract/css";
-import { tokens } from "@/design/tokens.css";
+import { darkThemeClass, lightThemeClass, tokens } from "@/design/tokens.css";
 
 export const errorBox = style({
   color: tokens.color.error,
@@ -27,12 +27,23 @@ export const footer = style({
 
 export const gridTop = style({
   marginTop: tokens.spacing["4"],
-  // Ensure the area behind the cards follows the theme background (light in light mode)
-  background: tokens.color.background,
-  // Provide slight rounding/shadow separation from hero when needed
-  borderRadius: tokens.radius.lg,
-  paddingTop: tokens.spacing["3"],
-  paddingBottom: tokens.spacing["3"],
+  // Theme-specific background treatment
+  selectors: {
+    // In light theme, use a white-ish panel behind cards for contrast
+    [`${lightThemeClass} &`]: {
+      background: tokens.color.background,
+      borderRadius: tokens.radius.lg,
+      paddingTop: tokens.spacing["3"],
+      paddingBottom: tokens.spacing["3"],
+    },
+    // In dark theme, keep the section transparent to the page background
+    [`${darkThemeClass} &`]: {
+      background: "transparent",
+      borderRadius: 0,
+      paddingTop: tokens.spacing["3"],
+      paddingBottom: tokens.spacing["3"],
+    },
+  },
 });
 
 export const loadMoreButton = style({

--- a/src/features/books/BookList.css.ts
+++ b/src/features/books/BookList.css.ts
@@ -27,6 +27,12 @@ export const footer = style({
 
 export const gridTop = style({
   marginTop: tokens.spacing["4"],
+  // Ensure the area behind the cards follows the theme background (light in light mode)
+  background: tokens.color.background,
+  // Provide slight rounding/shadow separation from hero when needed
+  borderRadius: tokens.radius.lg,
+  paddingTop: tokens.spacing["3"],
+  paddingBottom: tokens.spacing["3"],
 });
 
 export const loadMoreButton = style({

--- a/src/features/books/rating.ts
+++ b/src/features/books/rating.ts
@@ -1,0 +1,8 @@
+export function formatOneDecimal(n: number): string {
+  const clamped = Math.max(0, Math.min(5, n));
+  return clamped.toFixed(1);
+}
+
+export function formatCount(n: number, locale?: string): string {
+  return new Intl.NumberFormat(locale).format(n);
+}

--- a/src/features/books/types.ts
+++ b/src/features/books/types.ts
@@ -7,6 +7,8 @@ export type Book = {
   genre?: string;
   /** Optional numeric rating 0-5; decimals allowed */
   rating?: number;
+  /** Optional number of ratings/reviews to display alongside rating */
+  ratingsCount?: number;
   /** Optional published year */
   year?: number;
   /** Optional long description */

--- a/src/stories/BookCard.stories.tsx
+++ b/src/stories/BookCard.stories.tsx
@@ -6,7 +6,7 @@ export default {
 };
 
 export const Rich = () => (
-  <div className={lightThemeClass}>
+  <div className={lightThemeClass} style={{ background: "#fff", padding: 12 }}>
     <div style={{ maxWidth: 160 }}>
       <BookCard
         book={{
@@ -16,6 +16,7 @@ export const Rich = () => (
           cover: "https://placehold.co/120x180.png?text=Neuromancer",
           genre: "Sci-Fi",
           rating: 4.5,
+          ratingsCount: 12847,
           year: 1984,
         }}
       />

--- a/src/stories/BookCard.stories.tsx
+++ b/src/stories/BookCard.stories.tsx
@@ -1,4 +1,4 @@
-import { lightThemeClass } from "@/design/tokens.css";
+import { darkThemeClass, lightThemeClass } from "@/design/tokens.css";
 import { BookCard } from "@/features/books/BookCard";
 
 export default {
@@ -7,6 +7,25 @@ export default {
 
 export const Rich = () => (
   <div className={lightThemeClass} style={{ background: "#fff", padding: 12 }}>
+    <div style={{ maxWidth: 160 }}>
+      <BookCard
+        book={{
+          id: "99",
+          title: "Neuromancer",
+          author: "William Gibson",
+          cover: "https://placehold.co/120x180.png?text=Neuromancer",
+          genre: "Sci-Fi",
+          rating: 4.5,
+          ratingsCount: 12847,
+          year: 1984,
+        }}
+      />
+    </div>
+  </div>
+);
+
+export const RichDark = () => (
+  <div className={darkThemeClass} style={{ background: "#333", padding: 12 }}>
     <div style={{ maxWidth: 160 }}>
       <BookCard
         book={{

--- a/src/types/lucide-ambient.d.ts
+++ b/src/types/lucide-ambient.d.ts
@@ -1,0 +1,5 @@
+declare module "lucide-react/dist/esm/icons/*.js" {
+  import type { FC, SVGProps } from "react";
+  const Icon: FC<SVGProps<SVGSVGElement>>;
+  export default Icon;
+}


### PR DESCRIPTION
Summary
- Refactor BookCard and BookDetails to use a single-star rating UI with one-decimal value and formatted count.
- Add accessible sr-only text for ratings.
- Add visible top spacing above the cover image and tighten spacing using design tokens.
- Fix Storybook antivirus false-positive by avoiding lucide-react barrel that references chrome.js; import icons via per-icon ESM paths and add ambient typings.

Details
- Shared helpers `formatOneDecimal` and `formatCount` in `src/features/books/rating.ts`.
- BookDetails: replaced multi-star visuals with one star + text; added sr-only; preserved metadata layout.
- BookDetails.css.ts: margin-top for cover; rhythm tweaks.
- BookCard: reuse shared helpers for consistent formatting across list and detail.
- Switched `lucide-react` imports in layout/theme/book pages to per-icon ESM files and added `src/types/lucide-ambient.d.ts`.

Testing
- `bun run test`: 57 tests passing.
- `bun run lint`: clean.
- `bun run storybook`: starts successfully on Windows.

Closes #67