### PR TITLE
chore(tests): avoid DB side-effects in unit tests + add db:list helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# [0.28.0](https://github.com/amalv/bukie/compare/v0.27.0...v0.28.0) (2025-08-26)
+
+
+### Bug Fixes
+
+* **design-system:** make BookCard heart icon non-interactive to avoid test collisions ([09ee167](https://github.com/amalv/bukie/commit/09ee167c4ba17e557f4a2925d182465e049d1ab6))
+
+
+### Features
+
+* **design-system:** compact BookCard UI and uniform media heights ([83fe225](https://github.com/amalv/bukie/commit/83fe225b57dee6b4d615eacfa819ae76b42010ad))
+
+
+### Performance Improvements
+
+* **images:** reduce BookCard intrinsic size to 427x240 to avoid unnecessary bandwidth ([e4dae46](https://github.com/amalv/bukie/commit/e4dae46403aedf5dca2bc9a06d6446e1b36e5b8b))
+
 # [0.27.0](https://github.com/amalv/bukie/compare/v0.26.0...v0.27.0) (2025-08-25)
 
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -86,3 +86,23 @@ flowchart TD
 
 - See ADRs in `docs/decisions` for the testing and tooling rationale.
 - See `README.md` for CI and database notes.
+
+## Test-time DB mock and local DB helper
+
+- To avoid unit tests writing to the local dev SQLite file (`.data/dev.sqlite`), the test setup (`vitest.setup.ts`) applies a test-time mock for the DB provider that replaces create/update/delete with an in-memory implementation.
+  - `createBookRow` returns a synthetic id and tracks it in-process.
+  - `updateBookRow` and `deleteBookRow` simulate not-found for ids not created during the same test process.
+
+- A lightweight helper `scripts/db/list-books.ts` is available for local inspection of `.data/dev.sqlite`. Run it via:
+
+```powershell
+bun run db:list
+```
+
+- If you need tests to run against a real DB for integration verification, set the env var `TEST_USE_REAL_DB=1` before running tests and the provider mock will be skipped (see `vitest.setup.ts`). Example:
+
+```powershell
+$env:TEST_USE_REAL_DB=1; bun run test
+```
+
+This approach keeps unit tests fast and side-effect free while allowing teams to opt into a real-DB integration run when needed.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bukie",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "private": true,
   "scripts": {
     "build": "bun run db:migrate:pg && bun run db:seed:pg && next build",
@@ -27,6 +27,7 @@
     "test:playwright": "bunx playwright test",
     "test:storybook": "bunx vitest --config vitest.config.storybook.ts",
     "images:optimize": "bun ./scripts/optimize-images.ts --webp --maxWidth 450 --quality 80",
+    "db:list": "bunx tsx ./scripts/db/list-books.ts",
     "db:sync:covers": "bunx tsx ./scripts/db/sync-covers.ts",
     "covers:fetch": "bun ./scripts/covers/fetch-covers.ts",
     "covers:fetch:node": "bunx tsx ./scripts/covers/fetch-covers.ts"

--- a/scripts/db/list-books.ts
+++ b/scripts/db/list-books.ts
@@ -1,0 +1,35 @@
+import Database from "better-sqlite3";
+import { join } from "node:path";
+
+const DB_PATH = join(process.cwd(), ".data", "dev.sqlite");
+
+function main() {
+  const db = new Database(DB_PATH, { readonly: true });
+  try {
+    const rows = db
+      .prepare(
+        `SELECT id, title, author, year, ratings_count AS ratingsCount FROM books ORDER BY added_at DESC LIMIT 200;`,
+      )
+      .all();
+
+    if (!rows || rows.length === 0) {
+      console.log("No books found in the local dev DB (", DB_PATH, ")");
+      return;
+    }
+
+    // Print a compact table
+    console.table(
+      rows.map((r: any) => ({
+        id: r.id,
+        title: r.title,
+        author: r.author,
+        year: r.year ?? "-",
+        ratings: r.ratingsCount ?? "-",
+      })),
+    );
+  } finally {
+    db.close();
+  }
+}
+
+main();

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -12,7 +12,11 @@ import { server } from "./src/mocks/server";
 // fixtures continue to work; only create/update/delete are replaced.
 import { vi } from "vitest";
 
-vi.mock("@/db/provider", async () => {
+// Allow opting into a real DB for integration-style runs by setting
+// TEST_USE_REAL_DB=1 in the environment. When set, we skip the provider
+// mock so tests run against the real provider (useful for integration checks).
+if (process.env.TEST_USE_REAL_DB !== "1") {
+	vi.mock("@/db/provider", async () => {
 	// importActual to preserve non-write exports
 	const actual = await vi.importActual<any>("@/db/provider");
 
@@ -38,7 +42,8 @@ vi.mock("@/db/provider", async () => {
 			return true;
 		},
 	};
-});
+  });
+}
 
 beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
 afterEach(() => server.resetHandlers());

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -2,6 +2,44 @@ import '@testing-library/jest-dom';
 import { beforeAll, afterEach, afterAll } from "vitest";
 import { server } from "./src/mocks/server";
 
+// Prevent unit/integration tests from writing to the local dev sqlite file by
+// stubbing provider write operations. Tests that need DB-backed behavior
+// should opt into real DB usage explicitly (or use separate integration
+// fixtures). This keeps the test run hermetic and avoids polluting
+// `.data/dev.sqlite` during normal unit test runs.
+//
+// We keep read functions from the actual provider so existing mocks and
+// fixtures continue to work; only create/update/delete are replaced.
+import { vi } from "vitest";
+
+vi.mock("@/db/provider", async () => {
+	// importActual to preserve non-write exports
+	const actual = await vi.importActual<any>("@/db/provider");
+
+	// In-memory set to track IDs created during tests. This prevents writes
+	// to the real sqlite DB while allowing update/delete to correctly report
+	// not-found for unknown IDs.
+	const createdIds = new Set<string>();
+
+	return {
+		...actual,
+		createBookRow: async (input: any) => {
+			const id = input.id ?? `test-${Date.now()}`;
+			createdIds.add(id);
+			return { ...input, id } as any;
+		},
+		updateBookRow: async (id: string, patch: any) => {
+			if (!createdIds.has(id)) return undefined;
+			return { id, ...(patch ?? {}) } as any;
+		},
+		deleteBookRow: async (id: string) => {
+			if (!createdIds.has(id)) return false;
+			createdIds.delete(id);
+			return true;
+		},
+	};
+});
+
 beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());


### PR DESCRIPTION
This PR makes unit tests side-effect free by adding a test-time provider mock (skips writes to `.data/dev.sqlite`) and provides a small local helper to inspect the dev DB.

Changes:
- `vitest.setup.ts`: installs a provider mock that makes create/update/delete in-memory during test runs. Mock is opt-out via `TEST_USE_REAL_DB=1`.
- `scripts/db/list-books.ts`: simple CLI to print rows from `.data/dev.sqlite`.
- `package.json`: adds `db:list` script.
- `docs/testing.md`: documents the mock and how to opt into a real DB for integration runs.

Why:
- Keep unit tests fast and hermetic and avoid polluting the dev DB.

CI/Notes:
- The provider mock is only applied when `TEST_USE_REAL_DB` is not set to `1`. Integration tests should set that variable or use a separate ephemeral DB.

Closes #77