### PR TITLE
feat(layout): polish footer and fix cover image warnings

### DIFF
--- a/src/app/footer.css.ts
+++ b/src/app/footer.css.ts
@@ -1,0 +1,52 @@
+import { globalStyle, style } from "@vanilla-extract/css";
+import { darkThemeClass, lightThemeClass, tokens } from "@/design/tokens.css";
+
+export const footer = style({
+  // keep footer flush with content and avoid any visible divider band
+  marginTop: 0,
+  background: tokens.color.background,
+  color: tokens.color.onSurface,
+  borderTop: "none",
+  boxShadow: "none",
+  position: "relative",
+  zIndex: 1,
+});
+
+export const footerInner = style({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  gap: tokens.spacing["1"],
+  // compact vertical padding for mobile / small viewports
+  paddingTop: tokens.spacing["2"],
+  paddingBottom: tokens.spacing["2"],
+  textAlign: "center",
+  // slightly larger type so brand row is prominent but not oversized
+  fontSize: tokens.typography.lg,
+  fontWeight: 700,
+  letterSpacing: 0.2,
+});
+
+export const brandIconSelector = "footerBrandIcon"; // helper classname target for globalStyle
+
+// Make footer icon match header sizing and color per theme
+globalStyle(`${footerInner} .${brandIconSelector}`, {
+  width: 20,
+  height: 20,
+});
+
+// Theme-aware icon color (same as header.brandIcon)
+globalStyle(`${lightThemeClass} ${footerInner} .${brandIconSelector}`, {
+  color: tokens.color.primary,
+});
+globalStyle(`${darkThemeClass} ${footerInner} .${brandIconSelector}`, {
+  color: tokens.color.primary,
+});
+
+// Desktop: a touch more vertical padding at the md breakpoint for balance
+globalStyle(`@media (min-width: ${tokens.breakpoints.md})`, {
+  [footerInner]: {
+    paddingTop: tokens.spacing["3"],
+    paddingBottom: tokens.spacing["3"],
+  },
+});

--- a/src/app/header.css.ts
+++ b/src/app/header.css.ts
@@ -1,4 +1,4 @@
-import { style } from "@vanilla-extract/css";
+import { globalStyle, style } from "@vanilla-extract/css";
 import { darkThemeClass, lightThemeClass, tokens } from "@/design/tokens.css";
 
 export const header = style({
@@ -46,17 +46,39 @@ export const offset = style({
 });
 
 export const footer = style({
-  marginTop: tokens.spacing["4"],
+  // bring footer visually closer to page content and use a subtler divider
+  // keep footer compact by avoiding extra top margin
   background: tokens.color.background,
   color: tokens.color.onSurface,
-  borderTop: `1px solid ${tokens.color.outline}`,
+  // use overlay token for a lightweight 1px divider that maps well in light/dark
+  borderTop: `1px solid ${tokens.color.overlay}`,
 });
 
 export const footerInner = style({
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
-  gap: tokens.spacing["1"],
-  minHeight: 80,
+  gap: tokens.spacing["2"],
+  // compact vertical padding so the footer band is proportional to content
+  paddingTop: tokens.spacing["1"],
+  paddingBottom: tokens.spacing["1"],
   textAlign: "center",
+  // slightly larger type inside the footer band so the brand row reads prominent
+  fontSize: tokens.typography.lg,
+  // increase the brand icon inside the footer only (keeps header icon unchanged)
+});
+
+// Target the brand icon specifically when it's a descendant of the footer inner container.
+// Use `globalStyle` with the generated class names to avoid invalid selector errors.
+globalStyle(`${footerInner} ${brandIcon}`, {
+  width: 24,
+  height: 24,
+});
+
+// Slightly more vertical padding on wider viewports for improved balance
+globalStyle(`@media (min-width: ${tokens.breakpoints.md})`, {
+  [footerInner]: {
+    paddingTop: tokens.spacing["1_5"],
+    paddingBottom: tokens.spacing["1_5"],
+  },
 });

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import Script from "next/script";
 import { Container } from "@/design/layout/grid";
 import { darkThemeClass, lightThemeClass } from "@/design/tokens.css";
 import { ThemeToggle } from "../design/theme/ThemeToggle";
+import * as footerStyles from "./footer.css";
 import * as headerStyles from "./header.css";
 
 const geistSans = Geist({
@@ -71,10 +72,13 @@ export default async function RootLayout({
         {/* offset for fixed header */}
         <div className={headerStyles.offset} aria-hidden />
         {children}
-        <footer className={headerStyles.footer}>
+        <footer className={footerStyles.footer}>
           <Container>
-            <div className={headerStyles.footerInner}>
-              <BookOpen className={headerStyles.brandIcon} aria-hidden />
+            <div className={footerStyles.footerInner}>
+              <BookOpen
+                className={footerStyles.brandIconSelector}
+                aria-hidden
+              />
               Bukie
             </div>
           </Container>

--- a/src/features/books/BookCard.css.ts
+++ b/src/features/books/BookCard.css.ts
@@ -45,6 +45,8 @@ export const media = style({
 
 export const image = style({
   borderRadius: 0,
+  position: "absolute",
+  inset: 0,
   width: "100%",
   height: "100%",
   objectFit: "cover",
@@ -133,6 +135,7 @@ export const link = style({
 // Block-level link for the media area to eliminate inline spacing artifacts
 export const mediaLink = style({
   display: "block",
+  position: "relative",
   width: "100%",
   height: "100%",
 });

--- a/src/features/books/BookCard.tsx
+++ b/src/features/books/BookCard.tsx
@@ -32,17 +32,14 @@ export function BookCard({ book }: BookCardProps) {
           <Image
             src={book.cover?.trim() ? book.cover : "/covers/placeholder.webp"}
             alt={`Cover of ${book.title} by ${book.author}`}
-            // Use a reasonable intrinsic size to avoid unnecessary bandwidth.
-            // Displayed height is capped by CSS (max 240px), so use a matching height.
-            width={427}
-            height={240}
+            // Use fill to let the image fill the media container and use object-fit to preserve aspect ratio.
+            fill
             className={s.image}
             // Keep unoptimized in dev/test for stability; enable optimization in prod for raster images
             unoptimized={
               process.env.NODE_ENV !== "production" ||
               book.cover?.includes(".svg") === true
             }
-            sizes="(max-width: 640px) 50vw, (max-width: 1024px) 25vw, 240px"
           />
         </Link>
         <div className={s.mediaOverlay} />


### PR DESCRIPTION
This PR polishes the app footer and fixes book cover image runtime warnings.

Changes:
- Add dedicated `src/app/footer.css.ts` and wire it from `src/app/layout.tsx`.
- Match footer brand icon and text styling to the header (color, size, weight, spacing).
- Remove large top divider and tighten footer spacing; responsive padding tweaks.
- Fix Next/Image warnings for book covers by using `fill` with a positioned parent and updating `BookCard` CSS.
- Minor spacing and layout improvements across header/footer and book cards.

Acceptance / notes:
- Uses theme tokens for colors and spacing so light/dark are consistent.

Closes #84