### PR TITLE
chore(repo): add contribution templates for PRs and issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug Report
+about: Report a defect with clear impact, scope, and acceptance criteria.
+title: "fix(scope): "
+labels: bug
+---
+
+## Summary
+
+Describe the bug in 1-3 sentences.
+
+## Current Behavior
+
+What happens today? Include exact routes, actions, or environments when useful.
+
+## Expected Behavior
+
+What should happen instead?
+
+## Why
+
+Explain the product, quality, or operational impact.
+
+## Scope
+
+Bound the work so the issue is implementation-ready.
+
+- 
+- 
+
+## Acceptance Criteria
+
+Use flat bullets and make them testable.
+
+- [ ] The bug is reproducible on the current main branch
+- [ ] The fix works in the affected environments
+- [ ] Regression coverage is added where appropriate
+
+## References
+
+Routes, files, screenshots, logs, or external links.
+
+- 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,6 +28,13 @@ Bound the work so the issue is implementation-ready.
 - 
 - 
 
+## Suggested Labels
+
+Keep the base `bug` label and add any domain/priority labels that should match the eventual PR.
+
+- 
+- 
+
 ## Acceptance Criteria
 
 Use flat bullets and make them testable.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Bukie PR Template
+    url: https://github.com/amalv/bukie/blob/main/.github/pull_request_template.md
+    about: Review the pull request template for the level of detail expected when work is ready for implementation.

--- a/.github/ISSUE_TEMPLATE/work_item.md
+++ b/.github/ISSUE_TEMPLATE/work_item.md
@@ -1,0 +1,47 @@
+---
+name: Improvement / Feature / Chore
+about: Propose planned work with clear scope, rationale, and validation goals.
+title: "type(scope): "
+labels: enhancement
+---
+
+## Summary
+
+What are we trying to improve or add?
+
+## Why
+
+Why is this worth doing now?
+
+## Scope
+
+List the intended work and boundaries.
+
+- 
+- 
+
+## Acceptance Criteria
+
+Use flat bullets and make them concrete.
+
+- [ ] The resulting work is clear enough to implement
+- [ ] Validation expectations are explicit
+- [ ] Any architecture or documentation follow-up is called out
+
+## Architecture / ADR Impact
+
+Choose one and expand if needed.
+
+- [ ] No architectural impact
+- [ ] Maybe; decision should be evaluated during implementation
+- [ ] Yes; this likely needs a `docs/decisions` update
+
+Notes:
+
+- 
+
+## References
+
+Prior issues, PRs, docs, screenshots, or related files.
+
+- 

--- a/.github/ISSUE_TEMPLATE/work_item.md
+++ b/.github/ISSUE_TEMPLATE/work_item.md
@@ -20,6 +20,13 @@ List the intended work and boundaries.
 - 
 - 
 
+## Suggested Labels
+
+Keep the base `enhancement` label and add any domain/priority labels that should match the eventual PR.
+
+- 
+- 
+
 ## Acceptance Criteria
 
 Use flat bullets and make them concrete.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,7 @@
 <!-- Example: Closes #95 -->
 
 - Closes #
+- Labels aligned with linked issue: 
 
 ## Changes
 
@@ -79,6 +80,7 @@ Main risks and mitigations:
 ## Checklist
 
 - [ ] scope matches the linked issue
+- [ ] PR labels match the linked issue labels where applicable
 - [ ] touched code is cleaner than before
 - [ ] tests cover the changed behavior
 - [ ] docs were updated where needed

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,85 @@
+## Summary
+
+<!-- Explain the user-facing outcome first, then the key implementation changes. -->
+
+- 
+- 
+
+## Linked Issue
+
+<!-- Example: Closes #95 -->
+
+- Closes #
+
+## Changes
+
+<!-- Group by concern, not by file path. -->
+
+- 
+- 
+
+## Validation
+
+<!-- Keep this honest. Remove items that do not apply. -->
+
+- [ ] `bun run lint`
+- [ ] `bun run test`
+- [ ] `bunx playwright test`
+- [ ] manual verification completed where relevant
+
+## UX Notes
+
+<!-- Required for UI, content, layout, or interaction changes. -->
+
+- [ ] no visual changes
+- [ ] screenshots or video attached
+- [ ] responsive behavior verified at affected breakpoints
+- [ ] accessibility impact reviewed
+
+Notes:
+
+- 
+
+## Architecture Notes
+
+<!-- Link any ADR when the change introduces or updates a meaningful technical decision. -->
+
+- [ ] no architectural impact
+- [ ] follows existing architecture and framework defaults
+- [ ] introduces or updates a documented decision in `docs/decisions`
+
+ADR / decision links:
+
+- 
+
+## Data / API / Infra Impact
+
+- [ ] no data, API, or infra impact
+- [ ] database schema changed
+- [ ] seed/import/catalog data changed
+- [ ] API contract changed
+- [ ] environment variables changed
+- [ ] CI/CD or deployment behavior changed
+
+Operational notes:
+
+- 
+
+## Risks
+
+- [ ] low risk
+- [ ] medium risk
+- [ ] high risk
+
+Main risks and mitigations:
+
+- risk:
+- mitigation:
+
+## Checklist
+
+- [ ] scope matches the linked issue
+- [ ] touched code is cleaner than before
+- [ ] tests cover the changed behavior
+- [ ] docs were updated where needed
+- [ ] local-only/generated artifacts are excluded from git

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,9 @@ storybook-static
 # Copilot
 .github/copilot-instructions.md
 .vercel
+
+# Local importer reports
+artifacts/report-*.json
+artifacts/report-*.md
+!artifacts/report-sample.json
+!artifacts/report-sample.md


### PR DESCRIPTION
## Summary

- add repository contribution templates for both pull requests and issues so work starts from a consistent, high-signal structure
- keep the repo's existing style around summary, issue linkage, validation, scope, and acceptance criteria, while improving coverage for UX, accessibility, architecture, and operational impact
- reduce local workflow noise by ignoring generated importer report files while keeping the sample report references tracked

## Changes

- add `.github/pull_request_template.md`
- add Markdown issue templates for bug reports and broader work items under `.github/ISSUE_TEMPLATE/`
- keep GitHub issue-template configuration lightweight via `.github/ISSUE_TEMPLATE/config.yml`
- add ignore rules for generated local importer reports while preserving the tracked sample report files
- align related issue labels so the new workflow starts from the same conventions it encodes

## Validation

- [x] `bun run lint`
- [x] manual review of recent merged Bukie PR structure (#90, #88, #85, #83) and current issue-writing patterns
- [x] manual review that the issue templates are now Markdown-based for consistency with the PR template and existing repo style

Closes #95