### PR TITLE
docs(covers): align cover workflow guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,7 @@
 
 ## Validation
 
-<!-- Keep this honest. Remove items that do not apply. -->
+<!-- Keep this honest. Check items that passed locally or in CI. Remove items that do not apply. -->
 
 - [ ] `bun run lint`
 - [ ] `bun run test`
@@ -30,10 +30,9 @@
 
 ## UX Notes
 
-<!-- Required for UI, content, layout, or interaction changes. -->
+<!-- Required for UI, content, layout, or interaction changes. Attach screenshots or video when that will help review. Remove items that do not apply. -->
 
 - [ ] no visual changes
-- [ ] screenshots or video attached
 - [ ] responsive behavior verified at affected breakpoints
 - [ ] accessibility impact reviewed
 

--- a/docs/books-steps.md
+++ b/docs/books-steps.md
@@ -19,7 +19,7 @@ This guide describes how we’ll curate and ingest books in batches of 100 so ev
 - Covers
   - `covers:fetch` — downloads covers and updates `books.cover`.
   - `images:optimize` — converts/optimizes cover assets (e.g., WebP) under `public/covers`.
-  - `db:sync:covers` — syncs DB cover paths to slugged filenames based on files present.
+  - `db:sync:covers` — syncs DB cover paths to canonical id-based filenames based on files present.
 - Database lifecycle
   - `db:migrate:pg` / `db:init:pg` — Postgres migrations/initialization for preview/prod.
   - `db:seed` (SQLite) / `db:seed:pg` (Postgres) — seeders using `mocks/books.ts`.
@@ -75,7 +75,7 @@ See all script entries in `package.json`.
    bun run covers:fetch -- --limit=100 --concurrency=2 --no-optimize
    ```
 
-   - You can also target specific ids with `--id=<bookId>` and enable `--seo-filenames` once titles are final.
+   - You can also target specific ids with `--id=<bookId>`.
 
 4) Optimize images (optional for dev, recommended for preview/prod)
 
@@ -112,7 +112,7 @@ Required/primary fields per book:
 - pages (number | null)
 - description (string | null)
 - categories (array of strings; will become canonical tags)
-- cover (string URL/path like `/covers/<id>-<title-slug>.<ext>`) — filled by covers workflow
+- cover (string URL/path like `/covers/<id>.<ext>`) — filled by covers workflow
 
 Note: We previously considered JSON batch files under `artifacts/`, and the importer can read them with `--input` and `--category`.
 
@@ -137,7 +137,7 @@ bun run db:report -- --report=./artifacts/report-YYYY-MM-DD.json --out=./artifac
 ## Troubleshooting
 
 - Reset local DB if rows get out of sync: `bun run db:reset` then re‑seed and sync covers.
-- If covers don’t update in UI, ensure files exist under `public/covers` and that `db:sync:covers` ran.
+- If covers don’t update in UI, ensure files exist under `public/covers` and that `db:sync:covers` ran. When a local file is still missing, the app falls back to `/covers/placeholder.svg` instead of requesting a broken asset path.
 - CI: The previous JSON importer dry‑run workflow was consolidated; importer now handles report output by default.
 
 ## References

--- a/docs/covers-flow.md
+++ b/docs/covers-flow.md
@@ -12,7 +12,7 @@ This document explains how cover images flow from the catalog source to the UI, 
 ## Flow at a glance
 
 - Source of truth: `artifacts/catalog/*.ts` exports typed `Book[]` batches, and `artifacts/catalog/index.ts` combines them for the app seed path.
-- Enrichment: `artifacts/catalog/build.ts` checks `public/covers` and resolves each book to `/covers/<id>.webp` when the local asset exists.
+- Catalog output: `artifacts/catalog/build.ts` emits canonical id-based cover paths using `/covers/<id>.webp`.
 - Import: category-specific `bun run db:import:*` commands ingest each batch into the DB and persist fields including `cover`.
 - Fetching: `bun run covers:fetch` downloads from Open Library (ISBN first, then Search API and manual fallbacks) and writes assets under `public/covers`.
 - Sync: `bun run db:sync:covers` updates DB rows to the best local extension for the current typed catalog.
@@ -46,7 +46,7 @@ flowchart LR
 ## Contracts
 
 - Input: typed `Book` items with `cover` and optional `isbn`.
-- Output: `cover` paths that are either existing local assets (`/covers/*.webp|jpg|png`) or the placeholder.
+- Output: app-facing `cover` paths that are either existing local assets (`/covers/*.webp|jpg|png`) or the placeholder.
 - Error mode: missing files fall back to `/covers/placeholder.svg`.
 
 ## Pruning unused covers


### PR DESCRIPTION
## Summary

- align the remaining cover workflow docs with the canonical `/covers/<id>.<ext>` strategy
- remove stale slug-style and unsupported CLI guidance
- simplify the PR template so validation can reflect CI and the UX section does not leave an empty screenshots/video checkbox

## Linked Issue

- Closes #93
- Labels aligned with linked issue: bug, tooling, frontend, books, quality

## Changes

- update `docs/books-steps.md` to use canonical id-based cover path guidance
- update `docs/covers-flow.md` to match the current app-facing cover flow
- update `.github/pull_request_template.md` so validation can be checked from local or CI results and the UX notes no longer include a standalone screenshots/video checkbox

## Validation

- [x] `bun run lint`
- [x] `bun run test`
- [x] `bunx playwright test`
- [x] manual verification completed where relevant

## UX Notes

- [x] no visual changes

Notes:

- CI checks are passing, including lint, unit tests, Storybook tests, Playwright E2E, and Vercel preview
- no UI changes; docs now match the current cover-path behavior

## Architecture Notes

- [x] no architectural impact
- [x] follows existing architecture and framework defaults
- [ ] introduces or updates a documented decision in `docs/decisions`

ADR / decision links:

- none

## Data / API / Infra Impact

- [x] no data, API, or infra impact
- [ ] database schema changed
- [ ] seed/import/catalog data changed
- [ ] API contract changed
- [ ] environment variables changed
- [ ] CI/CD or deployment behavior changed

Operational notes:

- none

## Risks

- [x] low risk
- [ ] medium risk
- [ ] high risk

Main risks and mitigations:

- risk: docs drift from implementation over time
- mitigation: this PR updates the remaining stale guidance and trims one source of PR template friction

## Checklist

- [x] scope matches the linked issue
- [x] PR labels match the linked issue labels where applicable
- [x] touched code is cleaner than before
- [x] tests cover the changed behavior
- [x] docs were updated where needed
- [x] local-only/generated artifacts are excluded from git