### PR TITLE
fix(ci): pin Node version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
## Summary
- add `actions/setup-node` to the release workflow
- read the Node version from `.nvmrc` before installing Bun
- keep release behavior aligned with issue #104

## Testing
- not run locally

Closes #104