### PR TITLE
feat(ci): skip app checks for docs-only changes

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -3,6 +3,9 @@ name: Biome Lint & Format
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   biome:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,37 @@
+name: Documentation
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Lint Markdown
+        uses: DavidAnson/markdownlint-cli2-action@6bf21b07787794f89a243495939cd651942aeabe # v24.1.0
+        with:
+          globs: |
+            **/*.md
+            #node_modules
+            #playwright-report
+      - name: Check local documentation links
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
+        with:
+          args: >-
+            --offline
+            --root-dir "${{ github.workspace }}"
+            --no-progress
+            --exclude-path node_modules
+            --exclude-path playwright-report
+            --exclude-path .next
+            --exclude-path test-results
+            "./**/*.md"
+          fail: true

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -2,6 +2,9 @@ name: Playwright E2E Tests
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 jobs:
   test:
     timeout-minutes: 60

--- a/.github/workflows/qlty.yml
+++ b/.github/workflows/qlty.yml
@@ -3,9 +3,15 @@ name: Qlty.sh Coverage & Quality
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
   push:
     branches:
       - main
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   qlty:

--- a/.github/workflows/storybook-tests.yml
+++ b/.github/workflows/storybook-tests.yml
@@ -3,6 +3,9 @@ name: Storybook Tests
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   storybook-tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ name: Test
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   test:

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "default": false,
+    "MD018": true, // Require a space after an ATX heading marker.
+    "MD047": true // Require one final newline.
+  }
+}

--- a/docs/docs-only-validation.md
+++ b/docs/docs-only-validation.md
@@ -1,0 +1,53 @@
+# Documentation-only validation
+
+Bukie treats a pull request as documentation-only when every changed path is
+under `docs/**` or is a Markdown file (`**/*.md`). Any other changed path runs
+the full application pipeline.
+
+## GitHub Actions
+
+Biome, unit, Playwright, Storybook, and Qlty workflows use GitHub Actions'
+native `paths-ignore` filters. A genuinely documentation-only pull request does
+not start those workflows. Commitlint and the lightweight Documentation
+workflow continue to run.
+
+The Documentation workflow uses Markdownlint CLI2 for heading spacing and final
+newlines, plus Lychee in offline mode for local repository links. Both actions
+are pinned to immutable release commits. Generated dependency, build, and test
+report directories are excluded.
+
+GitHub evaluates the complete pull-request diff, not only the latest commit.
+Adding a documentation commit to a pull request that already changes
+application files therefore still runs the application workflows.
+
+Path-filtered workflows must not be configured as required checks: GitHub can
+leave a required but filtered workflow pending. The current repository has no
+branch protection or rulesets. If required checks are introduced, require an
+always-running gate such as Documentation or Commitlint, or add a dedicated
+required gate that accounts for path filtering.
+
+## Vercel
+
+[`vercel.json`](../vercel.json) uses Vercel's Ignored Build Step with a direct
+`git diff` command:
+
+- exit `0` cancels a documentation-only build;
+- exit `1` continues a build with application changes; and
+- an unavailable comparison commit or other Git error is normalized to exit
+  `1`, so the build continues instead of failing the deployment.
+
+The command compares the current commit with `VERCEL_GIT_PREVIOUS_SHA`, falling
+back to `HEAD^` when that environment variable is unavailable. It excludes
+`docs/**` and Markdown files case-insensitively from the diff. Rename detection
+is disabled so both sides of a rename are considered. A `.vercelignore` file
+controls uploaded files, not whether a Git build starts.
+
+For an intentional redeploy, choose **Redeploy** in Vercel and clear **Use
+project's Ignore Build Step**.
+
+References:
+
+- [GitHub Actions path filters](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onpushpull_requestpull_request_targetpathspaths-ignore)
+- [Markdownlint CLI2 Action](https://github.com/DavidAnson/markdownlint-cli2-action)
+- [Lychee offline link checking](https://github.com/lycheeverse/lychee)
+- [Vercel Ignored Build Step](https://vercel.com/kb/guide/how-do-i-use-the-ignored-build-step-field-on-vercel)

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "git diff --quiet --no-renames \"${VERCEL_GIT_PREVIOUS_SHA:-HEAD^}\" HEAD -- . ':(exclude)docs/**' ':(exclude,icase,glob)**/*.md' || exit 1"
+}


### PR DESCRIPTION
## Summary

- Skip application CI workflows for genuinely documentation-only pull
  requests using GitHub's native path filters.
- Keep Commitlint plus lightweight Markdown and local-link validation running.
- Skip documentation-only Vercel builds with one fail-open Git diff command.

## Linked Issue

Closes #117

Labels: `enhancement`, `ci`, `tooling`

## Changes

- Add `paths-ignore` for `docs/**` and `**/*.md` to Biome, unit, Playwright,
  Storybook, and Qlty workflow triggers.
- Add a read-only Documentation workflow using immutable Markdownlint CLI2 and
  offline Lychee actions.
- Add a narrow Markdownlint baseline for heading spacing and final newlines.
- Configure Vercel's Ignored Build Step without a repository-owned classifier.
- Document GitHub's complete-PR diff behavior, the required-check caveat,
  Vercel's fail-open behavior, and intentional redeploys.

## Validation

- [x] `bun run lint`
- [x] `bun run test` (39 files, 166 tests)
- [x] `bun run build:ci`
- [x] Markdownlint CLI2 (53 Markdown files, 0 issues)
- [x] Lychee offline (227 links, 0 errors)
- [x] Vercel diff returns `0` for root Markdown and `docs/**` changes
- [x] Vercel diff returns `1` for application changes
- [x] Invalid Vercel comparison is normalized to exit `1` and builds
- [x] workflow YAML and `vercel.json` parse successfully
- [x] `git diff --check`
- [x] all GitHub checks, including 12 Playwright browser/project cases
- [x] [Vercel preview](https://bukie-kk96p8clj-amalvs-projects.vercel.app)

This implementation PR changes workflow and deployment configuration, so the
complete application suite and preview ran. GitHub evaluates the whole
pull-request diff; native filtering can only be observed on a future pull
request whose complete diff is documentation-only.

## UX Notes

- [x] no visual changes

## Architecture Notes

- [x] no application architecture impact

Operational decision: use platform-native filtering while the repository has no
required-check ruleset. If required checks are introduced later, use an
always-running required gate rather than requiring a path-filtered workflow.

## Data / API / Infra Impact

- [x] no data or API impact
- [x] CI/CD and deployment behavior changed

## Risks

- [x] low risk

- A path-filtered workflow could block merging if it later becomes required.
  The repository currently has no branch protection or rulesets, and the
  limitation is documented.
- A missing Vercel comparison commit could make skipping unsafe. Git failures
  are normalized to exit `1`, which continues the build.

## Checklist

- [x] scope matches the linked issue
- [x] PR labels match the linked issue labels
- [x] application checks remain unchanged when triggered
- [x] documentation was updated
- [x] local-only/generated artifacts are excluded from Git
