### PR TITLE
feat(search): add URL-driven catalog filters

### DIFF
--- a/docs/database-architecture.md
+++ b/docs/database-architecture.md
@@ -45,10 +45,11 @@ The supported deterministic sorts are:
 - `publication`: publication metadata first, then
   `(preferred-edition publication_sort_date desc, works.id asc)`.
 
-Every cursor identifies its sort and carries the corresponding sort value plus
-work ID. Malformed cursors and cursors for a different sort restart from the
-first page. New arrivals use the same catalog-addition semantics. Detail and
-canonical `/books/<id>` routes use `works.id`.
+Every cursor identifies the complete canonical query context, its sort, and
+carries the corresponding sort value plus work ID. Malformed cursors and
+cursors for a different search, filter, or sort restart from the first page.
+New arrivals use the same catalog-addition semantics. Detail and canonical
+`/books/<id>` routes use `works.id`.
 
 Publication periods are `before-1950`, `1950-1999`, `2000-2009`, `2010-2019`,
 and `2020-present`. Their boundaries use ISO sort dates, so year-, month-, and

--- a/docs/database-architecture.md
+++ b/docs/database-architecture.md
@@ -31,10 +31,28 @@ sequenceDiagram
   Repo-->>UI: normalized contract
 ```
 
-Browse and search are ordered by `(works.sort_title, works.id)`. Cursors carry
-both values. New arrivals use preferred-edition `cataloged_at` descending and
-work ID as the deterministic tie-break. Detail and canonical `/books/<id>`
-routes use `works.id`.
+Catalog browse and search share the canonical `q`, `category`, `period`, and
+`sort` query model in `src/features/books/catalogQuery.ts`. `q` matches selected
+work titles and ordered author names. `category` is an active Bukie category
+slug. `period` applies one of the documented inclusive/exclusive ranges to the
+preferred edition's `publication_sort_date`; works without publication metadata
+remain visible unless a period is selected.
+
+The supported deterministic sorts are:
+
+- `title` (default): `(works.sort_title asc, works.id asc)`;
+- `added`: `(preferred-edition cataloged_at desc, works.id asc)`;
+- `publication`: publication metadata first, then
+  `(preferred-edition publication_sort_date desc, works.id asc)`.
+
+Every cursor identifies its sort and carries the corresponding sort value plus
+work ID. Malformed cursors and cursors for a different sort restart from the
+first page. New arrivals use the same catalog-addition semantics. Detail and
+canonical `/books/<id>` routes use `works.id`.
+
+Publication periods are `before-1950`, `1950-1999`, `2000-2009`, `2010-2019`,
+and `2020-present`. Their boundaries use ISO sort dates, so year-, month-, and
+day-precision metadata behave consistently in SQLite and Postgres.
 
 The repository first selects the page of works and then loads preferred
 editions, authors, categories, publishers, languages, identifiers, and covers
@@ -77,10 +95,13 @@ database, and deployment must remain available for rollback.
 
 ## API
 
-- `GET /api/books?q=<query>` returns `WorkSummary[]`.
-- `GET /api/books/page?q=<query>&after=<cursor>&limit=<n>` returns a normalized
-  work page.
+- `GET /api/books?<catalog-query>` returns `WorkSummary[]`.
+- `GET /api/books/page?<catalog-query>&after=<cursor>&limit=<n>` returns a
+  normalized work page including the filtered total.
 - `GET /api/books/<work-id>` returns `WorkDetail`.
+
+Both list routes parse the same canonical catalog query used by the
+server-rendered homepage and client-side load-more requests.
 
 Catalog mutation and HTTP seed endpoints were removed. Curated changes must
 eventually use the observation/resolution lifecycle rather than direct

--- a/drizzle/0004_loose_tyrannus.sql
+++ b/drizzle/0004_loose_tyrannus.sql
@@ -1,0 +1,1 @@
+CREATE INDEX `editions_cataloged_work_idx` ON `editions` (`cataloged_at`,`work_id`);

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,2125 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "9dd01ac8-1b57-41a3-a3bc-806fa5eb3248",
+  "prevId": "237a3ec8-db31-41e4-95bf-d753290f95e3",
+  "tables": {
+    "authors": {
+      "name": "authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_name": {
+          "name": "sort_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authors_sort_name_idx": {
+          "name": "authors_sort_name_idx",
+          "columns": [
+            "sort_name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "authors_name_nonempty_ck": {
+          "name": "authors_name_nonempty_ck",
+          "value": "length(trim(\"authors\".\"display_name\")) > 0"
+        },
+        "authors_sort_name_ck": {
+          "name": "authors_sort_name_ck",
+          "value": "\"authors\".\"sort_name\" is null or length(trim(\"authors\".\"sort_name\")) > 0"
+        }
+      }
+    },
+    "catalog_change_events": {
+      "name": "catalog_change_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "catalog_change_events_type_created_idx": {
+          "name": "catalog_change_events_type_created_idx",
+          "columns": [
+            "change_type",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "catalog_change_events_type_ck": {
+          "name": "catalog_change_events_type_ck",
+          "value": "\"catalog_change_events\".\"change_type\" in ('work_merge', 'work_split', 'edition_reassignment')"
+        },
+        "catalog_change_events_json_ck": {
+          "name": "catalog_change_events_json_ck",
+          "value": "json_valid(\"catalog_change_events\".\"payload_json\")"
+        },
+        "catalog_change_events_nonempty_ck": {
+          "name": "catalog_change_events_nonempty_ck",
+          "value": "length(trim(\"catalog_change_events\".\"actor_ref\")) > 0 and length(trim(\"catalog_change_events\".\"reason\")) > 0"
+        }
+      }
+    },
+    "categories": {
+      "name": "categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "categories_slug_uq": {
+          "name": "categories_slug_uq",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "categories_nonempty_ck": {
+          "name": "categories_nonempty_ck",
+          "value": "length(trim(\"categories\".\"slug\")) > 0 and length(trim(\"categories\".\"label\")) > 0"
+        },
+        "categories_status_ck": {
+          "name": "categories_status_ck",
+          "value": "\"categories\".\"status\" in ('active', 'retired')"
+        }
+      }
+    },
+    "cover_assets": {
+      "name": "cover_assets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_policy_id": {
+          "name": "source_policy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cover_assets_object_key_uq": {
+          "name": "cover_assets_object_key_uq",
+          "columns": [
+            "object_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "cover_assets_source_policy_id_metadata_sources_id_fk": {
+          "name": "cover_assets_source_policy_id_metadata_sources_id_fk",
+          "tableFrom": "cover_assets",
+          "tableTo": "metadata_sources",
+          "columnsFrom": [
+            "source_policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "cover_assets_object_key_ck": {
+          "name": "cover_assets_object_key_ck",
+          "value": "length(trim(\"cover_assets\".\"object_key\")) > 0 and substr(\"cover_assets\".\"object_key\", 1, 8) = '/covers/'"
+        },
+        "cover_assets_state_ck": {
+          "name": "cover_assets_state_ck",
+          "value": "\"cover_assets\".\"state\" in ('available', 'missing', 'withdrawn', 'failed')"
+        },
+        "cover_assets_dimensions_ck": {
+          "name": "cover_assets_dimensions_ck",
+          "value": "(\"cover_assets\".\"width\" is null or \"cover_assets\".\"width\" > 0)\n        and (\"cover_assets\".\"height\" is null or \"cover_assets\".\"height\" > 0)\n        and (\"cover_assets\".\"bytes\" is null or \"cover_assets\".\"bytes\" > 0)"
+        }
+      }
+    },
+    "edition_covers": {
+      "name": "edition_covers",
+      "columns": {
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cover_asset_id": {
+          "name": "cover_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "edition_covers_position_uq": {
+          "name": "edition_covers_position_uq",
+          "columns": [
+            "edition_id",
+            "position"
+          ],
+          "isUnique": true
+        },
+        "edition_covers_primary_uq": {
+          "name": "edition_covers_primary_uq",
+          "columns": [
+            "edition_id"
+          ],
+          "isUnique": true,
+          "where": "\"edition_covers\".\"is_primary\" = 1"
+        },
+        "edition_covers_owner_position_idx": {
+          "name": "edition_covers_owner_position_idx",
+          "columns": [
+            "edition_id",
+            "position"
+          ],
+          "isUnique": false
+        },
+        "edition_covers_primary_lookup_idx": {
+          "name": "edition_covers_primary_lookup_idx",
+          "columns": [
+            "edition_id",
+            "is_primary"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "edition_covers_edition_id_editions_id_fk": {
+          "name": "edition_covers_edition_id_editions_id_fk",
+          "tableFrom": "edition_covers",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edition_covers_cover_asset_id_cover_assets_id_fk": {
+          "name": "edition_covers_cover_asset_id_cover_assets_id_fk",
+          "tableFrom": "edition_covers",
+          "tableTo": "cover_assets",
+          "columnsFrom": [
+            "cover_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edition_covers_pk": {
+          "columns": [
+            "edition_id",
+            "cover_asset_id"
+          ],
+          "name": "edition_covers_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "edition_covers_position_ck": {
+          "name": "edition_covers_position_ck",
+          "value": "\"edition_covers\".\"position\" >= 0"
+        }
+      }
+    },
+    "edition_identifiers": {
+      "name": "edition_identifiers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheme": {
+          "name": "scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_normalized": {
+          "name": "value_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_display": {
+          "name": "value_display",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "edition_identifiers_value_uq": {
+          "name": "edition_identifiers_value_uq",
+          "columns": [
+            "scheme",
+            "value_normalized"
+          ],
+          "isUnique": true
+        },
+        "edition_identifiers_primary_uq": {
+          "name": "edition_identifiers_primary_uq",
+          "columns": [
+            "edition_id"
+          ],
+          "isUnique": true,
+          "where": "\"edition_identifiers\".\"is_primary\" = 1"
+        },
+        "edition_identifiers_owner_idx": {
+          "name": "edition_identifiers_owner_idx",
+          "columns": [
+            "edition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "edition_identifiers_edition_id_editions_id_fk": {
+          "name": "edition_identifiers_edition_id_editions_id_fk",
+          "tableFrom": "edition_identifiers",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "edition_identifiers_scheme_ck": {
+          "name": "edition_identifiers_scheme_ck",
+          "value": "\"edition_identifiers\".\"scheme\" in ('isbn10', 'isbn13')"
+        },
+        "edition_identifiers_value_ck": {
+          "name": "edition_identifiers_value_ck",
+          "value": "length(trim(\"edition_identifiers\".\"value_normalized\")) > 0"
+        }
+      }
+    },
+    "edition_languages": {
+      "name": "edition_languages",
+      "columns": {
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language_tag": {
+          "name": "language_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "edition_languages_position_uq": {
+          "name": "edition_languages_position_uq",
+          "columns": [
+            "edition_id",
+            "position"
+          ],
+          "isUnique": true
+        },
+        "edition_languages_owner_position_idx": {
+          "name": "edition_languages_owner_position_idx",
+          "columns": [
+            "edition_id",
+            "position"
+          ],
+          "isUnique": false
+        },
+        "edition_languages_language_edition_idx": {
+          "name": "edition_languages_language_edition_idx",
+          "columns": [
+            "language_tag",
+            "edition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "edition_languages_edition_id_editions_id_fk": {
+          "name": "edition_languages_edition_id_editions_id_fk",
+          "tableFrom": "edition_languages",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edition_languages_language_tag_languages_tag_fk": {
+          "name": "edition_languages_language_tag_languages_tag_fk",
+          "tableFrom": "edition_languages",
+          "tableTo": "languages",
+          "columnsFrom": [
+            "language_tag"
+          ],
+          "columnsTo": [
+            "tag"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edition_languages_pk": {
+          "columns": [
+            "edition_id",
+            "language_tag"
+          ],
+          "name": "edition_languages_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "edition_languages_position_ck": {
+          "name": "edition_languages_position_ck",
+          "value": "\"edition_languages\".\"position\" >= 0"
+        }
+      }
+    },
+    "edition_publishers": {
+      "name": "edition_publishers",
+      "columns": {
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "publisher_id": {
+          "name": "publisher_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "edition_publishers_position_uq": {
+          "name": "edition_publishers_position_uq",
+          "columns": [
+            "edition_id",
+            "position"
+          ],
+          "isUnique": true
+        },
+        "edition_publishers_owner_position_idx": {
+          "name": "edition_publishers_owner_position_idx",
+          "columns": [
+            "edition_id",
+            "position"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "edition_publishers_edition_id_editions_id_fk": {
+          "name": "edition_publishers_edition_id_editions_id_fk",
+          "tableFrom": "edition_publishers",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edition_publishers_publisher_id_publishers_id_fk": {
+          "name": "edition_publishers_publisher_id_publishers_id_fk",
+          "tableFrom": "edition_publishers",
+          "tableTo": "publishers",
+          "columnsFrom": [
+            "publisher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edition_publishers_pk": {
+          "columns": [
+            "edition_id",
+            "publisher_id"
+          ],
+          "name": "edition_publishers_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "edition_publishers_position_ck": {
+          "name": "edition_publishers_position_ck",
+          "value": "\"edition_publishers\".\"position\" >= 0"
+        },
+        "edition_publishers_role_ck": {
+          "name": "edition_publishers_role_ck",
+          "value": "\"edition_publishers\".\"role\" is null or \"edition_publishers\".\"role\" in ('publisher', 'co_publisher', 'imprint', 'distributor')"
+        }
+      }
+    },
+    "editions": {
+      "name": "editions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publication_date": {
+          "name": "publication_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publication_precision": {
+          "name": "publication_precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publication_sort_date": {
+          "name": "publication_sort_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pages": {
+          "name": "pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cataloged_at": {
+          "name": "cataloged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "editions_work_id_idx": {
+          "name": "editions_work_id_idx",
+          "columns": [
+            "work_id"
+          ],
+          "isUnique": false
+        },
+        "editions_publication_sort_work_idx": {
+          "name": "editions_publication_sort_work_idx",
+          "columns": [
+            "publication_sort_date",
+            "work_id"
+          ],
+          "isUnique": false
+        },
+        "editions_cataloged_work_idx": {
+          "name": "editions_cataloged_work_idx",
+          "columns": [
+            "cataloged_at",
+            "work_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "editions_work_id_works_id_fk": {
+          "name": "editions_work_id_works_id_fk",
+          "tableFrom": "editions",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "editions_title_ck": {
+          "name": "editions_title_ck",
+          "value": "\"editions\".\"title\" is null or length(trim(\"editions\".\"title\")) > 0"
+        },
+        "editions_subtitle_ck": {
+          "name": "editions_subtitle_ck",
+          "value": "\"editions\".\"subtitle\" is null or length(trim(\"editions\".\"subtitle\")) > 0"
+        },
+        "editions_format_ck": {
+          "name": "editions_format_ck",
+          "value": "\"editions\".\"format\" is null or \"editions\".\"format\" in ('hardcover', 'paperback', 'ebook', 'audiobook', 'other')"
+        },
+        "editions_pages_ck": {
+          "name": "editions_pages_ck",
+          "value": "\"editions\".\"pages\" is null or \"editions\".\"pages\" > 0"
+        },
+        "editions_publication_precision_ck": {
+          "name": "editions_publication_precision_ck",
+          "value": "\"editions\".\"publication_precision\" is null or \"editions\".\"publication_precision\" in ('year', 'month', 'day')"
+        },
+        "editions_publication_date_ck": {
+          "name": "editions_publication_date_ck",
+          "value": "(\n        \"editions\".\"publication_date\" is null\n        and \"editions\".\"publication_precision\" is null\n        and \"editions\".\"publication_sort_date\" is null\n      ) or (\n        \"editions\".\"publication_precision\" = 'year'\n        and length(\"editions\".\"publication_date\") = 4\n        and \"editions\".\"publication_sort_date\" = \"editions\".\"publication_date\" || '-01-01'\n      ) or (\n        \"editions\".\"publication_precision\" = 'month'\n        and length(\"editions\".\"publication_date\") = 7\n        and substr(\"editions\".\"publication_date\", 5, 1) = '-'\n        and \"editions\".\"publication_sort_date\" = \"editions\".\"publication_date\" || '-01'\n      ) or (\n        \"editions\".\"publication_precision\" = 'day'\n        and length(\"editions\".\"publication_date\") = 10\n        and substr(\"editions\".\"publication_date\", 5, 1) = '-'\n        and substr(\"editions\".\"publication_date\", 8, 1) = '-'\n        and \"editions\".\"publication_sort_date\" = \"editions\".\"publication_date\"\n      )"
+        }
+      }
+    },
+    "entity_aliases": {
+      "name": "entity_aliases",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_id": {
+          "name": "from_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_id": {
+          "name": "to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "entity_aliases_target_idx": {
+          "name": "entity_aliases_target_idx",
+          "columns": [
+            "entity_type",
+            "to_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "entity_aliases_pk": {
+          "columns": [
+            "entity_type",
+            "from_id"
+          ],
+          "name": "entity_aliases_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "entity_aliases_ck": {
+          "name": "entity_aliases_ck",
+          "value": "\"entity_aliases\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset')\n        and \"entity_aliases\".\"from_id\" <> \"entity_aliases\".\"to_id\"\n        and length(trim(\"entity_aliases\".\"reason\")) > 0"
+        }
+      }
+    },
+    "field_observations": {
+      "name": "field_observations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_json": {
+          "name": "value_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comparison_hash": {
+          "name": "comparison_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provenance_kind": {
+          "name": "provenance_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_modified_at": {
+          "name": "source_modified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retrieved_at": {
+          "name": "retrieved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mapping_confidence": {
+          "name": "mapping_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "derivation_name": {
+          "name": "derivation_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "derivation_version": {
+          "name": "derivation_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_ids_json": {
+          "name": "parent_ids_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "field_observations_identity_uq": {
+          "name": "field_observations_identity_uq",
+          "columns": [
+            "id"
+          ],
+          "isUnique": true
+        },
+        "field_observations_source_field_state_idx": {
+          "name": "field_observations_source_field_state_idx",
+          "columns": [
+            "source_record_id",
+            "field_key",
+            "state"
+          ],
+          "isUnique": false
+        },
+        "field_observations_target_field_idx": {
+          "name": "field_observations_target_field_idx",
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "field_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "field_observations_source_record_id_source_records_id_fk": {
+          "name": "field_observations_source_record_id_source_records_id_fk",
+          "tableFrom": "field_observations",
+          "tableTo": "source_records",
+          "columnsFrom": [
+            "source_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "field_observations_target_ck": {
+          "name": "field_observations_target_ck",
+          "value": "\"field_observations\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and \"field_observations\".\"field_key\" in ('work.preferred_title', 'work.description', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')"
+        },
+        "field_observations_json_ck": {
+          "name": "field_observations_json_ck",
+          "value": "json_valid(\"field_observations\".\"value_json\") and (\"field_observations\".\"parent_ids_json\" is null or json_valid(\"field_observations\".\"parent_ids_json\"))"
+        },
+        "field_observations_hash_ck": {
+          "name": "field_observations_hash_ck",
+          "value": "length(\"field_observations\".\"comparison_hash\") = 64"
+        },
+        "field_observations_provenance_ck": {
+          "name": "field_observations_provenance_ck",
+          "value": "\"field_observations\".\"provenance_kind\" in ('curated', 'imported', 'derived', 'synthetic')"
+        },
+        "field_observations_state_ck": {
+          "name": "field_observations_state_ck",
+          "value": "\"field_observations\".\"state\" in ('active', 'stale', 'withdrawn', 'invalid')"
+        },
+        "field_observations_confidence_ck": {
+          "name": "field_observations_confidence_ck",
+          "value": "\"field_observations\".\"mapping_confidence\" between 0 and 1"
+        },
+        "field_observations_curated_ck": {
+          "name": "field_observations_curated_ck",
+          "value": "\"field_observations\".\"provenance_kind\" <> 'curated'\n        or (length(trim(\"field_observations\".\"actor_ref\")) > 0 and length(trim(\"field_observations\".\"reason\")) > 0)"
+        },
+        "field_observations_derived_ck": {
+          "name": "field_observations_derived_ck",
+          "value": "\"field_observations\".\"provenance_kind\" <> 'derived'\n        or (\n          length(trim(\"field_observations\".\"derivation_name\")) > 0\n          and length(trim(\"field_observations\".\"derivation_version\")) > 0\n          and json_valid(\"field_observations\".\"parent_ids_json\")\n        )"
+        }
+      }
+    },
+    "field_resolution_heads": {
+      "name": "field_resolution_heads",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolution_id": {
+          "name": "resolution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "field_resolution_heads_resolution_uq": {
+          "name": "field_resolution_heads_resolution_uq",
+          "columns": [
+            "resolution_id"
+          ],
+          "isUnique": true
+        },
+        "field_resolution_heads_lookup_idx": {
+          "name": "field_resolution_heads_lookup_idx",
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "field_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "field_resolution_heads_resolution_id_field_resolutions_id_fk": {
+          "name": "field_resolution_heads_resolution_id_field_resolutions_id_fk",
+          "tableFrom": "field_resolution_heads",
+          "tableTo": "field_resolutions",
+          "columnsFrom": [
+            "resolution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "field_resolution_heads_pk": {
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "field_key"
+          ],
+          "name": "field_resolution_heads_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "field_resolution_heads_target_ck": {
+          "name": "field_resolution_heads_target_ck",
+          "value": "\"field_resolution_heads\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and \"field_resolution_heads\".\"field_key\" in ('work.preferred_title', 'work.description', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')"
+        }
+      }
+    },
+    "field_resolutions": {
+      "name": "field_resolutions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "selected_observation_id": {
+          "name": "selected_observation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "previous_resolution_id": {
+          "name": "previous_resolution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolver_version": {
+          "name": "resolver_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "field_resolutions_target_history_idx": {
+          "name": "field_resolutions_target_history_idx",
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "field_key",
+            "resolved_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "field_resolutions_selected_observation_id_field_observations_id_fk": {
+          "name": "field_resolutions_selected_observation_id_field_observations_id_fk",
+          "tableFrom": "field_resolutions",
+          "tableTo": "field_observations",
+          "columnsFrom": [
+            "selected_observation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "field_resolutions_previous_resolution_id_field_resolutions_id_fk": {
+          "name": "field_resolutions_previous_resolution_id_field_resolutions_id_fk",
+          "tableFrom": "field_resolutions",
+          "tableTo": "field_resolutions",
+          "columnsFrom": [
+            "previous_resolution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "field_resolutions_target_ck": {
+          "name": "field_resolutions_target_ck",
+          "value": "\"field_resolutions\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and \"field_resolutions\".\"field_key\" in ('work.preferred_title', 'work.description', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')"
+        },
+        "field_resolutions_state_ck": {
+          "name": "field_resolutions_state_ck",
+          "value": "\"field_resolutions\".\"state\" in ('present', 'missing', 'conflicting', 'stale', 'withdrawn')"
+        },
+        "field_resolutions_selection_ck": {
+          "name": "field_resolutions_selection_ck",
+          "value": "(\n        \"field_resolutions\".\"state\" in ('present', 'stale')\n        and \"field_resolutions\".\"selected_observation_id\" is not null\n      ) or (\n        \"field_resolutions\".\"state\" in ('missing', 'conflicting', 'withdrawn')\n        and \"field_resolutions\".\"selected_observation_id\" is null\n      )"
+        },
+        "field_resolutions_nonempty_ck": {
+          "name": "field_resolutions_nonempty_ck",
+          "value": "length(trim(\"field_resolutions\".\"reason\")) > 0\n        and length(trim(\"field_resolutions\".\"actor_ref\")) > 0\n        and length(trim(\"field_resolutions\".\"resolver_version\")) > 0"
+        }
+      }
+    },
+    "languages": {
+      "name": "languages",
+      "columns": {
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "languages_nonempty_ck": {
+          "name": "languages_nonempty_ck",
+          "value": "length(trim(\"languages\".\"tag\")) > 0 and length(trim(\"languages\".\"label\")) > 0"
+        }
+      }
+    },
+    "metadata_sources": {
+      "name": "metadata_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "terms_url": {
+          "name": "terms_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attribution_url": {
+          "name": "attribution_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approval_state": {
+          "name": "approval_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_policy": {
+          "name": "metadata_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "asset_policy": {
+          "name": "asset_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_policy": {
+          "name": "payload_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_interval_ms": {
+          "name": "refresh_interval_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "metadata_sources_key_uq": {
+          "name": "metadata_sources_key_uq",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "metadata_sources_nonempty_ck": {
+          "name": "metadata_sources_nonempty_ck",
+          "value": "length(trim(\"metadata_sources\".\"key\")) > 0 and length(trim(\"metadata_sources\".\"name\")) > 0"
+        },
+        "metadata_sources_approval_state_ck": {
+          "name": "metadata_sources_approval_state_ck",
+          "value": "\"metadata_sources\".\"approval_state\" in ('pending', 'approved', 'suspended', 'retired')"
+        },
+        "metadata_sources_payload_policy_ck": {
+          "name": "metadata_sources_payload_policy_ck",
+          "value": "\"metadata_sources\".\"payload_policy\" in ('none', 'selected_fields', 'full')"
+        },
+        "metadata_sources_policy_json_ck": {
+          "name": "metadata_sources_policy_json_ck",
+          "value": "json_valid(\"metadata_sources\".\"metadata_policy\") and json_valid(\"metadata_sources\".\"asset_policy\")"
+        },
+        "metadata_sources_approved_review_ck": {
+          "name": "metadata_sources_approved_review_ck",
+          "value": "\"metadata_sources\".\"approval_state\" <> 'approved' or \"metadata_sources\".\"reviewed_at\" is not null"
+        },
+        "metadata_sources_refresh_ck": {
+          "name": "metadata_sources_refresh_ck",
+          "value": "\"metadata_sources\".\"refresh_interval_ms\" is null or \"metadata_sources\".\"refresh_interval_ms\" > 0"
+        }
+      }
+    },
+    "publishers": {
+      "name": "publishers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "publishers_name_nonempty_ck": {
+          "name": "publishers_name_nonempty_ck",
+          "value": "length(trim(\"publishers\".\"display_name\")) > 0"
+        }
+      }
+    },
+    "source_record_links": {
+      "name": "source_record_links",
+      "columns": {
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "match_kind": {
+          "name": "match_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mapping_confidence": {
+          "name": "mapping_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "source_record_links_entity_idx": {
+          "name": "source_record_links_entity_idx",
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "state"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "source_record_links_source_record_id_source_records_id_fk": {
+          "name": "source_record_links_source_record_id_source_records_id_fk",
+          "tableFrom": "source_record_links",
+          "tableTo": "source_records",
+          "columnsFrom": [
+            "source_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "source_record_links_pk": {
+          "columns": [
+            "source_record_id",
+            "entity_type",
+            "entity_id"
+          ],
+          "name": "source_record_links_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "source_record_links_entity_type_ck": {
+          "name": "source_record_links_entity_type_ck",
+          "value": "\"source_record_links\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset')"
+        },
+        "source_record_links_match_kind_ck": {
+          "name": "source_record_links_match_kind_ck",
+          "value": "\"source_record_links\".\"match_kind\" in ('exact_identifier', 'source_relationship', 'curated', 'candidate')"
+        },
+        "source_record_links_state_ck": {
+          "name": "source_record_links_state_ck",
+          "value": "\"source_record_links\".\"state\" in ('active', 'candidate', 'rejected')"
+        },
+        "source_record_links_confidence_ck": {
+          "name": "source_record_links_confidence_ck",
+          "value": "\"source_record_links\".\"mapping_confidence\" between 0 and 1"
+        },
+        "source_record_links_actor_ck": {
+          "name": "source_record_links_actor_ck",
+          "value": "(\n        \"source_record_links\".\"match_kind\" <> 'curated' and \"source_record_links\".\"state\" <> 'rejected'\n      ) or (\n        length(trim(\"source_record_links\".\"actor_ref\")) > 0 and length(trim(\"source_record_links\".\"reason\")) > 0\n      )"
+        }
+      }
+    },
+    "source_records": {
+      "name": "source_records",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_modified_at": {
+          "name": "source_modified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retrieved_at": {
+          "name": "retrieved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "importer_version": {
+          "name": "importer_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_row_hash": {
+          "name": "source_row_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "source_records_source_key_uq": {
+          "name": "source_records_source_key_uq",
+          "columns": [
+            "source_id",
+            "record_key"
+          ],
+          "isUnique": true
+        },
+        "source_records_refresh_idx": {
+          "name": "source_records_refresh_idx",
+          "columns": [
+            "source_id",
+            "state",
+            "retrieved_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "source_records_source_id_metadata_sources_id_fk": {
+          "name": "source_records_source_id_metadata_sources_id_fk",
+          "tableFrom": "source_records",
+          "tableTo": "metadata_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "source_records_key_nonempty_ck": {
+          "name": "source_records_key_nonempty_ck",
+          "value": "length(trim(\"source_records\".\"record_key\")) > 0"
+        },
+        "source_records_state_ck": {
+          "name": "source_records_state_ck",
+          "value": "\"source_records\".\"state\" in ('active', 'withdrawn', 'deleted')"
+        },
+        "source_records_payload_json_ck": {
+          "name": "source_records_payload_json_ck",
+          "value": "\"source_records\".\"payload_json\" is null or json_valid(\"source_records\".\"payload_json\")"
+        },
+        "source_records_import_hash_ck": {
+          "name": "source_records_import_hash_ck",
+          "value": "(\"source_records\".\"importer_version\" is null and \"source_records\".\"source_row_hash\" is null)\n        or (length(trim(\"source_records\".\"importer_version\")) > 0 and length(\"source_records\".\"source_row_hash\") = 64)"
+        }
+      }
+    },
+    "work_authors": {
+      "name": "work_authors",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'author'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "work_authors_position_uq": {
+          "name": "work_authors_position_uq",
+          "columns": [
+            "work_id",
+            "position"
+          ],
+          "isUnique": true
+        },
+        "work_authors_owner_position_idx": {
+          "name": "work_authors_owner_position_idx",
+          "columns": [
+            "work_id",
+            "position"
+          ],
+          "isUnique": false
+        },
+        "work_authors_author_work_idx": {
+          "name": "work_authors_author_work_idx",
+          "columns": [
+            "author_id",
+            "work_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "work_authors_work_id_works_id_fk": {
+          "name": "work_authors_work_id_works_id_fk",
+          "tableFrom": "work_authors",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_authors_author_id_authors_id_fk": {
+          "name": "work_authors_author_id_authors_id_fk",
+          "tableFrom": "work_authors",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "work_authors_pk": {
+          "columns": [
+            "work_id",
+            "author_id",
+            "role"
+          ],
+          "name": "work_authors_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "work_authors_role_ck": {
+          "name": "work_authors_role_ck",
+          "value": "\"work_authors\".\"role\" in ('author', 'editor', 'translator', 'illustrator')"
+        },
+        "work_authors_position_ck": {
+          "name": "work_authors_position_ck",
+          "value": "\"work_authors\".\"position\" >= 0"
+        }
+      }
+    },
+    "work_categories": {
+      "name": "work_categories",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "work_categories_position_uq": {
+          "name": "work_categories_position_uq",
+          "columns": [
+            "work_id",
+            "position"
+          ],
+          "isUnique": true
+        },
+        "work_categories_primary_uq": {
+          "name": "work_categories_primary_uq",
+          "columns": [
+            "work_id"
+          ],
+          "isUnique": true,
+          "where": "\"work_categories\".\"is_primary\" = 1"
+        },
+        "work_categories_owner_position_idx": {
+          "name": "work_categories_owner_position_idx",
+          "columns": [
+            "work_id",
+            "position"
+          ],
+          "isUnique": false
+        },
+        "work_categories_category_work_idx": {
+          "name": "work_categories_category_work_idx",
+          "columns": [
+            "category_id",
+            "work_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "work_categories_work_id_works_id_fk": {
+          "name": "work_categories_work_id_works_id_fk",
+          "tableFrom": "work_categories",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_categories_category_id_categories_id_fk": {
+          "name": "work_categories_category_id_categories_id_fk",
+          "tableFrom": "work_categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "work_categories_pk": {
+          "columns": [
+            "work_id",
+            "category_id"
+          ],
+          "name": "work_categories_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "work_categories_position_ck": {
+          "name": "work_categories_position_ck",
+          "value": "\"work_categories\".\"position\" >= 0"
+        }
+      }
+    },
+    "works": {
+      "name": "works",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preferred_title": {
+          "name": "preferred_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_title": {
+          "name": "sort_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferred_edition_id": {
+          "name": "preferred_edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "works_sort_title_id_idx": {
+          "name": "works_sort_title_id_idx",
+          "columns": [
+            "sort_title",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "works_preferred_edition_idx": {
+          "name": "works_preferred_edition_idx",
+          "columns": [
+            "preferred_edition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "works_preferred_edition_id_editions_id_fk": {
+          "name": "works_preferred_edition_id_editions_id_fk",
+          "tableFrom": "works",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "preferred_edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "works_titles_nonempty_ck": {
+          "name": "works_titles_nonempty_ck",
+          "value": "length(trim(\"works\".\"preferred_title\")) > 0 and length(trim(\"works\".\"sort_title\")) > 0"
+        }
+      }
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1785141857413,
       "tag": "0003_concerned_vance_astro",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1785159863046,
+      "tag": "0004_loose_tyrannus",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/pg/0006_luxuriant_albert_cleary.sql
+++ b/drizzle/pg/0006_luxuriant_albert_cleary.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "editions_cataloged_work_idx" ON "editions" USING btree ("cataloged_at","work_id");

--- a/drizzle/pg/meta/0006_snapshot.json
+++ b/drizzle/pg/meta/0006_snapshot.json
@@ -1,0 +1,2516 @@
+{
+  "id": "9dc7ba9d-77a1-477a-982d-947cd73fb370",
+  "prevId": "fefd8505-c68b-46dc-87b4-3ce18615de36",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.authors": {
+      "name": "authors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_name": {
+          "name": "sort_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "authors_sort_name_idx": {
+          "name": "authors_sort_name_idx",
+          "columns": [
+            {
+              "expression": "sort_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "authors_name_nonempty_ck": {
+          "name": "authors_name_nonempty_ck",
+          "value": "length(trim(\"authors\".\"display_name\")) > 0"
+        },
+        "authors_sort_name_ck": {
+          "name": "authors_sort_name_ck",
+          "value": "\"authors\".\"sort_name\" is null or length(trim(\"authors\".\"sort_name\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.catalog_change_events": {
+      "name": "catalog_change_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "catalog_change_events_type_created_idx": {
+          "name": "catalog_change_events_type_created_idx",
+          "columns": [
+            {
+              "expression": "change_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_change_events_type_ck": {
+          "name": "catalog_change_events_type_ck",
+          "value": "\"catalog_change_events\".\"change_type\" in ('work_merge', 'work_split', 'edition_reassignment')"
+        },
+        "catalog_change_events_nonempty_ck": {
+          "name": "catalog_change_events_nonempty_ck",
+          "value": "length(trim(\"catalog_change_events\".\"actor_ref\")) > 0 and length(trim(\"catalog_change_events\".\"reason\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "categories_slug_uq": {
+          "name": "categories_slug_uq",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "categories_nonempty_ck": {
+          "name": "categories_nonempty_ck",
+          "value": "length(trim(\"categories\".\"slug\")) > 0 and length(trim(\"categories\".\"label\")) > 0"
+        },
+        "categories_status_ck": {
+          "name": "categories_status_ck",
+          "value": "\"categories\".\"status\" in ('active', 'retired')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.cover_assets": {
+      "name": "cover_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_policy_id": {
+          "name": "source_policy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cover_assets_object_key_uq": {
+          "name": "cover_assets_object_key_uq",
+          "columns": [
+            {
+              "expression": "object_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cover_assets_source_policy_id_metadata_sources_id_fk": {
+          "name": "cover_assets_source_policy_id_metadata_sources_id_fk",
+          "tableFrom": "cover_assets",
+          "tableTo": "metadata_sources",
+          "columnsFrom": [
+            "source_policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cover_assets_object_key_ck": {
+          "name": "cover_assets_object_key_ck",
+          "value": "length(trim(\"cover_assets\".\"object_key\")) > 0 and substring(\"cover_assets\".\"object_key\" from 1 for 8) = '/covers/'"
+        },
+        "cover_assets_state_ck": {
+          "name": "cover_assets_state_ck",
+          "value": "\"cover_assets\".\"state\" in ('available', 'missing', 'withdrawn', 'failed')"
+        },
+        "cover_assets_dimensions_ck": {
+          "name": "cover_assets_dimensions_ck",
+          "value": "(\"cover_assets\".\"width\" is null or \"cover_assets\".\"width\" > 0)\n        and (\"cover_assets\".\"height\" is null or \"cover_assets\".\"height\" > 0)\n        and (\"cover_assets\".\"bytes\" is null or \"cover_assets\".\"bytes\" > 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.edition_covers": {
+      "name": "edition_covers",
+      "schema": "",
+      "columns": {
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_asset_id": {
+          "name": "cover_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "edition_covers_position_uq": {
+          "name": "edition_covers_position_uq",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_covers_primary_uq": {
+          "name": "edition_covers_primary_uq",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"edition_covers\".\"is_primary\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_covers_owner_position_idx": {
+          "name": "edition_covers_owner_position_idx",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_covers_primary_lookup_idx": {
+          "name": "edition_covers_primary_lookup_idx",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "edition_covers_edition_id_editions_id_fk": {
+          "name": "edition_covers_edition_id_editions_id_fk",
+          "tableFrom": "edition_covers",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edition_covers_cover_asset_id_cover_assets_id_fk": {
+          "name": "edition_covers_cover_asset_id_cover_assets_id_fk",
+          "tableFrom": "edition_covers",
+          "tableTo": "cover_assets",
+          "columnsFrom": [
+            "cover_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edition_covers_pk": {
+          "name": "edition_covers_pk",
+          "columns": [
+            "edition_id",
+            "cover_asset_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "edition_covers_position_ck": {
+          "name": "edition_covers_position_ck",
+          "value": "\"edition_covers\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.edition_identifiers": {
+      "name": "edition_identifiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheme": {
+          "name": "scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_normalized": {
+          "name": "value_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_display": {
+          "name": "value_display",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "edition_identifiers_value_uq": {
+          "name": "edition_identifiers_value_uq",
+          "columns": [
+            {
+              "expression": "scheme",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_identifiers_primary_uq": {
+          "name": "edition_identifiers_primary_uq",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"edition_identifiers\".\"is_primary\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_identifiers_owner_idx": {
+          "name": "edition_identifiers_owner_idx",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "edition_identifiers_edition_id_editions_id_fk": {
+          "name": "edition_identifiers_edition_id_editions_id_fk",
+          "tableFrom": "edition_identifiers",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "edition_identifiers_scheme_ck": {
+          "name": "edition_identifiers_scheme_ck",
+          "value": "\"edition_identifiers\".\"scheme\" in ('isbn10', 'isbn13')"
+        },
+        "edition_identifiers_value_ck": {
+          "name": "edition_identifiers_value_ck",
+          "value": "length(trim(\"edition_identifiers\".\"value_normalized\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.edition_languages": {
+      "name": "edition_languages",
+      "schema": "",
+      "columns": {
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_tag": {
+          "name": "language_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "edition_languages_position_uq": {
+          "name": "edition_languages_position_uq",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_languages_owner_position_idx": {
+          "name": "edition_languages_owner_position_idx",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_languages_language_edition_idx": {
+          "name": "edition_languages_language_edition_idx",
+          "columns": [
+            {
+              "expression": "language_tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "edition_languages_edition_id_editions_id_fk": {
+          "name": "edition_languages_edition_id_editions_id_fk",
+          "tableFrom": "edition_languages",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edition_languages_language_tag_languages_tag_fk": {
+          "name": "edition_languages_language_tag_languages_tag_fk",
+          "tableFrom": "edition_languages",
+          "tableTo": "languages",
+          "columnsFrom": [
+            "language_tag"
+          ],
+          "columnsTo": [
+            "tag"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edition_languages_pk": {
+          "name": "edition_languages_pk",
+          "columns": [
+            "edition_id",
+            "language_tag"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "edition_languages_position_ck": {
+          "name": "edition_languages_position_ck",
+          "value": "\"edition_languages\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.edition_publishers": {
+      "name": "edition_publishers",
+      "schema": "",
+      "columns": {
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publisher_id": {
+          "name": "publisher_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "edition_publishers_position_uq": {
+          "name": "edition_publishers_position_uq",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_publishers_owner_position_idx": {
+          "name": "edition_publishers_owner_position_idx",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "edition_publishers_edition_id_editions_id_fk": {
+          "name": "edition_publishers_edition_id_editions_id_fk",
+          "tableFrom": "edition_publishers",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edition_publishers_publisher_id_publishers_id_fk": {
+          "name": "edition_publishers_publisher_id_publishers_id_fk",
+          "tableFrom": "edition_publishers",
+          "tableTo": "publishers",
+          "columnsFrom": [
+            "publisher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edition_publishers_pk": {
+          "name": "edition_publishers_pk",
+          "columns": [
+            "edition_id",
+            "publisher_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "edition_publishers_position_ck": {
+          "name": "edition_publishers_position_ck",
+          "value": "\"edition_publishers\".\"position\" >= 0"
+        },
+        "edition_publishers_role_ck": {
+          "name": "edition_publishers_role_ck",
+          "value": "\"edition_publishers\".\"role\" is null or \"edition_publishers\".\"role\" in ('publisher', 'co_publisher', 'imprint', 'distributor')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.editions": {
+      "name": "editions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_date": {
+          "name": "publication_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_precision": {
+          "name": "publication_precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_sort_date": {
+          "name": "publication_sort_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pages": {
+          "name": "pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cataloged_at": {
+          "name": "cataloged_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "editions_work_id_idx": {
+          "name": "editions_work_id_idx",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "editions_publication_sort_work_idx": {
+          "name": "editions_publication_sort_work_idx",
+          "columns": [
+            {
+              "expression": "publication_sort_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "editions_cataloged_work_idx": {
+          "name": "editions_cataloged_work_idx",
+          "columns": [
+            {
+              "expression": "cataloged_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "editions_work_id_works_id_fk": {
+          "name": "editions_work_id_works_id_fk",
+          "tableFrom": "editions",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "editions_title_ck": {
+          "name": "editions_title_ck",
+          "value": "\"editions\".\"title\" is null or length(trim(\"editions\".\"title\")) > 0"
+        },
+        "editions_subtitle_ck": {
+          "name": "editions_subtitle_ck",
+          "value": "\"editions\".\"subtitle\" is null or length(trim(\"editions\".\"subtitle\")) > 0"
+        },
+        "editions_format_ck": {
+          "name": "editions_format_ck",
+          "value": "\"editions\".\"format\" is null or \"editions\".\"format\" in ('hardcover', 'paperback', 'ebook', 'audiobook', 'other')"
+        },
+        "editions_pages_ck": {
+          "name": "editions_pages_ck",
+          "value": "\"editions\".\"pages\" is null or \"editions\".\"pages\" > 0"
+        },
+        "editions_publication_precision_ck": {
+          "name": "editions_publication_precision_ck",
+          "value": "\"editions\".\"publication_precision\" is null or \"editions\".\"publication_precision\" in ('year', 'month', 'day')"
+        },
+        "editions_publication_date_ck": {
+          "name": "editions_publication_date_ck",
+          "value": "(\n        \"editions\".\"publication_date\" is null\n        and \"editions\".\"publication_precision\" is null\n        and \"editions\".\"publication_sort_date\" is null\n      ) or (\n        \"editions\".\"publication_precision\" = 'year'\n        and length(\"editions\".\"publication_date\") = 4\n        and \"editions\".\"publication_sort_date\" = \"editions\".\"publication_date\" || '-01-01'\n      ) or (\n        \"editions\".\"publication_precision\" = 'month'\n        and length(\"editions\".\"publication_date\") = 7\n        and substring(\"editions\".\"publication_date\" from 5 for 1) = '-'\n        and \"editions\".\"publication_sort_date\" = \"editions\".\"publication_date\" || '-01'\n      ) or (\n        \"editions\".\"publication_precision\" = 'day'\n        and length(\"editions\".\"publication_date\") = 10\n        and substring(\"editions\".\"publication_date\" from 5 for 1) = '-'\n        and substring(\"editions\".\"publication_date\" from 8 for 1) = '-'\n        and \"editions\".\"publication_sort_date\" = \"editions\".\"publication_date\"\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.entity_aliases": {
+      "name": "entity_aliases",
+      "schema": "",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_id": {
+          "name": "from_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_id": {
+          "name": "to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "entity_aliases_target_idx": {
+          "name": "entity_aliases_target_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "entity_aliases_pk": {
+          "name": "entity_aliases_pk",
+          "columns": [
+            "entity_type",
+            "from_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "entity_aliases_ck": {
+          "name": "entity_aliases_ck",
+          "value": "\"entity_aliases\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset')\n        and \"entity_aliases\".\"from_id\" <> \"entity_aliases\".\"to_id\"\n        and length(trim(\"entity_aliases\".\"reason\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.field_observations": {
+      "name": "field_observations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_json": {
+          "name": "value_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comparison_hash": {
+          "name": "comparison_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provenance_kind": {
+          "name": "provenance_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_modified_at": {
+          "name": "source_modified_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retrieved_at": {
+          "name": "retrieved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mapping_confidence": {
+          "name": "mapping_confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "derivation_name": {
+          "name": "derivation_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "derivation_version": {
+          "name": "derivation_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_ids_json": {
+          "name": "parent_ids_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "field_observations_identity_uq": {
+          "name": "field_observations_identity_uq",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "field_observations_source_field_state_idx": {
+          "name": "field_observations_source_field_state_idx",
+          "columns": [
+            {
+              "expression": "source_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "field_observations_target_field_idx": {
+          "name": "field_observations_target_field_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "field_observations_source_record_id_source_records_id_fk": {
+          "name": "field_observations_source_record_id_source_records_id_fk",
+          "tableFrom": "field_observations",
+          "tableTo": "source_records",
+          "columnsFrom": [
+            "source_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "field_observations_target_ck": {
+          "name": "field_observations_target_ck",
+          "value": "\"field_observations\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and \"field_observations\".\"field_key\" in ('work.preferred_title', 'work.description', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')"
+        },
+        "field_observations_hash_ck": {
+          "name": "field_observations_hash_ck",
+          "value": "length(\"field_observations\".\"comparison_hash\") = 64"
+        },
+        "field_observations_provenance_ck": {
+          "name": "field_observations_provenance_ck",
+          "value": "\"field_observations\".\"provenance_kind\" in ('curated', 'imported', 'derived', 'synthetic')"
+        },
+        "field_observations_state_ck": {
+          "name": "field_observations_state_ck",
+          "value": "\"field_observations\".\"state\" in ('active', 'stale', 'withdrawn', 'invalid')"
+        },
+        "field_observations_confidence_ck": {
+          "name": "field_observations_confidence_ck",
+          "value": "\"field_observations\".\"mapping_confidence\" between 0 and 1"
+        },
+        "field_observations_curated_ck": {
+          "name": "field_observations_curated_ck",
+          "value": "\"field_observations\".\"provenance_kind\" <> 'curated'\n        or (length(trim(\"field_observations\".\"actor_ref\")) > 0 and length(trim(\"field_observations\".\"reason\")) > 0)"
+        },
+        "field_observations_derived_ck": {
+          "name": "field_observations_derived_ck",
+          "value": "\"field_observations\".\"provenance_kind\" <> 'derived'\n        or (\n          length(trim(\"field_observations\".\"derivation_name\")) > 0\n          and length(trim(\"field_observations\".\"derivation_version\")) > 0\n          and \"field_observations\".\"parent_ids_json\" is not null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.field_resolution_heads": {
+      "name": "field_resolution_heads",
+      "schema": "",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution_id": {
+          "name": "resolution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "field_resolution_heads_resolution_uq": {
+          "name": "field_resolution_heads_resolution_uq",
+          "columns": [
+            {
+              "expression": "resolution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "field_resolution_heads_lookup_idx": {
+          "name": "field_resolution_heads_lookup_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "field_resolution_heads_resolution_id_field_resolutions_id_fk": {
+          "name": "field_resolution_heads_resolution_id_field_resolutions_id_fk",
+          "tableFrom": "field_resolution_heads",
+          "tableTo": "field_resolutions",
+          "columnsFrom": [
+            "resolution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "field_resolution_heads_pk": {
+          "name": "field_resolution_heads_pk",
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "field_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "field_resolution_heads_target_ck": {
+          "name": "field_resolution_heads_target_ck",
+          "value": "\"field_resolution_heads\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and \"field_resolution_heads\".\"field_key\" in ('work.preferred_title', 'work.description', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.field_resolutions": {
+      "name": "field_resolutions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_observation_id": {
+          "name": "selected_observation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_resolution_id": {
+          "name": "previous_resolution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolver_version": {
+          "name": "resolver_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "field_resolutions_target_history_idx": {
+          "name": "field_resolutions_target_history_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "field_resolutions_selected_observation_id_field_observations_id_fk": {
+          "name": "field_resolutions_selected_observation_id_field_observations_id_fk",
+          "tableFrom": "field_resolutions",
+          "tableTo": "field_observations",
+          "columnsFrom": [
+            "selected_observation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "field_resolutions_previous_resolution_id_field_resolutions_id_fk": {
+          "name": "field_resolutions_previous_resolution_id_field_resolutions_id_fk",
+          "tableFrom": "field_resolutions",
+          "tableTo": "field_resolutions",
+          "columnsFrom": [
+            "previous_resolution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "field_resolutions_target_ck": {
+          "name": "field_resolutions_target_ck",
+          "value": "\"field_resolutions\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and \"field_resolutions\".\"field_key\" in ('work.preferred_title', 'work.description', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')"
+        },
+        "field_resolutions_state_ck": {
+          "name": "field_resolutions_state_ck",
+          "value": "\"field_resolutions\".\"state\" in ('present', 'missing', 'conflicting', 'stale', 'withdrawn')"
+        },
+        "field_resolutions_selection_ck": {
+          "name": "field_resolutions_selection_ck",
+          "value": "(\n        \"field_resolutions\".\"state\" in ('present', 'stale')\n        and \"field_resolutions\".\"selected_observation_id\" is not null\n      ) or (\n        \"field_resolutions\".\"state\" in ('missing', 'conflicting', 'withdrawn')\n        and \"field_resolutions\".\"selected_observation_id\" is null\n      )"
+        },
+        "field_resolutions_nonempty_ck": {
+          "name": "field_resolutions_nonempty_ck",
+          "value": "length(trim(\"field_resolutions\".\"reason\")) > 0\n        and length(trim(\"field_resolutions\".\"actor_ref\")) > 0\n        and length(trim(\"field_resolutions\".\"resolver_version\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.languages": {
+      "name": "languages",
+      "schema": "",
+      "columns": {
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "languages_nonempty_ck": {
+          "name": "languages_nonempty_ck",
+          "value": "length(trim(\"languages\".\"tag\")) > 0 and length(trim(\"languages\".\"label\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.metadata_sources": {
+      "name": "metadata_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terms_url": {
+          "name": "terms_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution_url": {
+          "name": "attribution_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_state": {
+          "name": "approval_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata_policy": {
+          "name": "metadata_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_policy": {
+          "name": "asset_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_policy": {
+          "name": "payload_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_interval_ms": {
+          "name": "refresh_interval_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "metadata_sources_key_uq": {
+          "name": "metadata_sources_key_uq",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "metadata_sources_nonempty_ck": {
+          "name": "metadata_sources_nonempty_ck",
+          "value": "length(trim(\"metadata_sources\".\"key\")) > 0 and length(trim(\"metadata_sources\".\"name\")) > 0"
+        },
+        "metadata_sources_approval_state_ck": {
+          "name": "metadata_sources_approval_state_ck",
+          "value": "\"metadata_sources\".\"approval_state\" in ('pending', 'approved', 'suspended', 'retired')"
+        },
+        "metadata_sources_payload_policy_ck": {
+          "name": "metadata_sources_payload_policy_ck",
+          "value": "\"metadata_sources\".\"payload_policy\" in ('none', 'selected_fields', 'full')"
+        },
+        "metadata_sources_approved_review_ck": {
+          "name": "metadata_sources_approved_review_ck",
+          "value": "\"metadata_sources\".\"approval_state\" <> 'approved' or \"metadata_sources\".\"reviewed_at\" is not null"
+        },
+        "metadata_sources_refresh_ck": {
+          "name": "metadata_sources_refresh_ck",
+          "value": "\"metadata_sources\".\"refresh_interval_ms\" is null or \"metadata_sources\".\"refresh_interval_ms\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.publishers": {
+      "name": "publishers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "publishers_name_nonempty_ck": {
+          "name": "publishers_name_nonempty_ck",
+          "value": "length(trim(\"publishers\".\"display_name\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.source_record_links": {
+      "name": "source_record_links",
+      "schema": "",
+      "columns": {
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_kind": {
+          "name": "match_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mapping_confidence": {
+          "name": "mapping_confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "source_record_links_entity_idx": {
+          "name": "source_record_links_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_record_links_source_record_id_source_records_id_fk": {
+          "name": "source_record_links_source_record_id_source_records_id_fk",
+          "tableFrom": "source_record_links",
+          "tableTo": "source_records",
+          "columnsFrom": [
+            "source_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "source_record_links_pk": {
+          "name": "source_record_links_pk",
+          "columns": [
+            "source_record_id",
+            "entity_type",
+            "entity_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "source_record_links_entity_type_ck": {
+          "name": "source_record_links_entity_type_ck",
+          "value": "\"source_record_links\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset')"
+        },
+        "source_record_links_match_kind_ck": {
+          "name": "source_record_links_match_kind_ck",
+          "value": "\"source_record_links\".\"match_kind\" in ('exact_identifier', 'source_relationship', 'curated', 'candidate')"
+        },
+        "source_record_links_state_ck": {
+          "name": "source_record_links_state_ck",
+          "value": "\"source_record_links\".\"state\" in ('active', 'candidate', 'rejected')"
+        },
+        "source_record_links_confidence_ck": {
+          "name": "source_record_links_confidence_ck",
+          "value": "\"source_record_links\".\"mapping_confidence\" between 0 and 1"
+        },
+        "source_record_links_actor_ck": {
+          "name": "source_record_links_actor_ck",
+          "value": "(\n        \"source_record_links\".\"match_kind\" <> 'curated' and \"source_record_links\".\"state\" <> 'rejected'\n      ) or (\n        length(trim(\"source_record_links\".\"actor_ref\")) > 0 and length(trim(\"source_record_links\".\"reason\")) > 0\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.source_records": {
+      "name": "source_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_modified_at": {
+          "name": "source_modified_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retrieved_at": {
+          "name": "retrieved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "importer_version": {
+          "name": "importer_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_row_hash": {
+          "name": "source_row_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "source_records_source_key_uq": {
+          "name": "source_records_source_key_uq",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "record_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_records_refresh_idx": {
+          "name": "source_records_refresh_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "retrieved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_records_source_id_metadata_sources_id_fk": {
+          "name": "source_records_source_id_metadata_sources_id_fk",
+          "tableFrom": "source_records",
+          "tableTo": "metadata_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "source_records_key_nonempty_ck": {
+          "name": "source_records_key_nonempty_ck",
+          "value": "length(trim(\"source_records\".\"record_key\")) > 0"
+        },
+        "source_records_state_ck": {
+          "name": "source_records_state_ck",
+          "value": "\"source_records\".\"state\" in ('active', 'withdrawn', 'deleted')"
+        },
+        "source_records_import_hash_ck": {
+          "name": "source_records_import_hash_ck",
+          "value": "(\"source_records\".\"importer_version\" is null and \"source_records\".\"source_row_hash\" is null)\n        or (length(trim(\"source_records\".\"importer_version\")) > 0 and length(\"source_records\".\"source_row_hash\") = 64)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.work_authors": {
+      "name": "work_authors",
+      "schema": "",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'author'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "work_authors_position_uq": {
+          "name": "work_authors_position_uq",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_authors_owner_position_idx": {
+          "name": "work_authors_owner_position_idx",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_authors_author_work_idx": {
+          "name": "work_authors_author_work_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "work_authors_work_id_works_id_fk": {
+          "name": "work_authors_work_id_works_id_fk",
+          "tableFrom": "work_authors",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_authors_author_id_authors_id_fk": {
+          "name": "work_authors_author_id_authors_id_fk",
+          "tableFrom": "work_authors",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "work_authors_pk": {
+          "name": "work_authors_pk",
+          "columns": [
+            "work_id",
+            "author_id",
+            "role"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "work_authors_role_ck": {
+          "name": "work_authors_role_ck",
+          "value": "\"work_authors\".\"role\" in ('author', 'editor', 'translator', 'illustrator')"
+        },
+        "work_authors_position_ck": {
+          "name": "work_authors_position_ck",
+          "value": "\"work_authors\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.work_categories": {
+      "name": "work_categories",
+      "schema": "",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "work_categories_position_uq": {
+          "name": "work_categories_position_uq",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_categories_primary_uq": {
+          "name": "work_categories_primary_uq",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"work_categories\".\"is_primary\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_categories_owner_position_idx": {
+          "name": "work_categories_owner_position_idx",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_categories_category_work_idx": {
+          "name": "work_categories_category_work_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "work_categories_work_id_works_id_fk": {
+          "name": "work_categories_work_id_works_id_fk",
+          "tableFrom": "work_categories",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_categories_category_id_categories_id_fk": {
+          "name": "work_categories_category_id_categories_id_fk",
+          "tableFrom": "work_categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "work_categories_pk": {
+          "name": "work_categories_pk",
+          "columns": [
+            "work_id",
+            "category_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "work_categories_position_ck": {
+          "name": "work_categories_position_ck",
+          "value": "\"work_categories\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.works": {
+      "name": "works",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "preferred_title": {
+          "name": "preferred_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_title": {
+          "name": "sort_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_edition_id": {
+          "name": "preferred_edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "works_sort_title_id_idx": {
+          "name": "works_sort_title_id_idx",
+          "columns": [
+            {
+              "expression": "sort_title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "works_preferred_edition_idx": {
+          "name": "works_preferred_edition_idx",
+          "columns": [
+            {
+              "expression": "preferred_edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "works_preferred_edition_id_editions_id_fk": {
+          "name": "works_preferred_edition_id_editions_id_fk",
+          "tableFrom": "works",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "preferred_edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "works_titles_nonempty_ck": {
+          "name": "works_titles_nonempty_ck",
+          "value": "length(trim(\"works\".\"preferred_title\")) > 0 and length(trim(\"works\".\"sort_title\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/pg/meta/_journal.json
+++ b/drizzle/pg/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1785141862681,
       "tag": "0005_sour_pretty_boy",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1785159867531,
+      "tag": "0006_luxuriant_albert_cleary",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/CatalogFilters.test.tsx
+++ b/src/app/CatalogFilters.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CatalogFilters } from "./CatalogFilters";
+
+const { push } = vi.hoisted(() => ({ push: vi.fn() }));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+
+describe("CatalogFilters", () => {
+  beforeEach(() => push.mockReset());
+
+  it("renders labeled controls and active context", () => {
+    render(
+      <CatalogFilters
+        categories={[{ slug: "science-fiction", label: "Science Fiction" }]}
+        query={{
+          q: "dune",
+          category: "science-fiction",
+          period: "1950-1999",
+          sort: "publication",
+        }}
+      />,
+    );
+    expect(screen.getByLabelText("Category")).toHaveValue("science-fiction");
+    expect(screen.getByLabelText("Publication period")).toHaveValue(
+      "1950-1999",
+    );
+    expect(screen.getByLabelText("Sort by")).toHaveValue("publication");
+    expect(screen.getByText(/Active filters:/)).toHaveTextContent(
+      "Category: Science Fiction",
+    );
+  });
+
+  it("applies one canonical shareable URL", () => {
+    render(
+      <CatalogFilters
+        categories={[{ slug: "science-fiction", label: "Science Fiction" }]}
+        query={{ q: "the", sort: "title" }}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText("Category"), {
+      target: { value: "science-fiction" },
+    });
+    fireEvent.change(screen.getByLabelText("Publication period"), {
+      target: { value: "1950-1999" },
+    });
+    fireEvent.change(screen.getByLabelText("Sort by"), {
+      target: { value: "publication" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    expect(push).toHaveBeenCalledWith(
+      "/?q=the&category=science-fiction&period=1950-1999&sort=publication",
+    );
+  });
+});

--- a/src/app/CatalogFilters.tsx
+++ b/src/app/CatalogFilters.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import type { FormEvent } from "react";
+import {
+  CATALOG_SORTS,
+  type CatalogCategory,
+  type CatalogQuery,
+  catalogSortLabel,
+  DEFAULT_CATALOG_SORT,
+  hasCatalogFilters,
+  PUBLICATION_PERIODS,
+  parseCatalogQuery,
+  publicationPeriodLabel,
+  serializeCatalogQuery,
+} from "@/features/books/catalogQuery";
+
+type Props = {
+  categories: CatalogCategory[];
+  query: CatalogQuery;
+};
+
+export function CatalogFilters({ categories, query }: Props) {
+  const router = useRouter();
+  const categoryLabel =
+    categories.find((category) => category.slug === query.category)?.label ??
+    query.category;
+  const context = [
+    query.q ? `Search: “${query.q}”` : undefined,
+    categoryLabel ? `Category: ${categoryLabel}` : undefined,
+    query.period
+      ? `Published: ${publicationPeriodLabel(query.period)}`
+      : undefined,
+  ].filter((value): value is string => Boolean(value));
+
+  function apply(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const params = new URLSearchParams(
+      Array.from(new FormData(event.currentTarget).entries()).map(
+        ([name, value]) => [name, String(value)],
+      ),
+    );
+    const canonical = serializeCatalogQuery(parseCatalogQuery(params));
+    router.push(canonical.size > 0 ? `/?${canonical}` : "/");
+  }
+
+  return (
+    <div className="mt-[var(--spacing-2)] w-full max-w-[960px]">
+      <form
+        action="/"
+        method="get"
+        aria-label="Filter and sort catalog"
+        className="grid grid-cols-1 gap-[var(--spacing-1)] rounded-[var(--radius-lg)] border border-[color:var(--color-outline)] bg-[var(--color-surface)] p-[var(--spacing-2)] text-left shadow-[var(--elevation-0)] sm:grid-cols-2 lg:grid-cols-[1fr_1fr_1fr_auto_auto]"
+        onSubmit={apply}
+      >
+        {query.q ? <input type="hidden" name="q" value={query.q} /> : null}
+        <label className="flex min-w-0 flex-col gap-[var(--spacing-0-5)] text-[var(--type-sm)] font-medium">
+          Category
+          <select
+            className="min-h-11 rounded-[var(--radius-sm)] border border-[color:var(--color-outline)] bg-[var(--color-background)] px-[var(--spacing-1)] text-[var(--color-on-background)] focus-visible:border-[color:var(--color-primary)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--color-primary)]"
+            defaultValue={query.category ?? ""}
+            name="category"
+          >
+            <option value="">All categories</option>
+            {categories.map((category) => (
+              <option value={category.slug} key={category.slug}>
+                {category.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex min-w-0 flex-col gap-[var(--spacing-0-5)] text-[var(--type-sm)] font-medium">
+          Publication period
+          <select
+            className="min-h-11 rounded-[var(--radius-sm)] border border-[color:var(--color-outline)] bg-[var(--color-background)] px-[var(--spacing-1)] text-[var(--color-on-background)] focus-visible:border-[color:var(--color-primary)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--color-primary)]"
+            defaultValue={query.period ?? ""}
+            name="period"
+          >
+            <option value="">Any publication date</option>
+            {PUBLICATION_PERIODS.map((period) => (
+              <option value={period.value} key={period.value}>
+                {period.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex min-w-0 flex-col gap-[var(--spacing-0-5)] text-[var(--type-sm)] font-medium">
+          Sort by
+          <select
+            className="min-h-11 rounded-[var(--radius-sm)] border border-[color:var(--color-outline)] bg-[var(--color-background)] px-[var(--spacing-1)] text-[var(--color-on-background)] focus-visible:border-[color:var(--color-primary)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--color-primary)]"
+            defaultValue={query.sort}
+            name="sort"
+          >
+            {CATALOG_SORTS.map((sort) => (
+              <option value={sort} key={sort}>
+                {catalogSortLabel(sort)}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button
+          type="submit"
+          className="min-h-11 self-end rounded-[var(--radius-sm)] bg-[var(--color-primary)] px-[var(--spacing-2)] font-semibold text-[var(--color-on-primary)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--color-primary)]"
+        >
+          Apply
+        </button>
+        {hasCatalogFilters(query) || query.sort !== DEFAULT_CATALOG_SORT ? (
+          <Link
+            href="/"
+            prefetch={false}
+            className="inline-flex min-h-11 items-center justify-center self-end rounded-[var(--radius-sm)] px-[var(--spacing-1)] text-[var(--color-primary)] underline-offset-4 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--color-primary)]"
+          >
+            Reset all
+          </Link>
+        ) : null}
+      </form>
+      <p
+        className="mb-0 mt-[var(--spacing-1)] text-[var(--type-sm)] text-[var(--color-on-surface)]"
+        aria-live="polite"
+      >
+        {hasCatalogFilters(query)
+          ? `Active filters: ${context.join(" · ")}. ${catalogSortLabel(query.sort)}.`
+          : `No active filters. ${catalogSortLabel(query.sort)}.`}
+      </p>
+    </div>
+  );
+}

--- a/src/app/SearchForm.test.tsx
+++ b/src/app/SearchForm.test.tsx
@@ -1,8 +1,15 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SearchForm } from "./SearchForm";
 
+const { push } = vi.hoisted(() => ({ push: vi.fn() }));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+
 describe("SearchForm edge cases", () => {
+  beforeEach(() => push.mockReset());
+
   it("renders with defaultValue", () => {
     render(<SearchForm defaultValue="dune" />);
     expect(screen.getByRole("searchbox")).toHaveValue("dune");
@@ -16,5 +23,25 @@ describe("SearchForm edge cases", () => {
   it("does not show clear link when defaultValue is empty", () => {
     render(<SearchForm defaultValue="" />);
     expect(screen.queryByRole("link", { name: /clear/i })).toBeNull();
+  });
+
+  it("preserves filters and serializes a new search canonically", () => {
+    render(
+      <SearchForm
+        defaultValue=""
+        query={{
+          category: "science-fiction",
+          period: "1950-1999",
+          sort: "publication",
+        }}
+      />,
+    );
+    fireEvent.change(screen.getByRole("searchbox"), {
+      target: { value: "  dune  " },
+    });
+    fireEvent.submit(screen.getByRole("form", { name: "Search books" }));
+    expect(push).toHaveBeenCalledWith(
+      "/?q=dune&category=science-fiction&period=1950-1999&sort=publication",
+    );
   });
 });

--- a/src/app/SearchForm.tsx
+++ b/src/app/SearchForm.tsx
@@ -1,11 +1,18 @@
 "use client";
 
 import Link from "next/link";
-import { useId } from "react";
+import { useRouter } from "next/navigation";
+import { type FormEvent, useId } from "react";
+import {
+  type CatalogQuery,
+  parseCatalogQuery,
+  serializeCatalogQuery,
+} from "@/features/books/catalogQuery";
 import { pageStyles as s } from "./pageStyles";
 
 type Props = {
   defaultValue?: string;
+  query?: CatalogQuery;
 };
 
 /**
@@ -13,13 +20,40 @@ type Props = {
  * - Clicking anywhere inside the search box focuses the input.
  * - Icon is decorative and doesn't steal focus.
  */
-export function SearchForm({ defaultValue = "" }: Props) {
+export function SearchForm({ defaultValue = "", query }: Props) {
   const id = useId();
+  const router = useRouter();
+  const activeQuery = query ?? { q: defaultValue || undefined, sort: "title" };
+  const retainedParams = serializeCatalogQuery({
+    ...activeQuery,
+    q: undefined,
+  });
+  const clearParams = serializeCatalogQuery({
+    ...activeQuery,
+    q: undefined,
+  });
+
+  function search(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const params = new URLSearchParams(retainedParams);
+    const data = new FormData(event.currentTarget);
+    params.set("q", String(data.get("q") ?? ""));
+    const canonical = serializeCatalogQuery(parseCatalogQuery(params));
+    router.push(canonical.size > 0 ? `/?${canonical}` : "/");
+  }
 
   return (
     <div className={s.searchRow}>
       <div className={s.searchBox}>
-        <form method="get" aria-label="Search books" className={s.form}>
+        <form
+          method="get"
+          aria-label="Search books"
+          className={s.form}
+          onSubmit={search}
+        >
+          {Array.from(retainedParams.entries()).map(([name, value]) => (
+            <input type="hidden" name={name} value={value} key={name} />
+          ))}
           <label htmlFor={id} className={s.labelWrap}>
             <span className={s.srOnly}>Search books</span>
             <svg
@@ -47,7 +81,11 @@ export function SearchForm({ defaultValue = "" }: Props) {
         </form>
       </div>
       {defaultValue ? (
-        <Link href="/" className={s.clearLink} prefetch={false}>
+        <Link
+          href={clearParams.size > 0 ? `/?${clearParams}` : "/"}
+          className={s.clearLink}
+          prefetch={false}
+        >
           Clear
         </Link>
       ) : null}

--- a/src/app/api/books/page/route.test.ts
+++ b/src/app/api/books/page/route.test.ts
@@ -12,6 +12,7 @@ describe("GET /api/books/page", () => {
       items: [workSummaryFixture],
       hasNext: true,
       nextCursor: "next",
+      total: 30,
     });
     const response = await GET(
       new Request("https://test/api/books/page?q=work&after=cursor&limit=10"),
@@ -20,9 +21,15 @@ describe("GET /api/books/page", () => {
       items: [workSummaryFixture],
       hasNext: true,
       nextCursor: "next",
+      total: 30,
     });
     expect(page).toHaveBeenCalledWith({
-      q: "work",
+      query: {
+        q: "work",
+        category: undefined,
+        period: undefined,
+        sort: "title",
+      },
       after: "cursor",
       limit: 10,
     });
@@ -32,10 +39,16 @@ describe("GET /api/books/page", () => {
     const page = vi.spyOn(repo, "getWorksPage").mockResolvedValue({
       items: [],
       hasNext: false,
+      total: 0,
     });
     await GET(new Request("https://test/api/books/page?limit=5000"));
     expect(page).toHaveBeenCalledWith({
-      q: undefined,
+      query: {
+        q: undefined,
+        category: undefined,
+        period: undefined,
+        sort: "title",
+      },
       after: undefined,
       limit: 50,
     });
@@ -45,10 +58,39 @@ describe("GET /api/books/page", () => {
     const page = vi.spyOn(repo, "getWorksPage").mockResolvedValue({
       items: [],
       hasNext: false,
+      total: 0,
     });
     await GET(new Request("https://test/api/books/page?limit=invalid"));
     expect(page).toHaveBeenCalledWith({
-      q: undefined,
+      query: {
+        q: undefined,
+        category: undefined,
+        period: undefined,
+        sort: "title",
+      },
+      after: undefined,
+      limit: DEFAULT_BOOKS_PAGE_SIZE,
+    });
+  });
+
+  it("forwards the canonical combined filter and sort model", async () => {
+    const page = vi.spyOn(repo, "getWorksPage").mockResolvedValue({
+      items: [],
+      hasNext: false,
+      total: 0,
+    });
+    await GET(
+      new Request(
+        "https://test/api/books/page?q=glass&category=fantasy&period=2000-2009&sort=publication",
+      ),
+    );
+    expect(page).toHaveBeenCalledWith({
+      query: {
+        q: "glass",
+        category: "fantasy",
+        period: "2000-2009",
+        sort: "publication",
+      },
       after: undefined,
       limit: DEFAULT_BOOKS_PAGE_SIZE,
     });

--- a/src/app/api/books/page/route.ts
+++ b/src/app/api/books/page/route.ts
@@ -1,18 +1,19 @@
 import { NextResponse } from "next/server";
+import { parseCatalogQuery } from "@/features/books/catalogQuery";
 import { DEFAULT_BOOKS_PAGE_SIZE } from "@/features/books/pageSize";
 import { getWorksPage } from "@/features/books/repo";
 
 export async function GET(request: Request) {
   try {
     const url = new URL(request.url);
-    const q = url.searchParams.get("q") ?? undefined;
+    const query = parseCatalogQuery(url.searchParams);
     const after = url.searchParams.get("after") ?? undefined;
     const limitRaw = url.searchParams.get("limit");
     const parsedLimit = limitRaw ? Number(limitRaw) : Number.NaN;
     const limit = Number.isFinite(parsedLimit)
       ? Math.max(1, Math.min(50, Math.trunc(parsedLimit)))
       : DEFAULT_BOOKS_PAGE_SIZE;
-    const page = await getWorksPage({ q, after, limit });
+    const page = await getWorksPage({ query, after, limit });
     return NextResponse.json(page);
   } catch (err) {
     // eslint-disable-next-line no-console

--- a/src/app/api/books/route.test.ts
+++ b/src/app/api/books/route.test.ts
@@ -13,13 +13,33 @@ describe("GET /api/books", () => {
     const response = await GET(new Request("https://test/api/books?q=author"));
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual([workSummaryFixture]);
-    expect(list).toHaveBeenCalledWith("author");
+    expect(list).toHaveBeenCalledWith({
+      q: "author",
+      category: undefined,
+      period: undefined,
+      sort: "title",
+    });
   });
 
   it("returns 500 when the repository fails", async () => {
     vi.spyOn(repo, "getWorks").mockRejectedValue(new Error("failed"));
     const response = await GET(new Request("https://test/api/books"));
     expect(response.status).toBe(500);
+  });
+
+  it("uses the canonical filter and sort model", async () => {
+    const list = vi.spyOn(repo, "getWorks").mockResolvedValue([]);
+    await GET(
+      new Request(
+        "https://test/api/books?category=science-fiction&period=1950-1999&sort=publication",
+      ),
+    );
+    expect(list).toHaveBeenCalledWith({
+      q: undefined,
+      category: "science-fiction",
+      period: "1950-1999",
+      sort: "publication",
+    });
   });
 
   it("advertises read-only methods", async () => {

--- a/src/app/api/books/route.ts
+++ b/src/app/api/books/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse } from "next/server";
+import { parseCatalogQuery } from "@/features/books/catalogQuery";
 import { getWorks } from "@/features/books/repo";
 
 export async function GET(request: Request) {
   try {
-    const query = new URL(request.url).searchParams.get("q") ?? undefined;
+    const query = parseCatalogQuery(new URL(request.url).searchParams);
     return NextResponse.json(await getWorks(query));
   } catch (error) {
     console.error("[/api/books] GET failed", error);

--- a/src/app/components/BooksCount.tsx
+++ b/src/app/components/BooksCount.tsx
@@ -3,12 +3,23 @@ import { pageStyles as s } from "../pageStyles";
 interface BooksCountProps {
   count: number;
   mode?: "found" | "shown";
+  total?: number;
 }
 
 export const BooksCount: React.FC<BooksCountProps> = ({
   count,
   mode = "found",
+  total,
 }) => {
+  if (mode === "shown" && total !== undefined) {
+    const noun = total === 1 ? "book" : "books";
+    return (
+      <div className={s.booksCount}>
+        {count} of {total} {noun} shown
+      </div>
+    );
+  }
+
   const noun = count === 1 ? "book" : "books";
 
   return (

--- a/src/app/helpers/pageParams.test.ts
+++ b/src/app/helpers/pageParams.test.ts
@@ -1,21 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { normalizeAfter, normalizeQ } from "./pageParams";
+import { normalizeAfter } from "./pageParams";
 
 describe("pageParams helpers", () => {
-  it("normalizeQ returns first element when array with value", () => {
-    expect(normalizeQ(["a"])).toBe("a");
-  });
-
-  it("normalizeQ returns empty string when array empty or element undefined", () => {
-    expect(normalizeQ([])).toBe("");
-    expect(normalizeQ([undefined as unknown as string])).toBe("");
-  });
-
-  it("normalizeQ returns raw value or empty when undefined", () => {
-    expect(normalizeQ("x")).toBe("x");
-    expect(normalizeQ(undefined)).toBe("");
-  });
-
   it("normalizeAfter returns first element or undefined for empty/undefined", () => {
     expect(normalizeAfter(["cursor-1"])).toBe("cursor-1");
     expect(normalizeAfter([])).toBeUndefined();

--- a/src/app/helpers/pageParams.ts
+++ b/src/app/helpers/pageParams.ts
@@ -1,8 +1,3 @@
-export function normalizeQ(rawQ: string | string[] | undefined): string {
-  if (Array.isArray(rawQ)) return rawQ[0] ?? "";
-  return rawQ ?? "";
-}
-
 export function normalizeAfter(
   rawAfter: string | string[] | undefined,
 ): string | undefined {

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -5,14 +5,22 @@ import * as repo from "@/features/books/repo";
 import { workSummaryFixture } from "@/test/catalog-fixtures";
 import Page from "./page";
 
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
 describe("homepage", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     vi.spyOn(repo, "getWorksPage").mockResolvedValue({
       items: [workSummaryFixture],
       hasNext: false,
+      total: 1,
     });
     vi.spyOn(repo, "getNewArrivals").mockResolvedValue([workSummaryFixture]);
+    vi.spyOn(repo, "getCatalogCategories").mockResolvedValue([
+      { slug: "fiction", label: "Fiction" },
+    ]);
   });
 
   it("renders the honest supported catalog sections", async () => {
@@ -42,13 +50,41 @@ describe("homepage", () => {
     const page = vi.spyOn(repo, "getWorksPage");
     render(await Page({ searchParams: Promise.resolve({ q: "example" }) }));
     expect(
-      screen.getByText(/Showing results for "example"/),
+      screen.getByText(/Active filters: Search: “example”/),
     ).toBeInTheDocument();
     expect(page).toHaveBeenCalledWith({
-      q: "example",
+      query: {
+        q: "example",
+        category: undefined,
+        period: undefined,
+        sort: "title",
+      },
       after: undefined,
       limit: 24,
     });
+  });
+
+  it("renders canonical active-filter context and zero-result recovery", async () => {
+    vi.spyOn(repo, "getWorksPage").mockResolvedValue({
+      items: [],
+      hasNext: false,
+      total: 0,
+    });
+    render(
+      await Page({
+        searchParams: Promise.resolve({
+          category: "fiction",
+          period: "2000-2009",
+          sort: "publication",
+        }),
+      }),
+    );
+    expect(
+      screen.getByText(/Active filters: Category: Fiction/),
+    ).toHaveTextContent("Published: 2000–2009");
+    expect(
+      screen.getByRole("link", { name: "Reset all filters" }),
+    ).toHaveAttribute("href", "/");
   });
 
   it("renders an error state when catalog reads fail", async () => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,10 +4,10 @@ import Clock from "lucide-react/dist/esm/icons/clock.js";
 import { Container } from "@/design/layout/grid";
 import { BookList } from "@/features/books/BookList";
 import {
+  catalogQueryKey,
   DEFAULT_CATALOG_SORT,
   hasCatalogFilters,
   parseCatalogQuery,
-  serializeCatalogQuery,
 } from "@/features/books/catalogQuery";
 import { PaginatedBooks } from "@/features/books/PaginatedBooks.client";
 import { DEFAULT_BOOKS_PAGE_SIZE } from "@/features/books/pageSize";
@@ -51,7 +51,7 @@ export default async function Page({
         getCatalogCategories(),
         section === "new" ? getNewArrivals(20) : undefined,
       ]);
-    const queryKey = serializeCatalogQuery(query).toString();
+    const queryKey = catalogQueryKey(query);
 
     return (
       <main>
@@ -62,8 +62,16 @@ export default async function Page({
               <p className={s.subtitle}>
                 Browse a curated catalog and search by title or author
               </p>
-              <SearchForm defaultValue={query.q} query={query} />
-              <CatalogFilters categories={categories} query={query} />
+              <SearchForm
+                key={`search-${queryKey}`}
+                defaultValue={query.q}
+                query={query}
+              />
+              <CatalogFilters
+                key={`filters-${queryKey}`}
+                categories={categories}
+                query={query}
+              />
             </header>
           </Container>
         </section>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,12 +3,23 @@ export const dynamic = "force-dynamic";
 import Clock from "lucide-react/dist/esm/icons/clock.js";
 import { Container } from "@/design/layout/grid";
 import { BookList } from "@/features/books/BookList";
+import {
+  DEFAULT_CATALOG_SORT,
+  hasCatalogFilters,
+  parseCatalogQuery,
+  serializeCatalogQuery,
+} from "@/features/books/catalogQuery";
 import { PaginatedBooks } from "@/features/books/PaginatedBooks.client";
 import { DEFAULT_BOOKS_PAGE_SIZE } from "@/features/books/pageSize";
-import { getNewArrivals, getWorksPage } from "@/features/books/repo";
+import {
+  getCatalogCategories,
+  getNewArrivals,
+  getWorksPage,
+} from "@/features/books/repo";
+import { CatalogFilters } from "./CatalogFilters";
 import { BooksCount } from "./components/BooksCount";
 import { SectionHeader } from "./components/SectionHeader";
-import { normalizeAfter, normalizeQ } from "./helpers/pageParams";
+import { normalizeAfter } from "./helpers/pageParams";
 import { pageStyles as s } from "./pageStyles";
 import { SearchForm } from "./SearchForm";
 
@@ -21,19 +32,26 @@ export default async function Page({
 }) {
   try {
     const resolved = await searchParams;
-    const q = normalizeQ(resolved?.q);
+    const query = parseCatalogQuery(resolved);
     const rawSection = resolved?.section;
     const requestedSection =
       (Array.isArray(rawSection) ? rawSection[0] : rawSection) ?? "all";
-    const section = requestedSection === "new" ? "new" : "all";
+    const queryIsActive =
+      hasCatalogFilters(query) || query.sort !== DEFAULT_CATALOG_SORT;
+    const section =
+      requestedSection === "new" && !queryIsActive ? "new" : "all";
     const after = normalizeAfter(resolved?.after);
-    const { items, nextCursor } = await getWorksPage({
-      q,
-      after,
-      limit: DEFAULT_BOOKS_PAGE_SIZE,
-    });
-    const sectionItems =
-      !q && section === "new" ? await getNewArrivals(20) : undefined;
+    const [{ items, nextCursor, total }, categories, sectionItems] =
+      await Promise.all([
+        getWorksPage({
+          query,
+          after,
+          limit: DEFAULT_BOOKS_PAGE_SIZE,
+        }),
+        getCatalogCategories(),
+        section === "new" ? getNewArrivals(20) : undefined,
+      ]);
+    const queryKey = serializeCatalogQuery(query).toString();
 
     return (
       <main>
@@ -44,16 +62,14 @@ export default async function Page({
               <p className={s.subtitle}>
                 Browse a curated catalog and search by title or author
               </p>
-              <SearchForm defaultValue={q} />
-              {q ? (
-                <p className={s.searchMeta}>Showing results for "{q}"</p>
-              ) : null}
+              <SearchForm defaultValue={query.q} query={query} />
+              <CatalogFilters categories={categories} query={query} />
             </header>
           </Container>
         </section>
 
-        {!q ? (
-          <section className={s.contentSurface}>
+        <section className={s.contentSurface}>
+          {!queryIsActive ? (
             <Container>
               <nav aria-label="Sections" className={s.sectionsNav}>
                 <ul className={s.tabsList}>
@@ -78,44 +94,45 @@ export default async function Page({
                 </ul>
               </nav>
             </Container>
+          ) : null}
 
-            <div className={s.sectionDivider} />
+          {!queryIsActive ? <div className={s.sectionDivider} /> : null}
 
-            {sectionItems ? (
-              <>
-                <Container>
-                  <SectionHeader
-                    icon={
-                      <Clock
-                        className={s.sectionHeaderIcon}
-                        width={20}
-                        height={20}
-                        aria-hidden
-                      />
-                    }
-                    title="New Arrivals"
-                  />
-                  <BooksCount count={sectionItems.length} />
-                </Container>
-                <BookList works={sectionItems} spacing="dense" />
-              </>
-            ) : null}
-
-            {section === "all" && (items.length > 0 || nextCursor) ? (
-              <PaginatedBooks
-                initial={items}
-                initialNextCursor={nextCursor}
-                title="All Books"
-              />
-            ) : null}
-          </section>
-        ) : (
-          <PaginatedBooks
-            initial={items}
-            initialNextCursor={nextCursor}
-            q={q}
-          />
-        )}
+          {sectionItems ? (
+            <>
+              <Container>
+                <SectionHeader
+                  icon={
+                    <Clock
+                      className={s.sectionHeaderIcon}
+                      width={20}
+                      height={20}
+                      aria-hidden
+                    />
+                  }
+                  title="New Arrivals"
+                />
+                <BooksCount count={sectionItems.length} />
+              </Container>
+              <BookList works={sectionItems} spacing="dense" />
+            </>
+          ) : (
+            <PaginatedBooks
+              key={queryKey}
+              initial={items}
+              initialNextCursor={nextCursor}
+              query={query}
+              total={total}
+              title={
+                query.q
+                  ? "Search Results"
+                  : hasCatalogFilters(query)
+                    ? "Filtered Books"
+                    : "All Books"
+              }
+            />
+          )}
+        </section>
       </main>
     );
   } catch (error) {

--- a/src/db/catalog/postgres-rebuild.test.ts
+++ b/src/db/catalog/postgres-rebuild.test.ts
@@ -130,6 +130,23 @@ describe.skipIf(!isolatedUrl)("Postgres normalized catalog rebuild", () => {
       expect(invalidCursorPage.items.map((work) => work.id)).toEqual(
         byPublication.slice(0, 7).map((work) => work.id),
       );
+
+      const sourceFilterPage = await repository.pageWorkSummaries({
+        query: { category: "science-fiction", sort: "title" },
+        limit: 50,
+      });
+      const expectedFantasyPage = await repository.pageWorkSummaries({
+        query: { category: "fantasy", sort: "title" },
+        limit: 7,
+      });
+      const mismatchedFilterPage = await repository.pageWorkSummaries({
+        query: { category: "fantasy", sort: "title" },
+        after: sourceFilterPage.nextCursor,
+        limit: 7,
+      });
+      expect(mismatchedFilterPage.items.map((work) => work.id)).toEqual(
+        expectedFantasyPage.items.map((work) => work.id),
+      );
     } finally {
       await client.end({ timeout: 5_000 });
     }

--- a/src/db/catalog/postgres-rebuild.test.ts
+++ b/src/db/catalog/postgres-rebuild.test.ts
@@ -60,13 +60,20 @@ describe.skipIf(!isolatedUrl)("Postgres normalized catalog rebuild", () => {
         },
       };
       const repository = createCatalogRepository(executor);
-      const dune = await repository.listWorkSummaries("Dune");
+      const dune = await repository.listWorkSummaries({
+        q: "Dune",
+        sort: "title",
+      });
       expect(dune.length).toBeGreaterThan(0);
       const detail = await repository.getWorkDetail(dune[0].id);
       expect(detail?.id).toBe(dune[0].id);
       expect(JSON.stringify(detail)).not.toMatch(/rating|trending/i);
-      const firstPage = await repository.pageWorkSummaries({ limit: 7 });
+      const firstPage = await repository.pageWorkSummaries({
+        query: { sort: "title" },
+        limit: 7,
+      });
       const secondPage = await repository.pageWorkSummaries({
+        query: { sort: "title" },
         limit: 7,
         after: firstPage.nextCursor,
       });
@@ -75,6 +82,54 @@ describe.skipIf(!isolatedUrl)("Postgres normalized catalog rebuild", () => {
           [...firstPage.items, ...secondPage.items].map((work) => work.id),
         ).size,
       ).toBe(14);
+
+      const combined = await repository.pageWorkSummaries({
+        query: {
+          q: "Dune",
+          category: "science-fiction",
+          period: "1950-1999",
+          sort: "publication",
+        },
+        limit: 10,
+      });
+      expect(combined.items.map((work) => work.title)).toContain("Dune");
+
+      for (const sort of ["title", "added", "publication"] as const) {
+        const expected = await repository.listWorkSummaries({ sort });
+        const actual: string[] = [];
+        let after: string | undefined;
+        do {
+          const page = await repository.pageWorkSummaries({
+            query: { sort },
+            after,
+            limit: 37,
+          });
+          actual.push(...page.items.map((work) => work.id));
+          after = page.nextCursor;
+        } while (after);
+        expect(actual).toEqual(expected.map((work) => work.id));
+      }
+
+      const byPublication = await repository.listWorkSummaries({
+        sort: "publication",
+      });
+      const firstMissing = byPublication.findIndex(
+        (work) => !work.preferredEdition?.publication,
+      );
+      expect(firstMissing).toBeGreaterThan(0);
+      expect(
+        byPublication
+          .slice(firstMissing)
+          .every((work) => !work.preferredEdition?.publication),
+      ).toBe(true);
+      const invalidCursorPage = await repository.pageWorkSummaries({
+        query: { sort: "publication" },
+        after: "invalid",
+        limit: 7,
+      });
+      expect(invalidCursorPage.items.map((work) => work.id)).toEqual(
+        byPublication.slice(0, 7).map((work) => work.id),
+      );
     } finally {
       await client.end({ timeout: 5_000 });
     }

--- a/src/db/catalog/repository.test.ts
+++ b/src/db/catalog/repository.test.ts
@@ -3,6 +3,8 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import type Database from "better-sqlite3";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { CatalogQuery, CatalogSort } from "@/features/books/catalogQuery";
+import { encodeCursor } from "@/features/books/pagination";
 import { ADR_REPRESENTATIVE_RECORDS } from "./fixtures";
 import { buildCatalogImportGraph } from "./importer";
 import {
@@ -41,9 +43,18 @@ describe("normalized catalog repository", () => {
     rmSync(directory, { recursive: true, force: true });
   });
 
+  const query = (overrides: Partial<CatalogQuery> = {}): CatalogQuery => ({
+    sort: "title",
+    ...overrides,
+  });
+
   it("pages by stable sort title and work ID without duplicates", async () => {
-    const first = await repository.pageWorkSummaries({ limit: 5 });
+    const first = await repository.pageWorkSummaries({
+      query: query(),
+      limit: 5,
+    });
     const second = await repository.pageWorkSummaries({
+      query: query(),
       limit: 5,
       after: first.nextCursor,
     });
@@ -60,8 +71,12 @@ describe("normalized catalog repository", () => {
   });
 
   it("searches selected titles and ordered author names", async () => {
-    const byTitle = await repository.listWorkSummaries("Glass Harbors");
-    const byAuthor = await repository.listWorkSummaries("Tomas Grey");
+    const byTitle = await repository.listWorkSummaries(
+      query({ q: "Glass Harbors" }),
+    );
+    const byAuthor = await repository.listWorkSummaries(
+      query({ q: "Tomas Grey" }),
+    );
     expect(byTitle).toHaveLength(1);
     expect(byAuthor.map((work) => work.id)).toEqual(
       byTitle.map((work) => work.id),
@@ -69,7 +84,9 @@ describe("normalized catalog repository", () => {
   });
 
   it("projects work details with preferred/all editions and ordered relations", async () => {
-    const [summary] = await repository.listWorkSummaries("Glass Harbors");
+    const [summary] = await repository.listWorkSummaries(
+      query({ q: "Glass Harbors" }),
+    );
     const detail = await repository.getWorkDetail(summary.id);
     expect(detail?.authors.map((author) => author.name)).toEqual([
       "Tomas Grey",
@@ -85,7 +102,9 @@ describe("normalized catalog repository", () => {
   });
 
   it("keeps missing metadata absent and never projects rating/popularity fields", async () => {
-    const [summary] = await repository.listWorkSummaries("Empty Colophon");
+    const [summary] = await repository.listWorkSummaries(
+      query({ q: "Empty Colophon" }),
+    );
     const detail = await repository.getWorkDetail(summary.id);
     expect(detail?.authors).toEqual([]);
     expect(detail?.preferredEdition?.identifiers).toEqual([]);
@@ -97,5 +116,148 @@ describe("normalized catalog repository", () => {
     const first = await repository.listNewArrivals(4);
     const second = await repository.listNewArrivals(4);
     expect(second.map((work) => work.id)).toEqual(first.map((work) => work.id));
+  });
+
+  it("lists active normalized category slugs deterministically", async () => {
+    const categories = await repository.listCategories();
+    expect(categories).toContainEqual({
+      slug: "science-fiction",
+      label: "Science Fiction",
+    });
+    expect(categories.map((category) => category.label)).toEqual(
+      [...categories.map((category) => category.label)].sort((left, right) =>
+        left.localeCompare(right),
+      ),
+    );
+  });
+
+  it("combines title/author search, normalized category, and publication period", async () => {
+    const result = await repository.pageWorkSummaries({
+      query: query({
+        q: "June",
+        category: "classics",
+        period: "1950-1999",
+        sort: "publication",
+      }),
+      limit: 10,
+    });
+    expect(result.items.map((work) => work.title)).toEqual(["June, Precisely"]);
+    expect(result.total).toBe(1);
+  });
+
+  it("orders every supported sort deterministically", async () => {
+    const byTitle = await repository.listWorkSummaries(query());
+    expect(byTitle.map((work) => work.title)).toEqual(
+      [...byTitle.map((work) => work.title)].sort((left, right) =>
+        left.localeCompare(right),
+      ),
+    );
+
+    const byAddition = await repository.listWorkSummaries(
+      query({ sort: "added" }),
+    );
+    const additionKeys = byAddition.map(
+      (work) =>
+        [
+          work.preferredEdition?.catalogedAt ?? Number.NEGATIVE_INFINITY,
+          work.id,
+        ] as const,
+    );
+    expect(additionKeys).toEqual(
+      [...additionKeys].sort(
+        (left, right) => right[0] - left[0] || left[1].localeCompare(right[1]),
+      ),
+    );
+
+    const byPublication = await repository.listWorkSummaries(
+      query({ sort: "publication" }),
+    );
+    const publicationDates = byPublication
+      .map((work) => work.preferredEdition?.publication?.date)
+      .filter((date): date is string => Boolean(date));
+    expect(publicationDates).toEqual(
+      [...publicationDates].sort((left, right) => right.localeCompare(left)),
+    );
+    const firstMissing = byPublication.findIndex(
+      (work) => !work.preferredEdition?.publication,
+    );
+    expect(
+      byPublication
+        .slice(firstMissing)
+        .every((work) => !work.preferredEdition?.publication),
+    ).toBe(true);
+  });
+
+  it.each<CatalogSort>([
+    "title",
+    "added",
+    "publication",
+  ])("keeps %s cursors stable without skips or duplicates", async (sort) => {
+    const activeQuery = query({ sort });
+    const expected = await repository.listWorkSummaries(activeQuery);
+    const actual: string[] = [];
+    let after: string | undefined;
+    do {
+      const page = await repository.pageWorkSummaries({
+        query: activeQuery,
+        after,
+        limit: 4,
+      });
+      actual.push(...page.items.map((work) => work.id));
+      after = page.nextCursor;
+    } while (after);
+    expect(actual).toEqual(expected.map((work) => work.id));
+    expect(new Set(actual).size).toBe(actual.length);
+  });
+
+  it("restarts safely for malformed or sort-mismatched cursors", async () => {
+    const activeQuery = query({ sort: "publication" });
+    const expected = await repository.pageWorkSummaries({
+      query: activeQuery,
+      limit: 3,
+    });
+    const mismatched = encodeCursor({
+      version: 1,
+      sort: "title",
+      sortTitle: "zzzz",
+      id: "work-id",
+    });
+    for (const after of ["invalid", mismatched]) {
+      const result = await repository.pageWorkSummaries({
+        query: activeQuery,
+        after,
+        limit: 3,
+      });
+      expect(result.items.map((work) => work.id)).toEqual(
+        expected.items.map((work) => work.id),
+      );
+    }
+  });
+
+  it("treats special search input literally and invalid categories as empty results", async () => {
+    await expect(
+      repository.listWorkSummaries(query({ q: "%" })),
+    ).resolves.toEqual([]);
+    await expect(
+      repository.listWorkSummaries(query({ category: "../invalid" })),
+    ).resolves.toEqual([]);
+  });
+
+  it("excludes missing publication metadata only when a period is active", async () => {
+    const allByPublication = await repository.listWorkSummaries(
+      query({ sort: "publication" }),
+    );
+    expect(
+      allByPublication.some((work) => work.title === "The Empty Colophon"),
+    ).toBe(true);
+    const period = await repository.listWorkSummaries(
+      query({ period: "1950-1999", sort: "publication" }),
+    );
+    expect(
+      period.every((work) => Boolean(work.preferredEdition?.publication)),
+    ).toBe(true);
+    expect(period.some((work) => work.title === "The Empty Colophon")).toBe(
+      false,
+    );
   });
 });

--- a/src/db/catalog/repository.test.ts
+++ b/src/db/catalog/repository.test.ts
@@ -217,7 +217,8 @@ describe("normalized catalog repository", () => {
       limit: 3,
     });
     const mismatched = encodeCursor({
-      version: 1,
+      version: 2,
+      queryKey: "",
       sort: "title",
       sortTitle: "zzzz",
       id: "work-id",
@@ -232,6 +233,25 @@ describe("normalized catalog repository", () => {
         expected.items.map((work) => work.id),
       );
     }
+  });
+
+  it("restarts safely when a cursor is reused with different filters and the same sort", async () => {
+    const source = await repository.pageWorkSummaries({
+      query: query({ category: "science-fiction" }),
+      limit: 1,
+    });
+    const expected = await repository.pageWorkSummaries({
+      query: query({ category: "fantasy" }),
+      limit: 2,
+    });
+    const result = await repository.pageWorkSummaries({
+      query: query({ category: "fantasy" }),
+      after: source.nextCursor,
+      limit: 2,
+    });
+    expect(result.items.map((work) => work.id)).toEqual(
+      expected.items.map((work) => work.id),
+    );
   });
 
   it("treats special search input literally and invalid categories as empty results", async () => {

--- a/src/db/catalog/repository.ts
+++ b/src/db/catalog/repository.ts
@@ -1,4 +1,9 @@
 import {
+  type CatalogCategory,
+  type CatalogQuery,
+  publicationPeriodBounds,
+} from "@/features/books/catalogQuery";
+import {
   decodeCursor,
   encodeCursor,
   type PageResult,
@@ -29,6 +34,8 @@ type WorkRow = {
   sortTitle: string;
   description: string | null;
   preferredEditionId: string | null;
+  publicationSortDate: string | null;
+  catalogedAt: number | string | Date | null;
 };
 
 type EditionRow = {
@@ -96,12 +103,13 @@ type CoverRow = {
 };
 
 export type CatalogRepository = {
-  listWorkSummaries(query?: string): Promise<WorkSummary[]>;
+  listWorkSummaries(query?: CatalogQuery): Promise<WorkSummary[]>;
   pageWorkSummaries(params: {
-    query?: string;
+    query: CatalogQuery;
     after?: string | null;
     limit: number;
   }): Promise<PageResult<WorkSummary>>;
+  listCategories(): Promise<CatalogCategory[]>;
   listNewArrivals(limit?: number): Promise<WorkSummary[]>;
   getWorkDetail(id: string): Promise<WorkDetail | undefined>;
 };
@@ -112,8 +120,11 @@ const WORK_COLUMNS = `
     w.preferred_title as "title",
     w.sort_title as "sortTitle",
     w.description as "description",
-    w.preferred_edition_id as "preferredEditionId"
+    w.preferred_edition_id as "preferredEditionId",
+    preferred.publication_sort_date as "publicationSortDate",
+    preferred.cataloged_at as "catalogedAt"
   from works w
+  left join editions preferred on preferred.id = w.preferred_edition_id
 `;
 
 function optional<T>(value: T | null): T | undefined {
@@ -161,52 +172,156 @@ export function createCatalogRepository(
   }
 
   async function selectWorkRows(params: {
-    query?: string;
-    cursor?: { sortTitle: string; id: string } | null;
+    query: CatalogQuery;
+    cursor?: ReturnType<typeof decodeCursor>;
     limit?: number;
   }): Promise<WorkRow[]> {
     const conditions: string[] = [];
     const values: unknown[] = [];
-    const search = params.query?.trim();
+    const search = params.query.q;
     if (search) {
+      const escapedSearch = search
+        .toLowerCase()
+        .replaceAll("\\", "\\\\")
+        .replaceAll("%", "\\%")
+        .replaceAll("_", "\\_");
       const titlePlaceholder = placeholder(values.length + 1);
-      values.push(`%${search.toLowerCase()}%`);
+      values.push(`%${escapedSearch}%`);
+      const titleEscapePlaceholder = placeholder(values.length + 1);
+      values.push("\\");
       const authorPlaceholder = placeholder(values.length + 1);
-      values.push(`%${search.toLowerCase()}%`);
+      values.push(`%${escapedSearch}%`);
+      const authorEscapePlaceholder = placeholder(values.length + 1);
+      values.push("\\");
       conditions.push(`(
-        lower(w.preferred_title) like ${titlePlaceholder}
+        lower(w.preferred_title) like ${titlePlaceholder} escape ${titleEscapePlaceholder}
         or exists (
           select 1
           from work_authors wa_search
           join authors a_search on a_search.id = wa_search.author_id
           where wa_search.work_id = w.id
-            and lower(a_search.display_name) like ${authorPlaceholder}
+            and lower(a_search.display_name) like ${authorPlaceholder} escape ${authorEscapePlaceholder}
         )
       )`);
     }
-    if (params.cursor) {
-      const greaterSortPlaceholder = placeholder(values.length + 1);
-      values.push(params.cursor.sortTitle);
-      const equalSortPlaceholder = placeholder(values.length + 1);
-      values.push(params.cursor.sortTitle);
-      const idPlaceholder = placeholder(values.length + 1);
-      values.push(params.cursor.id);
-      conditions.push(`(
-        w.sort_title > ${greaterSortPlaceholder}
-        or (w.sort_title = ${equalSortPlaceholder} and w.id > ${idPlaceholder})
+    if (params.query.category) {
+      const categoryPlaceholder = placeholder(values.length + 1);
+      values.push(params.query.category);
+      conditions.push(`exists (
+        select 1
+        from work_categories wc_filter
+        join categories c_filter on c_filter.id = wc_filter.category_id
+        where wc_filter.work_id = w.id
+          and c_filter.slug = ${categoryPlaceholder}
+          and c_filter.status = 'active'
       )`);
+    }
+    if (params.query.period) {
+      const bounds = publicationPeriodBounds(params.query.period);
+      if (bounds.from) {
+        const fromPlaceholder = placeholder(values.length + 1);
+        values.push(bounds.from);
+        conditions.push(
+          `preferred.publication_sort_date >= ${fromPlaceholder}`,
+        );
+      }
+      if (bounds.before) {
+        const beforePlaceholder = placeholder(values.length + 1);
+        values.push(bounds.before);
+        conditions.push(
+          `preferred.publication_sort_date < ${beforePlaceholder}`,
+        );
+      }
+    }
+    if (params.cursor) {
+      if (params.cursor.sort === "title") {
+        const greaterSortPlaceholder = placeholder(values.length + 1);
+        values.push(params.cursor.sortTitle);
+        const equalSortPlaceholder = placeholder(values.length + 1);
+        values.push(params.cursor.sortTitle);
+        const idPlaceholder = placeholder(values.length + 1);
+        values.push(params.cursor.id);
+        conditions.push(`(
+          w.sort_title > ${greaterSortPlaceholder}
+          or (
+            w.sort_title = ${equalSortPlaceholder}
+            and w.id > ${idPlaceholder}
+          )
+        )`);
+      } else if (params.cursor.sort === "added") {
+        if (params.cursor.catalogedAt === null) {
+          const idPlaceholder = placeholder(values.length + 1);
+          values.push(params.cursor.id);
+          conditions.push(`(
+            preferred.cataloged_at is null and w.id > ${idPlaceholder}
+          )`);
+        } else {
+          const cursorValue =
+            executor.dialect === "postgres"
+              ? new Date(params.cursor.catalogedAt)
+              : params.cursor.catalogedAt;
+          const lesserAddedPlaceholder = placeholder(values.length + 1);
+          values.push(cursorValue);
+          const equalAddedPlaceholder = placeholder(values.length + 1);
+          values.push(cursorValue);
+          const idPlaceholder = placeholder(values.length + 1);
+          values.push(params.cursor.id);
+          conditions.push(`(
+            preferred.cataloged_at < ${lesserAddedPlaceholder}
+            or preferred.cataloged_at is null
+            or (
+              preferred.cataloged_at = ${equalAddedPlaceholder}
+              and w.id > ${idPlaceholder}
+            )
+          )`);
+        }
+      } else if (params.cursor.publicationSortDate === null) {
+        const idPlaceholder = placeholder(values.length + 1);
+        values.push(params.cursor.id);
+        conditions.push(`(
+          preferred.publication_sort_date is null and w.id > ${idPlaceholder}
+        )`);
+      } else {
+        const lesserPublicationPlaceholder = placeholder(values.length + 1);
+        values.push(params.cursor.publicationSortDate);
+        const equalPublicationPlaceholder = placeholder(values.length + 1);
+        values.push(params.cursor.publicationSortDate);
+        const idPlaceholder = placeholder(values.length + 1);
+        values.push(params.cursor.id);
+        conditions.push(`(
+          preferred.publication_sort_date < ${lesserPublicationPlaceholder}
+          or preferred.publication_sort_date is null
+          or (
+            preferred.publication_sort_date = ${equalPublicationPlaceholder}
+            and w.id > ${idPlaceholder}
+          )
+        )`);
+      }
     }
 
     let statement = WORK_COLUMNS;
     if (conditions.length > 0) {
       statement += ` where ${conditions.join(" and ")}`;
     }
-    statement += " order by w.sort_title asc, w.id asc";
+    if (params.query.sort === "added") {
+      statement +=
+        " order by (preferred.cataloged_at is null) asc, preferred.cataloged_at desc, w.id asc";
+    } else if (params.query.sort === "publication") {
+      statement +=
+        " order by (preferred.publication_sort_date is null) asc, preferred.publication_sort_date desc, w.id asc";
+    } else {
+      statement += " order by w.sort_title asc, w.id asc";
+    }
     if (params.limit !== undefined) {
       statement += ` limit ${placeholder(values.length + 1)}`;
       values.push(params.limit);
     }
     return executor.query<WorkRow>(statement, values);
+  }
+
+  async function countWorkRows(query: CatalogQuery): Promise<number> {
+    const rows = await selectWorkRows({ query });
+    return rows.length;
   }
 
   async function loadEditionRowsByIds(ids: string[]): Promise<EditionRow[]> {
@@ -488,38 +603,72 @@ export function createCatalogRepository(
   }
 
   return {
-    async listWorkSummaries(query) {
+    async listWorkSummaries(query = { sort: "title" }) {
       const rows = await selectWorkRows({ query });
       return (await projectWorks(rows)) as WorkSummary[];
     },
 
     async pageWorkSummaries({ query, after, limit }) {
-      const cursor = decodeCursor(after);
+      const cursor = decodeCursor(after, query.sort);
       const pageSize = boundedLimit(limit);
-      const rows = await selectWorkRows({
-        query,
-        cursor,
-        limit: pageSize + 1,
-      });
+      const [rows, total] = await Promise.all([
+        selectWorkRows({
+          query,
+          cursor,
+          limit: pageSize + 1,
+        }),
+        countWorkRows(query),
+      ]);
       const hasNext = rows.length > pageSize;
       const pageRows = rows.slice(0, pageSize);
       const items = (await projectWorks(pageRows)) as WorkSummary[];
       const last = pageRows.at(-1);
+      const nextCursor =
+        hasNext && last
+          ? query.sort === "added"
+            ? encodeCursor({
+                version: 1,
+                sort: "added",
+                catalogedAt:
+                  last.catalogedAt === null ? null : Number(last.catalogedAt),
+                id: last.id,
+              })
+            : query.sort === "publication"
+              ? encodeCursor({
+                  version: 1,
+                  sort: "publication",
+                  publicationSortDate: last.publicationSortDate,
+                  id: last.id,
+                })
+              : encodeCursor({
+                  version: 1,
+                  sort: "title",
+                  sortTitle: last.sortTitle,
+                  id: last.id,
+                })
+          : undefined;
       return {
         items,
         hasNext,
-        nextCursor:
-          hasNext && last
-            ? encodeCursor({ sortTitle: last.sortTitle, id: last.id })
-            : undefined,
+        nextCursor,
+        total,
       };
+    },
+
+    async listCategories() {
+      return executor.query<CatalogCategory>(`
+        select slug as "slug", label as "label"
+        from categories
+        where status = 'active'
+        order by label asc, slug asc
+      `);
     },
 
     async listNewArrivals(limit = 24) {
       const pageSize = boundedLimit(limit);
       const rows = await executor.query<WorkRow>(
         `${WORK_COLUMNS}
-          join editions preferred on preferred.id = w.preferred_edition_id
+          where w.preferred_edition_id is not null
           order by preferred.cataloged_at desc, w.id asc
           limit ${placeholder(1)}
         `,

--- a/src/db/catalog/repository.ts
+++ b/src/db/catalog/repository.ts
@@ -1,6 +1,7 @@
 import {
   type CatalogCategory,
   type CatalogQuery,
+  catalogQueryKey,
   publicationPeriodBounds,
 } from "@/features/books/catalogQuery";
 import {
@@ -609,7 +610,8 @@ export function createCatalogRepository(
     },
 
     async pageWorkSummaries({ query, after, limit }) {
-      const cursor = decodeCursor(after, query.sort);
+      const cursor = decodeCursor(after, query);
+      const queryKey = catalogQueryKey(query);
       const pageSize = boundedLimit(limit);
       const [rows, total] = await Promise.all([
         selectWorkRows({
@@ -627,7 +629,8 @@ export function createCatalogRepository(
         hasNext && last
           ? query.sort === "added"
             ? encodeCursor({
-                version: 1,
+                version: 2,
+                queryKey,
                 sort: "added",
                 catalogedAt:
                   last.catalogedAt === null ? null : Number(last.catalogedAt),
@@ -635,13 +638,15 @@ export function createCatalogRepository(
               })
             : query.sort === "publication"
               ? encodeCursor({
-                  version: 1,
+                  version: 2,
+                  queryKey,
                   sort: "publication",
                   publicationSortDate: last.publicationSortDate,
                   id: last.id,
                 })
               : encodeCursor({
-                  version: 1,
+                  version: 2,
+                  queryKey,
                   sort: "title",
                   sortTitle: last.sortTitle,
                   id: last.id,

--- a/src/db/catalog/schema-parity.test.ts
+++ b/src/db/catalog/schema-parity.test.ts
@@ -138,4 +138,22 @@ describe("SQLite/Postgres normalized catalog schema parity", () => {
       expect(migration).toMatch(/drop table (?:if exists )?["`]?book_metrics/i);
     }
   });
+
+  it("adds the catalog-addition sort index in both providers", () => {
+    const sqliteMigration = readFileSync(
+      path.resolve("drizzle/0004_loose_tyrannus.sql"),
+      "utf8",
+    );
+    const postgresMigration = readFileSync(
+      path.resolve("drizzle/pg/0006_luxuriant_albert_cleary.sql"),
+      "utf8",
+    );
+    for (const migration of [sqliteMigration, postgresMigration]) {
+      expect(migration).toContain("editions_cataloged_work_idx");
+      expect(migration).toMatch(/cataloged_at["`]?,["`]?work_id/);
+      expect(migration).not.toMatch(
+        /(?:create|alter|drop)\s+table|delete\s+from/i,
+      );
+    }
+  });
 });

--- a/src/db/catalog/schema.pg.ts
+++ b/src/db/catalog/schema.pg.ts
@@ -170,6 +170,7 @@ export const editionsPg = pgTable(
       table.publicationSortDate,
       table.workId,
     ),
+    index("editions_cataloged_work_idx").on(table.catalogedAt, table.workId),
   ],
 );
 

--- a/src/db/catalog/schema.ts
+++ b/src/db/catalog/schema.ts
@@ -170,6 +170,7 @@ export const editions = sqliteTable(
       table.publicationSortDate,
       table.workId,
     ),
+    index("editions_cataloged_work_idx").on(table.catalogedAt, table.workId),
   ],
 );
 

--- a/src/features/books/BookList.tsx
+++ b/src/features/books/BookList.tsx
@@ -14,6 +14,9 @@ export type BookListProps = {
   footer?: React.ReactNode;
   /** Optional current search string to improve empty-state copy */
   q?: string;
+  /** Optional copy/action for recovering from an empty filtered result */
+  emptyMessage?: string;
+  emptyAction?: React.ReactNode;
   /** Spacing preset above the grid */
   spacing?: "normal" | "dense";
 };
@@ -25,6 +28,8 @@ export function BookList({
   presentation = "grid",
   footer,
   q,
+  emptyMessage,
+  emptyAction,
   spacing = "normal",
 }: BookListProps) {
   const isCompact = presentation === "compact";
@@ -87,7 +92,9 @@ export function BookList({
         >
           <p className="m-0 font-semibold">No books found</p>
           <p className="m-0 opacity-80">
-            {q ? (
+            {emptyMessage ? (
+              emptyMessage
+            ) : q ? (
               <>
                 We couldn't find any results matching <em>"{q}"</em>.
               </>
@@ -97,8 +104,11 @@ export function BookList({
           </p>
           <ul className="mx-auto mt-3 max-w-[560px] list-disc px-4 text-left text-[0.95em] opacity-85">
             <li>Try a different title or author</li>
-            <li>Check your spelling</li>
+            <li>Adjust or reset the active filters</li>
           </ul>
+          {emptyAction ? (
+            <div className="mt-[var(--spacing-2)]">{emptyAction}</div>
+          ) : null}
         </div>
       </Container>
     );

--- a/src/features/books/PaginatedBooks.client.test.tsx
+++ b/src/features/books/PaginatedBooks.client.test.tsx
@@ -17,13 +17,15 @@ describe("PaginatedBooks", () => {
       "fetch",
       vi.fn().mockResolvedValue({
         ok: true,
-        json: async () => ({ items: [second], hasNext: false }),
+        json: async () => ({ items: [second], hasNext: false, total: 2 }),
       }),
     );
     render(
       <PaginatedBooks
         initial={[workSummaryFixture]}
         initialNextCursor="cursor"
+        query={{ sort: "title" }}
+        total={2}
         title="All Books"
       />,
     );
@@ -31,7 +33,41 @@ describe("PaginatedBooks", () => {
     await waitFor(() =>
       expect(screen.getByText("Second Work")).toBeInTheDocument(),
     );
-    expect(screen.getByText("2 books shown")).toBeInTheDocument();
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/books/page?after=cursor&limit=24",
+      { cache: "no-store" },
+    );
+    expect(screen.getByText("2 of 2 books shown")).toBeInTheDocument();
+  });
+
+  it("preserves canonical filters and sort in load-more requests", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ items: [], hasNext: false, total: 25 }),
+      }),
+    );
+    render(
+      <PaginatedBooks
+        initial={[workSummaryFixture]}
+        initialNextCursor="cursor"
+        query={{
+          q: "the",
+          category: "science-fiction",
+          period: "1950-1999",
+          sort: "publication",
+        }}
+        total={25}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /load more books/i }));
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/books/page?q=the&category=science-fiction&period=1950-1999&sort=publication&after=cursor&limit=24",
+        { cache: "no-store" },
+      ),
+    );
   });
 
   it("shows a recoverable error when pagination fails", async () => {
@@ -40,6 +76,8 @@ describe("PaginatedBooks", () => {
       <PaginatedBooks
         initial={[workSummaryFixture]}
         initialNextCursor="cursor"
+        query={{ sort: "title" }}
+        total={2}
       />,
     );
     fireEvent.click(screen.getByRole("button", { name: /load more books/i }));

--- a/src/features/books/PaginatedBooks.client.tsx
+++ b/src/features/books/PaginatedBooks.client.tsx
@@ -1,10 +1,16 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { BooksCount } from "@/app/components/BooksCount";
 import { pageStyles as page } from "@/app/pageStyles";
 import { Container } from "@/design/layout/grid";
 import { BookList } from "./BookList";
+import {
+  type CatalogQuery,
+  hasCatalogFilters,
+  serializeCatalogPageQuery,
+} from "./catalogQuery";
 import { DEFAULT_BOOKS_PAGE_SIZE } from "./pageSize";
 import type { PageResult } from "./pagination";
 import type { WorkSummary } from "./types";
@@ -12,7 +18,8 @@ import type { WorkSummary } from "./types";
 type Props = {
   initial: WorkSummary[];
   initialNextCursor?: string;
-  q?: string;
+  query: CatalogQuery;
+  total: number;
   title?: string;
   limit?: number;
 };
@@ -20,7 +27,8 @@ type Props = {
 export function PaginatedBooks({
   initial,
   initialNextCursor,
-  q,
+  query,
+  total,
   title,
   limit = DEFAULT_BOOKS_PAGE_SIZE,
 }: Props) {
@@ -28,15 +36,21 @@ export function PaginatedBooks({
   const [cursor, setCursor] = useState<string | undefined>(initialNextCursor);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | undefined>();
-  const sectionTitle = title ?? (q ? "Search Results" : undefined);
+  const sectionTitle = title ?? (query.q ? "Search Results" : undefined);
+  const params = useMemo(
+    () =>
+      serializeCatalogPageQuery(query, {
+        after: cursor,
+        limit,
+      }).toString(),
+    [query, cursor, limit],
+  );
 
-  const params = useMemo(() => {
-    const search = new URLSearchParams();
-    if (q) search.set("q", q);
-    if (cursor) search.set("after", cursor);
-    search.set("limit", String(limit));
-    return search.toString();
-  }, [q, cursor, limit]);
+  useEffect(() => {
+    setItems(initial);
+    setCursor(initialNextCursor);
+    setError(undefined);
+  }, [initial, initialNextCursor]);
 
   const loadMore = useCallback(async () => {
     if (!cursor || loading) return;
@@ -63,26 +77,49 @@ export function PaginatedBooks({
         <Container>
           <header className={page.allBooksHeader}>
             <h2 className={page.sectionTitle}>{sectionTitle}</h2>
-            <BooksCount count={items.length} mode="shown" />
+            <BooksCount count={items.length} mode="shown" total={total} />
           </header>
         </Container>
       ) : null}
       <BookList
         works={items}
-        presentation={q ? "compact" : "grid"}
-        q={q}
-        footer={
-          error ? (
-            <div role="alert">{error}</div>
-          ) : cursor ? (
-            <button
-              type="button"
-              className="inline-flex items-center justify-center rounded-[var(--radius-lg)] border border-[color:var(--color-outline)] bg-[var(--color-surface)] px-[var(--spacing-3)] py-[var(--spacing-1-5)] text-lg leading-[1.2] text-[var(--color-on-surface)] no-underline shadow-[var(--elevation-1)] transition-[box-shadow,transform,border-color] duration-200 ease-out hover:-translate-y-px hover:border-[color:var(--color-primary)] hover:shadow-[var(--elevation-2)] focus-visible:-translate-y-px focus-visible:border-[color:var(--color-primary)] focus-visible:shadow-[var(--elevation-2)] focus-visible:outline-none active:translate-y-0 active:shadow-[var(--elevation-1)] disabled:cursor-not-allowed disabled:opacity-70"
-              onClick={loadMore}
-              disabled={loading}
+        presentation={query.q ? "compact" : "grid"}
+        q={query.q}
+        emptyMessage={
+          hasCatalogFilters(query)
+            ? "No books match the active search and filters."
+            : undefined
+        }
+        emptyAction={
+          hasCatalogFilters(query) ? (
+            <Link
+              href="/"
+              prefetch={false}
+              className="inline-flex min-h-11 items-center rounded-[var(--radius-sm)] bg-[var(--color-primary)] px-[var(--spacing-2)] font-semibold text-[var(--color-on-primary)] no-underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--color-primary)]"
             >
-              {loading ? "Loading..." : "Load More Books"}
-            </button>
+              Reset all filters
+            </Link>
+          ) : undefined
+        }
+        footer={
+          error || cursor || items.length > initial.length ? (
+            <div className="flex flex-col items-center gap-[var(--spacing-1)]">
+              {error ? <div role="alert">{error}</div> : null}
+              <button
+                type="button"
+                className="inline-flex items-center justify-center rounded-[var(--radius-lg)] border border-[color:var(--color-outline)] bg-[var(--color-surface)] px-[var(--spacing-3)] py-[var(--spacing-1-5)] text-lg leading-[1.2] text-[var(--color-on-surface)] no-underline shadow-[var(--elevation-1)] transition-[box-shadow,transform,border-color] duration-200 ease-out hover:-translate-y-px hover:border-[color:var(--color-primary)] hover:shadow-[var(--elevation-2)] focus-visible:-translate-y-px focus-visible:border-[color:var(--color-primary)] focus-visible:shadow-[var(--elevation-2)] focus-visible:outline-none active:translate-y-0 active:shadow-[var(--elevation-1)] aria-disabled:cursor-not-allowed aria-disabled:opacity-70"
+                onClick={loadMore}
+                aria-disabled={loading || !cursor}
+              >
+                {loading
+                  ? "Loading..."
+                  : cursor
+                    ? error
+                      ? "Try Loading Again"
+                      : "Load More Books"
+                    : "All Matching Books Loaded"}
+              </button>
+            </div>
           ) : null
         }
       />

--- a/src/features/books/catalogQuery.test.ts
+++ b/src/features/books/catalogQuery.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseCatalogQuery,
+  publicationPeriodBounds,
+  serializeCatalogPageQuery,
+  serializeCatalogQuery,
+} from "./catalogQuery";
+
+describe("canonical catalog query", () => {
+  it("parses and normalizes every supported parameter", () => {
+    expect(
+      parseCatalogQuery({
+        q: "  ursula   le guin ",
+        category: " Science-Fiction ",
+        period: "1950-1999",
+        sort: "publication",
+      }),
+    ).toEqual({
+      q: "ursula le guin",
+      category: "science-fiction",
+      period: "1950-1999",
+      sort: "publication",
+    });
+  });
+
+  it("uses safe defaults for invalid and repeated parameters", () => {
+    expect(
+      parseCatalogQuery({
+        q: ["first", "second"],
+        category: "../invalid",
+        period: "future",
+        sort: "relevance",
+      }),
+    ).toEqual({
+      q: "first",
+      category: undefined,
+      period: undefined,
+      sort: "title",
+    });
+  });
+
+  it("serializes in one stable canonical order and omits defaults", () => {
+    const parsed = parseCatalogQuery(
+      new URLSearchParams(
+        "sort=publication&period=2000-2009&category=fantasy&q=harbor",
+      ),
+    );
+    expect(serializeCatalogQuery(parsed).toString()).toBe(
+      "q=harbor&category=fantasy&period=2000-2009&sort=publication",
+    );
+    expect(
+      serializeCatalogQuery(
+        parseCatalogQuery(new URLSearchParams()),
+      ).toString(),
+    ).toBe("");
+  });
+
+  it("uses the same model for paginated API parameters", () => {
+    const query = parseCatalogQuery(
+      new URLSearchParams("category=classics&sort=added"),
+    );
+    expect(
+      serializeCatalogPageQuery(query, {
+        after: "opaque-cursor",
+        limit: 24,
+      }).toString(),
+    ).toBe("category=classics&sort=added&after=opaque-cursor&limit=24");
+  });
+
+  it("exposes inclusive and exclusive publication-period bounds", () => {
+    expect(publicationPeriodBounds("1950-1999")).toEqual({
+      from: "1950-01-01",
+      before: "2000-01-01",
+    });
+    expect(publicationPeriodBounds("2020-present")).toEqual({
+      from: "2020-01-01",
+      before: undefined,
+    });
+  });
+});

--- a/src/features/books/catalogQuery.test.ts
+++ b/src/features/books/catalogQuery.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  catalogQueryKey,
   parseCatalogQuery,
   publicationPeriodBounds,
   serializeCatalogPageQuery,
@@ -53,6 +54,9 @@ describe("canonical catalog query", () => {
         parseCatalogQuery(new URLSearchParams()),
       ).toString(),
     ).toBe("");
+    expect(catalogQueryKey(parsed)).toBe(
+      "q=harbor&category=fantasy&period=2000-2009&sort=publication",
+    );
   });
 
   it("uses the same model for paginated API parameters", () => {

--- a/src/features/books/catalogQuery.ts
+++ b/src/features/books/catalogQuery.ts
@@ -1,0 +1,163 @@
+export const CATALOG_SORTS = ["title", "added", "publication"] as const;
+export type CatalogSort = (typeof CATALOG_SORTS)[number];
+
+export const DEFAULT_CATALOG_SORT: CatalogSort = "title";
+
+export const PUBLICATION_PERIODS = [
+  {
+    value: "before-1950",
+    label: "Before 1950",
+    before: "1950-01-01",
+  },
+  {
+    value: "1950-1999",
+    label: "1950–1999",
+    from: "1950-01-01",
+    before: "2000-01-01",
+  },
+  {
+    value: "2000-2009",
+    label: "2000–2009",
+    from: "2000-01-01",
+    before: "2010-01-01",
+  },
+  {
+    value: "2010-2019",
+    label: "2010–2019",
+    from: "2010-01-01",
+    before: "2020-01-01",
+  },
+  {
+    value: "2020-present",
+    label: "2020–present",
+    from: "2020-01-01",
+  },
+] as const;
+
+export type PublicationPeriod = (typeof PUBLICATION_PERIODS)[number]["value"];
+
+export type CatalogQuery = {
+  q?: string;
+  category?: string;
+  period?: PublicationPeriod;
+  sort: CatalogSort;
+};
+
+export type CatalogCategory = {
+  slug: string;
+  label: string;
+};
+
+type SearchParamsRecord = Record<string, string | string[] | null | undefined>;
+
+type SearchParamsReader = {
+  get(name: string): string | null;
+};
+
+const categorySlugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+function readParam(
+  source: SearchParamsRecord | SearchParamsReader,
+  name: string,
+): string | undefined {
+  const reader = source as SearchParamsReader;
+  if (typeof reader.get === "function") {
+    return reader.get(name) ?? undefined;
+  }
+  const value = (source as SearchParamsRecord)[name];
+  return Array.isArray(value) ? value[0] : (value ?? undefined);
+}
+
+function normalizeOptionalText(value: string | undefined): string | undefined {
+  const normalized = value?.trim().replace(/\s+/g, " ");
+  return normalized ? normalized.slice(0, 200) : undefined;
+}
+
+function normalizeCategory(value: string | undefined): string | undefined {
+  const normalized = value?.trim().toLowerCase();
+  if (
+    !normalized ||
+    normalized.length > 80 ||
+    !categorySlugPattern.test(normalized)
+  ) {
+    return undefined;
+  }
+  return normalized;
+}
+
+function isCatalogSort(value: string | undefined): value is CatalogSort {
+  return CATALOG_SORTS.some((sort) => sort === value);
+}
+
+function isPublicationPeriod(
+  value: string | undefined,
+): value is PublicationPeriod {
+  return PUBLICATION_PERIODS.some((period) => period.value === value);
+}
+
+export function parseCatalogQuery(
+  source: SearchParamsRecord | SearchParamsReader,
+): CatalogQuery {
+  const sort = readParam(source, "sort");
+  const period = readParam(source, "period");
+  return {
+    q: normalizeOptionalText(readParam(source, "q")),
+    category: normalizeCategory(readParam(source, "category")),
+    period: isPublicationPeriod(period) ? period : undefined,
+    sort: isCatalogSort(sort) ? sort : DEFAULT_CATALOG_SORT,
+  };
+}
+
+export function serializeCatalogQuery(query: CatalogQuery): URLSearchParams {
+  const params = new URLSearchParams();
+  if (query.q) params.set("q", query.q);
+  if (query.category) params.set("category", query.category);
+  if (query.period) params.set("period", query.period);
+  if (query.sort !== DEFAULT_CATALOG_SORT) params.set("sort", query.sort);
+  return params;
+}
+
+export function serializeCatalogPageQuery(
+  query: CatalogQuery,
+  pagination: { after?: string; limit: number },
+): URLSearchParams {
+  const params = serializeCatalogQuery(query);
+  if (pagination.after) params.set("after", pagination.after);
+  params.set("limit", String(pagination.limit));
+  return params;
+}
+
+export function publicationPeriodBounds(period: PublicationPeriod): {
+  from?: string;
+  before?: string;
+} {
+  const match = PUBLICATION_PERIODS.find(
+    (candidate) => candidate.value === period,
+  );
+  return {
+    from: match && "from" in match ? match.from : undefined,
+    before: match && "before" in match ? match.before : undefined,
+  };
+}
+
+export function publicationPeriodLabel(period: PublicationPeriod): string {
+  return (
+    PUBLICATION_PERIODS.find((candidate) => candidate.value === period)
+      ?.label ?? period
+  );
+}
+
+export function catalogSortLabel(sort: CatalogSort): string {
+  switch (sort) {
+    case "added":
+      return "Newest catalog additions";
+    case "publication":
+      return "Publication date (newest)";
+    default:
+      return "Title (A–Z)";
+  }
+}
+
+export function hasCatalogFilters(query: CatalogQuery): boolean {
+  return Boolean(query.q || query.category || query.period);
+}

--- a/src/features/books/catalogQuery.ts
+++ b/src/features/books/catalogQuery.ts
@@ -117,6 +117,10 @@ export function serializeCatalogQuery(query: CatalogQuery): URLSearchParams {
   return params;
 }
 
+export function catalogQueryKey(query: CatalogQuery): string {
+  return serializeCatalogQuery(query).toString();
+}
+
 export function serializeCatalogPageQuery(
   query: CatalogQuery,
   pagination: { after?: string; limit: number },

--- a/src/features/books/pagination.test.ts
+++ b/src/features/books/pagination.test.ts
@@ -1,28 +1,41 @@
 import { describe, expect, it } from "vitest";
+import type { CatalogQuery } from "./catalogQuery";
 import { decodeCursor, encodeCursor } from "./pagination";
 
 describe("catalog cursors", () => {
   it.each([
     {
-      version: 1 as const,
-      sort: "title" as const,
-      sortTitle: "example work",
-      id: "work-id",
+      query: { sort: "title" } satisfies CatalogQuery,
+      payload: {
+        version: 2 as const,
+        queryKey: "",
+        sort: "title" as const,
+        sortTitle: "example work",
+        id: "work-id",
+      },
     },
     {
-      version: 1 as const,
-      sort: "added" as const,
-      catalogedAt: 123,
-      id: "work-id",
+      query: { sort: "added" } satisfies CatalogQuery,
+      payload: {
+        version: 2 as const,
+        queryKey: "sort=added",
+        sort: "added" as const,
+        catalogedAt: 123,
+        id: "work-id",
+      },
     },
     {
-      version: 1 as const,
-      sort: "publication" as const,
-      publicationSortDate: null,
-      id: "work-id",
+      query: { sort: "publication" } satisfies CatalogQuery,
+      payload: {
+        version: 2 as const,
+        queryKey: "sort=publication",
+        sort: "publication" as const,
+        publicationSortDate: null,
+        id: "work-id",
+      },
     },
-  ])("round-trips a $sort cursor", (value) => {
-    expect(decodeCursor(encodeCursor(value), value.sort)).toEqual(value);
+  ])("round-trips a $payload.sort cursor", ({ payload, query }) => {
+    expect(decodeCursor(encodeCursor(payload), query)).toEqual(payload);
   });
 
   it("rejects legacy and malformed cursors", () => {
@@ -33,7 +46,7 @@ describe("catalog cursors", () => {
     expect(
       decodeCursor(
         Buffer.from(
-          '{"version":1,"sort":"title","sortTitle":"valid","id":""}',
+          '{"version":2,"queryKey":"","sort":"title","sortTitle":"valid","id":""}',
         ).toString("base64url"),
       ),
     ).toBeNull();
@@ -41,11 +54,25 @@ describe("catalog cursors", () => {
 
   it("rejects a cursor created for a different sort", () => {
     const cursor = encodeCursor({
-      version: 1,
+      version: 2,
+      queryKey: "",
       sort: "title",
       sortTitle: "example",
       id: "work-id",
     });
-    expect(decodeCursor(cursor, "publication")).toBeNull();
+    expect(decodeCursor(cursor, { sort: "publication" })).toBeNull();
+  });
+
+  it("rejects a cursor created for different filters with the same sort", () => {
+    const cursor = encodeCursor({
+      version: 2,
+      queryKey: "category=science-fiction",
+      sort: "title",
+      sortTitle: "example",
+      id: "work-id",
+    });
+    expect(
+      decodeCursor(cursor, { category: "fantasy", sort: "title" }),
+    ).toBeNull();
   });
 });

--- a/src/features/books/pagination.test.ts
+++ b/src/features/books/pagination.test.ts
@@ -2,9 +2,27 @@ import { describe, expect, it } from "vitest";
 import { decodeCursor, encodeCursor } from "./pagination";
 
 describe("catalog cursors", () => {
-  it("round-trips sort title and work ID", () => {
-    const value = { sortTitle: "example work", id: "work-id" };
-    expect(decodeCursor(encodeCursor(value))).toEqual(value);
+  it.each([
+    {
+      version: 1 as const,
+      sort: "title" as const,
+      sortTitle: "example work",
+      id: "work-id",
+    },
+    {
+      version: 1 as const,
+      sort: "added" as const,
+      catalogedAt: 123,
+      id: "work-id",
+    },
+    {
+      version: 1 as const,
+      sort: "publication" as const,
+      publicationSortDate: null,
+      id: "work-id",
+    },
+  ])("round-trips a $sort cursor", (value) => {
+    expect(decodeCursor(encodeCursor(value), value.sort)).toEqual(value);
   });
 
   it("rejects legacy and malformed cursors", () => {
@@ -12,5 +30,22 @@ describe("catalog cursors", () => {
       decodeCursor(Buffer.from('{"id":"old"}').toString("base64url")),
     ).toBeNull();
     expect(decodeCursor("not-base64-json")).toBeNull();
+    expect(
+      decodeCursor(
+        Buffer.from(
+          '{"version":1,"sort":"title","sortTitle":"valid","id":""}',
+        ).toString("base64url"),
+      ),
+    ).toBeNull();
+  });
+
+  it("rejects a cursor created for a different sort", () => {
+    const cursor = encodeCursor({
+      version: 1,
+      sort: "title",
+      sortTitle: "example",
+      id: "work-id",
+    });
+    expect(decodeCursor(cursor, "publication")).toBeNull();
   });
 });

--- a/src/features/books/pagination.ts
+++ b/src/features/books/pagination.ts
@@ -1,24 +1,86 @@
 import { Buffer } from "node:buffer";
+import type { CatalogSort } from "./catalogQuery";
 
-/** Opaque keyset cursor for the canonical (sort_title, work.id) ordering. */
-export type CursorPayload = { sortTitle: string; id: string };
+type CursorBase = {
+  version: 1;
+  id: string;
+};
+
+/** Opaque keyset cursor carrying every visible sort key plus work ID. */
+export type CursorPayload =
+  | (CursorBase & {
+      sort: "title";
+      sortTitle: string;
+    })
+  | (CursorBase & {
+      sort: "added";
+      catalogedAt: number | null;
+    })
+  | (CursorBase & {
+      sort: "publication";
+      publicationSortDate: string | null;
+    });
 
 export function encodeCursor(payload: CursorPayload): string {
   const json = JSON.stringify(payload);
   return Buffer.from(json, "utf8").toString("base64url");
 }
 
-export function decodeCursor(cursor?: string | null): CursorPayload | null {
+export function decodeCursor(
+  cursor?: string | null,
+  expectedSort?: CatalogSort,
+): CursorPayload | null {
   if (!cursor) return null;
   try {
     const json = Buffer.from(cursor, "base64url").toString("utf8");
-    const obj = JSON.parse(json);
+    const obj = JSON.parse(json) as Record<string, unknown>;
     if (
-      obj &&
-      typeof obj.sortTitle === "string" &&
-      typeof obj.id === "string"
+      !obj ||
+      obj.version !== 1 ||
+      typeof obj.id !== "string" ||
+      obj.id.length === 0
     ) {
-      return { sortTitle: obj.sortTitle, id: obj.id };
+      return null;
+    }
+    if (expectedSort && obj.sort !== expectedSort) return null;
+    if (
+      obj.sort === "title" &&
+      typeof obj.sortTitle === "string" &&
+      obj.sortTitle.length > 0
+    ) {
+      return {
+        version: 1,
+        sort: "title",
+        sortTitle: obj.sortTitle,
+        id: obj.id,
+      };
+    }
+    if (
+      obj.sort === "added" &&
+      ((typeof obj.catalogedAt === "number" &&
+        Number.isFinite(obj.catalogedAt) &&
+        obj.catalogedAt >= 0) ||
+        obj.catalogedAt === null)
+    ) {
+      return {
+        version: 1,
+        sort: "added",
+        catalogedAt: obj.catalogedAt,
+        id: obj.id,
+      };
+    }
+    if (
+      obj.sort === "publication" &&
+      ((typeof obj.publicationSortDate === "string" &&
+        /^\d{4}-\d{2}-\d{2}$/.test(obj.publicationSortDate)) ||
+        obj.publicationSortDate === null)
+    ) {
+      return {
+        version: 1,
+        sort: "publication",
+        publicationSortDate: obj.publicationSortDate,
+        id: obj.id,
+      };
     }
     return null;
   } catch {
@@ -30,4 +92,5 @@ export type PageResult<T> = {
   items: T[];
   nextCursor?: string;
   hasNext: boolean;
+  total: number;
 };

--- a/src/features/books/pagination.ts
+++ b/src/features/books/pagination.ts
@@ -1,8 +1,9 @@
 import { Buffer } from "node:buffer";
-import type { CatalogSort } from "./catalogQuery";
+import { type CatalogQuery, catalogQueryKey } from "./catalogQuery";
 
 type CursorBase = {
-  version: 1;
+  version: 2;
+  queryKey: string;
   id: string;
 };
 
@@ -28,7 +29,7 @@ export function encodeCursor(payload: CursorPayload): string {
 
 export function decodeCursor(
   cursor?: string | null,
-  expectedSort?: CatalogSort,
+  expectedQuery?: CatalogQuery,
 ): CursorPayload | null {
   if (!cursor) return null;
   try {
@@ -36,20 +37,28 @@ export function decodeCursor(
     const obj = JSON.parse(json) as Record<string, unknown>;
     if (
       !obj ||
-      obj.version !== 1 ||
+      obj.version !== 2 ||
+      typeof obj.queryKey !== "string" ||
       typeof obj.id !== "string" ||
       obj.id.length === 0
     ) {
       return null;
     }
-    if (expectedSort && obj.sort !== expectedSort) return null;
+    if (
+      expectedQuery &&
+      (obj.sort !== expectedQuery.sort ||
+        obj.queryKey !== catalogQueryKey(expectedQuery))
+    ) {
+      return null;
+    }
     if (
       obj.sort === "title" &&
       typeof obj.sortTitle === "string" &&
       obj.sortTitle.length > 0
     ) {
       return {
-        version: 1,
+        version: 2,
+        queryKey: obj.queryKey,
         sort: "title",
         sortTitle: obj.sortTitle,
         id: obj.id,
@@ -63,7 +72,8 @@ export function decodeCursor(
         obj.catalogedAt === null)
     ) {
       return {
-        version: 1,
+        version: 2,
+        queryKey: obj.queryKey,
         sort: "added",
         catalogedAt: obj.catalogedAt,
         id: obj.id,
@@ -76,7 +86,8 @@ export function decodeCursor(
         obj.publicationSortDate === null)
     ) {
       return {
-        version: 1,
+        version: 2,
+        queryKey: obj.queryKey,
         sort: "publication",
         publicationSortDate: obj.publicationSortDate,
         id: obj.id,

--- a/src/features/books/repo.ts
+++ b/src/features/books/repo.ts
@@ -5,6 +5,7 @@ import {
 import { ensureDb, getSqliteRaw } from "@/db/client";
 import { getDbEnv } from "@/db/env";
 import { getPgSql } from "@/db/pg";
+import type { CatalogCategory, CatalogQuery } from "./catalogQuery";
 import type { PageResult } from "./pagination";
 import type { WorkDetail, WorkSummary } from "./types";
 
@@ -40,20 +41,26 @@ async function repository() {
   return createCatalogRepository(activeExecutor());
 }
 
-export async function getWorks(query?: string): Promise<WorkSummary[]> {
+export async function getWorks(
+  query: CatalogQuery = { sort: "title" },
+): Promise<WorkSummary[]> {
   return (await repository()).listWorkSummaries(query);
 }
 
 export async function getWorksPage(params: {
-  q?: string;
+  query: CatalogQuery;
   after?: string | null;
   limit: number;
 }): Promise<PageResult<WorkSummary>> {
   return (await repository()).pageWorkSummaries({
-    query: params.q,
+    query: params.query,
     after: params.after,
     limit: params.limit,
   });
+}
+
+export async function getCatalogCategories(): Promise<CatalogCategory[]> {
+  return (await repository()).listCategories();
 }
 
 export async function findWorkById(

--- a/tests/all-books-pagination.spec.ts
+++ b/tests/all-books-pagination.spec.ts
@@ -10,7 +10,7 @@ test.describe("All Books pagination", () => {
     await expect(
       page.getByRole("heading", { level: 2, name: "All Books" }),
     ).toBeVisible();
-    await expect(page.getByText("24 books shown")).toBeVisible();
+    await expect(page.getByText("24 of 500 books shown")).toBeVisible();
 
     const beforeRowCounts = await page
       .getByRole("link", { name: /view details for/i })
@@ -30,7 +30,7 @@ test.describe("All Books pagination", () => {
 
     await page.getByRole("button", { name: "Load More Books" }).click();
 
-    await expect(page.getByText("48 books shown")).toBeVisible();
+    await expect(page.getByText("48 of 500 books shown")).toBeVisible();
 
     const afterRowCounts = await page
       .getByRole("link", { name: /view details for/i })

--- a/tests/book-presentation.spec.ts
+++ b/tests/book-presentation.spec.ts
@@ -155,6 +155,7 @@ test.describe("Book presentation", () => {
       .getByRole("link", { name: /view details for/i })
       .first();
     const card = firstLink.locator("xpath=ancestor::article");
+    await card.scrollIntoViewIfNeeded();
     const coverBox = await card.locator(":scope > div").first().boundingBox();
     expect(coverBox).not.toBeNull();
 

--- a/tests/catalog-filters.spec.ts
+++ b/tests/catalog-filters.spec.ts
@@ -1,0 +1,101 @@
+import { expect, test } from "@playwright/test";
+
+const combinedUrl =
+  "/?q=the&category=science-fiction&period=1950-1999&sort=publication";
+const zeroResultUrl =
+  "/?q=no-such-book-110&category=science-fiction&period=1950-1999&sort=publication";
+
+test.describe("URL-driven catalog filters", () => {
+  test("renders a combined-filter URL on the server with active context", async ({
+    page,
+    request,
+  }) => {
+    const response = await request.get(combinedUrl);
+    expect(response.ok()).toBe(true);
+    const html = await response.text();
+    expect(html).toContain("Search Results");
+    expect(html).toContain("Active filters:");
+
+    await page.goto(combinedUrl, { waitUntil: "domcontentloaded" });
+    await expect(page).toHaveURL(combinedUrl);
+    await expect(
+      page.getByText(/Active filters: Search: “the”/),
+    ).toContainText("Category: Science Fiction");
+    await expect(
+      page.getByRole("heading", { level: 2, name: "Search Results" }),
+    ).toBeVisible();
+    await expect(page.getByText("24 of 25 books shown")).toBeVisible();
+  });
+
+  test("keeps every active parameter in filtered pagination", async ({
+    page,
+  }) => {
+    await page.goto(combinedUrl, { waitUntil: "domcontentloaded" });
+    const links = page.getByRole("link", { name: /view details for/i });
+    const firstPageHrefs = await links.evaluateAll((items) =>
+      items.map((item) => item.getAttribute("href")),
+    );
+
+    const requestPromise = page.waitForRequest((request) => {
+      const url = new URL(request.url());
+      return (
+        url.pathname === "/api/books/page" &&
+        url.searchParams.get("q") === "the" &&
+        url.searchParams.get("category") === "science-fiction" &&
+        url.searchParams.get("period") === "1950-1999" &&
+        url.searchParams.get("sort") === "publication" &&
+        Boolean(url.searchParams.get("after"))
+      );
+    });
+    const loadMore = page.getByRole("button", { name: "Load More Books" });
+    await loadMore.click();
+    await requestPromise;
+
+    await expect(page.getByText("25 of 25 books shown")).toBeVisible();
+    const loaded = page.getByRole("button", {
+      name: "All Matching Books Loaded",
+    });
+    await expect(loaded).toBeVisible();
+    await expect(loaded).toBeFocused();
+    await expect(page).toHaveURL(combinedUrl);
+    const allHrefs = await links.evaluateAll((items) =>
+      items.map((item) => item.getAttribute("href")),
+    );
+    expect(allHrefs).toHaveLength(25);
+    expect(new Set(allHrefs).size).toBe(allHrefs.length);
+    expect(allHrefs.slice(0, firstPageHrefs.length)).toEqual(firstPageHrefs);
+  });
+
+  test("preserves canonical state through refresh and back-forward navigation", async ({
+    page,
+  }) => {
+    await page.goto(combinedUrl, { waitUntil: "domcontentloaded" });
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await expect(page).toHaveURL(combinedUrl);
+    await expect(page.getByLabel("Category")).toHaveValue("science-fiction");
+    await expect(page.getByLabel("Publication period")).toHaveValue(
+      "1950-1999",
+    );
+    await expect(page.getByLabel("Sort by")).toHaveValue("publication");
+
+    await page.goto(zeroResultUrl, { waitUntil: "domcontentloaded" });
+    await expect(page.getByText("No books found")).toBeVisible();
+    await page.goBack({ waitUntil: "domcontentloaded" });
+    await expect(page).toHaveURL(combinedUrl);
+    await expect(page.getByText("24 of 25 books shown")).toBeVisible();
+    await page.goForward({ waitUntil: "domcontentloaded" });
+    await expect(page).toHaveURL(zeroResultUrl);
+    await expect(page.getByText("No books found")).toBeVisible();
+  });
+
+  test("offers one-action recovery from zero results", async ({ page }) => {
+    await page.goto(zeroResultUrl, { waitUntil: "domcontentloaded" });
+    await expect(page.getByText("0 of 0 books shown")).toBeVisible();
+    await expect(
+      page.getByText("No books match the active search and filters."),
+    ).toBeVisible();
+    await page.getByRole("link", { name: "Reset all filters" }).click();
+    await expect(page).toHaveURL("/");
+    await expect(page.getByText("24 of 500 books shown")).toBeVisible();
+  });
+});

--- a/tests/catalog-filters.spec.ts
+++ b/tests/catalog-filters.spec.ts
@@ -1,9 +1,16 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
 const combinedUrl =
   "/?q=the&category=science-fiction&period=1950-1999&sort=publication";
 const zeroResultUrl =
   "/?q=no-such-book-110&category=science-fiction&period=1950-1999&sort=publication";
+
+async function expectDefaultControls(page: Page) {
+  await expect(page.getByRole("searchbox")).toHaveValue("");
+  await expect(page.getByLabel("Category")).toHaveValue("");
+  await expect(page.getByLabel("Publication period")).toHaveValue("");
+  await expect(page.getByLabel("Sort by")).toHaveValue("title");
+}
 
 test.describe("URL-driven catalog filters", () => {
   test("renders a combined-filter URL on the server with active context", async ({
@@ -78,14 +85,45 @@ test.describe("URL-driven catalog filters", () => {
     );
     await expect(page.getByLabel("Sort by")).toHaveValue("publication");
 
-    await page.goto(zeroResultUrl, { waitUntil: "domcontentloaded" });
-    await expect(page.getByText("No books found")).toBeVisible();
+    await page.getByRole("link", { name: "Reset all", exact: true }).click();
+    await expect(page).toHaveURL("/");
+    await expect(page.getByText("24 of 500 books shown")).toBeVisible();
+    await expectDefaultControls(page);
+
     await page.goBack({ waitUntil: "domcontentloaded" });
     await expect(page).toHaveURL(combinedUrl);
     await expect(page.getByText("24 of 25 books shown")).toBeVisible();
+    await expect(page.getByRole("searchbox")).toHaveValue("the");
+    await expect(page.getByLabel("Category")).toHaveValue("science-fiction");
+    await expect(page.getByLabel("Publication period")).toHaveValue(
+      "1950-1999",
+    );
+    await expect(page.getByLabel("Sort by")).toHaveValue("publication");
+
     await page.goForward({ waitUntil: "domcontentloaded" });
-    await expect(page).toHaveURL(zeroResultUrl);
-    await expect(page.getByText("No books found")).toBeVisible();
+    await expect(page).toHaveURL("/");
+    await expect(page.getByText("24 of 500 books shown")).toBeVisible();
+    await expectDefaultControls(page);
+  });
+
+  test("restarts safely when a cursor is reused with different filters", async ({
+    request,
+  }) => {
+    const source = await request.get(
+      "/api/books/page?category=science-fiction&sort=title&limit=50",
+    );
+    const sourcePage = await source.json();
+    const expected = await request.get(
+      "/api/books/page?category=fantasy&sort=title&limit=5",
+    );
+    const expectedPage = await expected.json();
+    const mismatched = await request.get(
+      `/api/books/page?category=fantasy&sort=title&limit=5&after=${encodeURIComponent(sourcePage.nextCursor)}`,
+    );
+    const mismatchedPage = await mismatched.json();
+    expect(
+      mismatchedPage.items.map((work: { id: string }) => work.id),
+    ).toEqual(expectedPage.items.map((work: { id: string }) => work.id));
   });
 
   test("offers one-action recovery from zero results", async ({ page }) => {
@@ -97,5 +135,6 @@ test.describe("URL-driven catalog filters", () => {
     await page.getByRole("link", { name: "Reset all filters" }).click();
     await expect(page).toHaveURL("/");
     await expect(page.getByText("24 of 500 books shown")).toBeVisible();
+    await expectDefaultControls(page);
   });
 });


### PR DESCRIPTION
## Summary

- adds shareable URL-driven title/author search, normalized category and publication-period filters, deterministic sorting, active context, accurate counts, and zero-result reset
- uses one canonical query model across SSR, both normalized API routes, repository reads, and client load-more requests

## Linked Issue

- Closes #110
- Labels aligned with linked issue: `enhancement`, `area: discovery`

## Changes

- adds canonical parsing/serialization for `q`, `category`, `period`, and `sort`, with safe defaults for invalid input
- adds title, catalog-addition, and publication-date keyset cursors carrying work ID as the final tie-breaker
- binds every cursor to the complete canonical query so changed search/filter/sort state safely restarts from page one
- filters normalized categories and preferred-edition publication metadata equivalently in SQLite and Postgres
- preserves active state through search, filter application, pagination, refresh, reset, and browser history
- adds accessible active-filter context, accurate visible/total counts, retry behavior, reset actions, and focused post-pagination state
- adds equivalent SQLite/Postgres catalog-addition indexes and documents the supported API/query semantics

## Validation

- [x] `bun run lint`
- [x] `bun run test` — 156 passed; isolated live-Postgres test correctly gated
- [x] `bunx tsc --noEmit`
- [x] `bun run test:storybook` — 27 passed
- [x] `bun run build:ci`
- [x] `bun run test:playwright -- tests/catalog-filters.spec.ts` — 5 passed
- [x] `bun run test:playwright` — 16 passed
- [x] isolated SQLite initialization and normalized catalog verification — 500 works/editions, zero broken links or retired tables
- [x] `git diff --check`
- [x] manual verification completed where relevant

## UX Notes

- [ ] no visual changes
- [x] responsive behavior verified at affected breakpoints
- [x] accessibility impact reviewed

Notes:

- native labeled controls remain keyboard operable and initial results remain server rendered
- canonical navigation remounts uncontrolled controls so reset and back/forward state match the URL
- load-more retains focus on a stable status button after the final page
- no book-card redesign or unsupported discovery signal was introduced

## Architecture Notes

- [ ] no architectural impact
- [x] follows existing architecture and framework defaults
- [ ] introduces or updates a documented decision in `docs/decisions`

ADR / decision links:

- follows ADR 0016 work/category/preferred-edition boundaries
- updates `docs/database-architecture.md` with canonical parameters, period bounds, sort order, cursor semantics, and API behavior

## Data / API / Infra Impact

- [ ] no data, API, or infra impact
- [x] database schema changed
- [ ] seed/import/catalog data changed
- [x] API contract changed
- [ ] environment variables changed
- [ ] CI/CD or deployment behavior changed

Operational notes:

- forward SQLite and Postgres migrations add only the `editions_cataloged_work_idx` index
- `/api/books` and `/api/books/page` accept the canonical catalog query; paginated responses now include the matching total
- live Postgres integration remains gated on an explicitly disposable `CATALOG_TEST_POSTGRES_URL`

## Risks

- [ ] low risk
- [x] medium risk
- [ ] high risk

Main risks and mitigations:

- risk: a cursor could be reused with different active state
- mitigation: versioned cursors identify the complete canonical query, malformed/mismatched cursors restart safely, and every sort ends with work ID
- risk: SQLite and Postgres could diverge on null ordering or timestamps
- mitigation: null placement is explicit, timestamp cursor binding is provider-aware, schema parity is enforced, and the gated Postgres contract exercises every sort and combined filters

## Checklist

- [x] scope matches the linked issue
- [x] PR labels match the linked issue labels where applicable
- [x] touched code is cleaner than before
- [x] tests cover the changed behavior
- [x] docs were updated where needed
- [x] local-only/generated artifacts are excluded from git
