### PR TITLE
feat(catalog): add policy-gated enrichment adapter foundation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,6 @@ jobs:
       - name: Run Postgres integration tests
         run: >-
           bun run test --
-          src/db/catalog/postgres-rebuild.test.ts
           src/db/catalog/enrichment/persistence.pg.test.ts
           --no-file-parallelism
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,3 +22,37 @@ jobs:
         run: bun install --frozen-lockfile
       - name: Run Vitest
         run: bun run test
+
+  postgres-test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: bukie_catalog_test
+          POSTGRES_PASSWORD: bukie_test
+          POSTGRES_USER: bukie_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U bukie_test -d bukie_catalog_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.10
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Run Postgres integration tests
+        run: >-
+          bun run test --
+          src/db/catalog/postgres-rebuild.test.ts
+          src/db/catalog/enrichment/persistence.pg.test.ts
+          --no-file-parallelism
+        env:
+          CATALOG_TEST_POSTGRES_URL: postgresql://bukie_test:bukie_test@127.0.0.1:5432/bukie_catalog_test

--- a/docs/catalog-enrichment.md
+++ b/docs/catalog-enrichment.md
@@ -1,0 +1,157 @@
+# Policy-gated catalog enrichment
+
+Issue #131 adds a provider-neutral adapter foundation on top of ADR 0016's
+existing source-record, link, observation, resolution, and eligibility
+lifecycle. It does not add another catalog data system and does not promote
+enrichment into current resolution heads or reader-facing projections.
+
+## Execution boundary
+
+Executable enrichment is restricted by
+`src/db/catalog/enrichment/sample-manifest.ts` to the versioned
+`bukie-enrichment-diagnostic-five@2026-07-28.v1` manifest:
+
+| Work | Work ID | Recorded Wikidata work candidate |
+|---|---|---|
+| Dune | `7adeda04-34e2-5a7d-a101-de0578138b29` | `Q190192` |
+| Moby-Dick | `00a218bd-3005-59cd-9c23-13efb48abe5a` | `Q174596` |
+| The City and the Stars | `00a01d7f-3f29-5c95-a292-c70a4e5dbb4f` | `Q386544` |
+| Born a Crime | `03ac5ae7-dcf1-5fe7-b6ac-b8f171459fb3` | `Q29831237` |
+| Faithful Place | `0100088c-3aca-5e52-9e7a-fb89192e9248` | `Q5431286` |
+
+The manifest records sample identity evidence; adapters, policies, matchers,
+normalizers, and acquisition code contain no sample-specific branches.
+Requests outside the manifest fail before acquisition or persistence. The
+diagnostic workflow builds its five baseline work rows directly from this
+manifest and never loads or scans the 500-work artifact.
+
+Catalog-wide dry run and promotion remain deferred to #135.
+
+## Adapter and policy contract
+
+Every adapter declares stable source and adapter IDs, adapter and source-policy
+versions, separate metadata/text/asset permissions, acquisition method,
+attribution, caching, payload retention, transformation, withdrawal and purge
+behavior, credentials, concurrency, request interval, retry ceiling,
+exponential backoff, jitter, `Retry-After`, conditional retrieval, revision
+identity, approval state, disabled reason, and review date.
+
+The shared acquisition layer:
+
+- limits each host to its declared concurrency and minimum request interval;
+- uses injected transports, clocks, sleeps, random values, and caches so tests
+  never call a live provider;
+- distinguishes terminal 4xx responses from retryable 408, 429, and 5xx
+  responses;
+- honors `Retry-After` and otherwise applies bounded exponential backoff and
+  jitter;
+- supports ETag/Last-Modified conditional retrieval and snapshot caches;
+- fails closed on missing credentials or an exhausted retry ceiling; and
+- redacts authorization, cookie, credential, password, secret, token, and API
+  key material from diagnostics.
+
+Raw payloads are retained only when the field-class permission allows `full`
+retention. `selected_fields` stores the normalized selected evidence, while
+`none` stores no payload. A supplied raw payload under a non-full policy fails
+closed. Payloads containing sensitive field names are rejected.
+
+## Source approval matrix
+
+Policy review date is 2026-07-28. Enabled sources are still
+`proposedEvidenceOnly` under #131: their observations may be written only to an
+isolated target, and they cannot create or advance current resolution heads.
+
+| Adapter | State | Metadata | Text | Assets | Operational decision |
+|---|---|---|---|---|---|
+| `bukie.editorial` | enabled | `work.preferred_title` | `work.description` | none | Bukie-owned evidence; internal actor/reason audit required |
+| `wikidata.work-facts` | enabled | `work.preferred_title` candidate | none | none | CC0 structured work facts only; no edition authority and no Wikipedia prose |
+| `open-library.metadata` | pending | none | none | none | Retention, display, and bulk-access policy pending |
+| `open-library.descriptions` | pending | none | none | none | Third-party prose rights policy pending |
+| `open-library.covers` | pending | none | none | none | Identity, caching, transformation, and asset-display policy pending |
+| `google-books` | pending | none | none | none | Caching, branding, quota, retention, and third-party terms pending |
+| `publisher.official` | pending | none | none | none | No approved feed or reusable text/asset license |
+| `worldcat.oclc` | pending | none | none | none | Licensed access and data-use terms pending |
+| `isbn.commercial` | pending | none | none | none | Contract, retention, display, and withdrawal terms pending |
+| `wikipedia.prose` | pending | none | none | none | Attribution, share-alike, copying, spoiler, and drift policy pending |
+| `web-content.retailer-competitor-search` | pending | none | none | none | Scraping and ingestion are prohibited |
+
+The Wikidata policy cites the official
+[licensing](https://www.wikidata.org/wiki/Wikidata:Licensing) and
+[data-access](https://www.wikidata.org/wiki/Wikidata:Data_access) guidance.
+Its policy is reviewed separately from Wikipedia prose.
+
+## Identity, matching, and deterministic evidence
+
+The matcher applies these rules in order:
+
+1. a withdrawn source record produces a withdrawn outcome;
+2. adaptation, translation, edition, or other explicit identity conflicts
+   produce an ambiguous review outcome;
+3. an exact identifier may activate a link;
+4. an existing provider-native work relation may activate a work link;
+5. a strong structured tuple creates a candidate;
+6. normalized title plus ordered creator creates a candidate only; and
+7. title alone remains unmatched.
+
+Wikidata work links never make publisher, page, format, cover, or edition date
+claims authoritative. The current allowed Wikidata field set contains no
+edition fields.
+
+Run, source-snapshot, source-record-revision, proposed-link, and observation
+IDs are deterministic UUIDv5 values. Observation identity includes the source
+record revision, entity, field, and normalized value hash. Duplicate
+source-record revisions in one run fail closed because deterministic identity
+would be ambiguous. Provider response order, input order, and database row
+order are sorted away before hashing.
+
+## Isolated persistence and telemetry
+
+The run artifact contains ADR 0016-compatible metadata-source, source-record,
+source-link, and field-observation rows. Persistence intentionally has no
+field-resolution or field-resolution-head write path. SQLite persistence
+checks the complete current-head hash before and after every transaction.
+
+The structured report distinguishes:
+
+- requested and successful records;
+- cache and conditional hits;
+- latency, retries, status classes, throttling, `Retry-After`, and bytes;
+- source-revision age;
+- unmatched, candidate, ambiguous, active, rejected, and withdrawn links;
+- created, reused, rejected, and omitted observations;
+- policy blocks;
+- acquisition, provider, parsing, and normalization failures; and
+- review-queue candidates.
+
+No external observability vendor is used.
+
+## Disposable five-work proof
+
+Run only against a new or disposable SQLite path accepted by the existing
+catalog rebuild safeguards:
+
+```powershell
+bun run db:catalog:enrichment-sample --target=sqlite:.data/catalog-targets/issue-131-enrichment-test.sqlite --confirm-disposable
+```
+
+The command:
+
+1. creates a five-work-only baseline in the disposable target;
+2. persists the same recorded Bukie editorial and Wikidata fixture revision
+   twice;
+3. verifies the second pass creates no logical rows;
+4. compares complete isolated-enrichment snapshot hashes;
+5. verifies current resolution-head hashes are unchanged; and
+6. reports that no catalog-wide scan, public projection write, pending-provider
+   write, or current-head write occurred.
+
+The recorded fixture currently produces ten source records and links, nine
+immutable observations, and one honest review candidate. *Dune* remains
+ambiguous because same-title adaptations and series results were present; its
+Wikidata observation is omitted rather than hidden with a source-specific
+shortcut.
+
+SQLite/Postgres persistence adapters serialize the recorded fixture to
+equivalent logical rows. Live Postgres rebuild coverage remains gated by the
+existing explicitly isolated `CATALOG_TEST_POSTGRES_URL`; no application or
+preview database is used by this workflow.

--- a/docs/catalog-enrichment.md
+++ b/docs/catalog-enrichment.md
@@ -25,6 +25,13 @@ Requests outside the manifest fail before acquisition or persistence. The
 diagnostic workflow builds its five baseline work rows directly from this
 manifest and never loads or scans the 500-work artifact.
 
+The enrichment engine receives its versioned scope manifest as an input rather
+than importing the diagnostic fixture. The issue #131 command is the only
+executable entry point and always supplies the five-work manifest. A future
+catalog runner can supply reviewed, checkpointed batch manifests without
+changing adapter, matching, normalization, or persistence behavior; that
+catalog-wide execution remains part of #135.
+
 Catalog-wide dry run and promotion remain deferred to #135.
 
 ## Adapter and policy contract

--- a/docs/catalog-enrichment.md
+++ b/docs/catalog-enrichment.md
@@ -111,12 +111,21 @@ source-record revisions in one run fail closed because deterministic identity
 would be ambiguous. Provider response order, input order, and database row
 order are sorted away before hashing.
 
+Composite identities use canonical JSON tuple hashes rather than delimiter-
+joined strings, so provider-controlled record keys and revisions cannot create
+ambiguous identities. Snapshot revision sets are likewise hashed as sorted
+arrays.
+
 ## Isolated persistence and telemetry
 
 The run artifact contains ADR 0016-compatible metadata-source, source-record,
 source-link, and field-observation rows. Persistence intentionally has no
 field-resolution or field-resolution-head write path. SQLite persistence
 checks the complete current-head hash before and after every transaction.
+SQLite and Postgres also compare every reused row with its recorded semantic
+content inside the transaction. Reusing an identity with a different policy,
+source-row hash, link decision, value, or provenance fails closed and rolls
+back the complete run.
 
 The structured report distinguishes:
 
@@ -129,6 +138,13 @@ The structured report distinguishes:
 - policy blocks;
 - acquisition, provider, parsing, and normalization failures; and
 - review-queue candidates.
+
+Acquisition telemetry retains per-attempt status classes and 429 counts,
+including failed retry sequences. Structured failure inputs carry stable
+categories and numeric diagnostics without retaining error text that could
+contain provider payloads or credentials. Persistence reports created and
+reused rows separately; rejected and omitted observations are distinguished in
+the deterministic run report.
 
 No external observability vendor is used.
 

--- a/docs/catalog-rebuild.md
+++ b/docs/catalog-rebuild.md
@@ -136,6 +136,22 @@ verified multi-edition grouping, missing identifiers and metadata, compatible
 and conflicting partial dates, stale and withdrawn evidence, uncertain
 same-title matches, reusable covers and synthetic fallback fields.
 
+## Five-work enrichment rehearsal
+
+Issue #131's enrichment workflow is separate from the 500-record rebuild. It
+constructs only the explicit diagnostic-five baseline and writes proposed
+source records, links, and observations without changing resolution heads:
+
+```powershell
+bun run db:catalog:enrichment-sample --target=sqlite:.data/catalog-targets/issue-131-enrichment-test.sqlite --confirm-disposable
+```
+
+The command uses the same target safety checks as this rebuild, processes the
+recorded fixture twice, and fails when the second logical snapshot or the
+current-head hash differs. See
+[catalog-enrichment.md](./catalog-enrichment.md) for adapter policies and the
+five-work execution boundary.
+
 ## Validation
 
 Run:

--- a/docs/database-architecture.md
+++ b/docs/database-architecture.md
@@ -96,6 +96,13 @@ resolution heads, and the existing display-eligibility checks. Dry runs write
 to an isolated disposable target and cannot update current heads, projections,
 or cover pointers.
 
+The issue #131
+[policy-gated adapter foundation](./catalog-enrichment.md) implements that
+isolated proposed-evidence boundary for the versioned five-work diagnostic
+manifest. It registers only Bukie editorial and Wikidata work-fact adapters as
+enabled, keeps every other researched provider pending, and exposes no current
+resolution-head write path.
+
 ## Initialization
 
 `bun run db:init` migrates and idempotently imports the deterministic artifact

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@
 - Media storage - `media-storage.md`
 - Adding book covers - `adding-covers.md`
 - Book-detail enrichment benchmark - `research/book-detail-enrichment.md`
+- Policy-gated catalog enrichment - `catalog-enrichment.md`
 - Testing - `testing.md`
 - Release automation - `release-automation.md`
 - Design system - `design-system/README.md`

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "db:reset": "bun ./scripts/db/reset.ts",
     "db:reseed": "bun run db:reset && bun run db:init",
     "db:catalog:rebuild": "bunx tsx ./scripts/db/rebuild-catalog.ts",
+    "db:catalog:enrichment-sample": "bunx tsx ./scripts/db/run-enrichment-sample.ts",
     "lint": "bunx @biomejs/biome check --no-errors-on-unmatched .",
     "lint:fix": "bunx @biomejs/biome check --write --no-errors-on-unmatched .",
     "release": "semantic-release",

--- a/scripts/db/run-enrichment-sample.ts
+++ b/scripts/db/run-enrichment-sample.ts
@@ -31,6 +31,7 @@ if (target.driver !== "sqlite") {
 const workIds = ENRICHMENT_SAMPLE_MANIFEST.works.map((work) => work.workId);
 const graph = buildCatalogImportGraph(SAMPLE_BASELINE_IMPORT_RECORDS);
 const run = buildEnrichmentRun({
+  manifest: ENRICHMENT_SAMPLE_MANIFEST,
   requestedWorkIds: workIds,
   records: SAMPLE_PROVIDER_RECORDS,
 });

--- a/scripts/db/run-enrichment-sample.ts
+++ b/scripts/db/run-enrichment-sample.ts
@@ -1,0 +1,75 @@
+import {
+  enrichmentSqliteSnapshot,
+  persistEnrichmentRunSqlite,
+} from "@/db/catalog/enrichment/persistence";
+import {
+  SAMPLE_BASELINE_IMPORT_RECORDS,
+  SAMPLE_PROVIDER_RECORDS,
+} from "@/db/catalog/enrichment/fixtures";
+import { ENRICHMENT_SAMPLE_MANIFEST } from "@/db/catalog/enrichment/sample-manifest";
+import { buildEnrichmentRun } from "@/db/catalog/enrichment/workflow";
+import { buildCatalogImportGraph } from "@/db/catalog/importer";
+import { resolveRebuildTarget } from "@/db/catalog/rebuild-safety";
+import {
+  openCatalogSqlite,
+  rebuildCatalogSqlite,
+} from "@/db/catalog/sqlite-rebuild";
+
+const rawTarget = process.argv
+  .find((argument) => argument.startsWith("--target="))
+  ?.slice("--target=".length);
+const target = resolveRebuildTarget({
+  rawTarget,
+  confirmDisposable: process.argv.includes("--confirm-disposable"),
+});
+if (target.driver !== "sqlite") {
+  throw new Error(
+    "The issue #131 diagnostic workflow currently accepts disposable SQLite targets only",
+  );
+}
+
+const workIds = ENRICHMENT_SAMPLE_MANIFEST.works.map((work) => work.workId);
+const graph = buildCatalogImportGraph(SAMPLE_BASELINE_IMPORT_RECORDS);
+const run = buildEnrichmentRun({
+  requestedWorkIds: workIds,
+  records: SAMPLE_PROVIDER_RECORDS,
+});
+
+rebuildCatalogSqlite({ sqlitePath: target.path, graph });
+const { raw } = openCatalogSqlite(target.path);
+try {
+  const first = persistEnrichmentRunSqlite(raw, run);
+  const firstSnapshot = enrichmentSqliteSnapshot(raw, run);
+  const second = persistEnrichmentRunSqlite(raw, run);
+  const secondSnapshot = enrichmentSqliteSnapshot(raw, run);
+  if (firstSnapshot.hash !== secondSnapshot.hash) {
+    throw new Error("Enrichment sample rerun was not logically stable");
+  }
+  if (first.currentHeadHash !== second.currentHeadHash) {
+    throw new Error("Enrichment sample changed current resolution heads");
+  }
+  console.log(
+    JSON.stringify(
+      {
+        target: target.description,
+        manifest: `${run.manifestId}@${run.manifestVersion}`,
+        requestedWorkIds: run.requestedWorkIds,
+        contentHash: run.contentHash,
+        snapshotHash: secondSnapshot.hash,
+        first,
+        second,
+        report: run.report,
+        safeguards: {
+          catalogWideScan: false,
+          publicProjectionWrites: false,
+          currentResolutionHeadWrites: false,
+          pendingProviderWrites: false,
+        },
+      },
+      null,
+      2,
+    ),
+  );
+} finally {
+  raw.close();
+}

--- a/src/db/catalog/enrichment/acquisition.test.ts
+++ b/src/db/catalog/enrichment/acquisition.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it } from "vitest";
+import {
+  type AcquisitionResponse,
+  acquireRecord,
+  acquireRecords,
+  sanitizeDiagnostic,
+} from "./acquisition";
+import { PENDING_ADAPTERS, WIKIDATA_WORK_FACTS_ADAPTER } from "./policies";
+
+const okResponse = (
+  overrides: Partial<AcquisitionResponse> = {},
+): AcquisitionResponse => ({
+  status: 200,
+  headers: {},
+  body: '{"ok":true}',
+  latencyMs: 5,
+  ...overrides,
+});
+
+const wikidataRequest = (url: string) => ({
+  url,
+  fieldClass: "metadata" as const,
+  fieldKey: "work.preferred_title" as const,
+});
+
+describe("provider-neutral acquisition resilience", () => {
+  it("honors Retry-After, exponential backoff, jitter configuration, and retry ceiling", async () => {
+    const responses = [
+      okResponse({
+        status: 429,
+        headers: { "Retry-After": "2" },
+        body: "",
+      }),
+      okResponse({ status: 503, body: "" }),
+      okResponse(),
+    ];
+    const sleeps: number[] = [];
+    const result = await acquireRecord({
+      adapter: WIKIDATA_WORK_FACTS_ADAPTER,
+      request: wikidataRequest(
+        "https://www.wikidata.org/wiki/Special:EntityData/Q1.json",
+      ),
+      dependencies: {
+        transport: async () => responses.shift() ?? okResponse(),
+        sleep: async (milliseconds) => {
+          sleeps.push(milliseconds);
+        },
+        now: () => 0,
+        random: () => 0.5,
+      },
+    });
+    expect(result).toMatchObject({
+      retries: 2,
+      throttled: true,
+      retryAfterMs: 2_000,
+      responseBytes: Buffer.byteLength('{"ok":true}'),
+    });
+    expect(sleeps).toEqual([2_000, 2_200]);
+  });
+
+  it("uses conditional retrieval and returns the cached body on 304", async () => {
+    const headers: Record<string, string> = {};
+    const result = await acquireRecord({
+      adapter: WIKIDATA_WORK_FACTS_ADAPTER,
+      request: wikidataRequest(
+        "https://www.wikidata.org/wiki/Special:EntityData/Q1.json",
+      ),
+      dependencies: {
+        cache: {
+          get: async () => ({
+            ...okResponse({ body: '{"cached":true}' }),
+            etag: '"fixture-etag"',
+            lastModified: "Tue, 28 Jul 2026 12:00:00 GMT",
+          }),
+          set: async () => undefined,
+        },
+        transport: async (request) => {
+          Object.assign(headers, request.headers);
+          return okResponse({ status: 304, body: "" });
+        },
+      },
+    });
+    expect(headers).toMatchObject({
+      "If-None-Match": '"fixture-etag"',
+      "If-Modified-Since": "Tue, 28 Jul 2026 12:00:00 GMT",
+    });
+    expect(result).toMatchObject({
+      cacheHit: true,
+      conditionalHit: true,
+      responseBytes: 0,
+    });
+    expect(result.response.body).toBe('{"cached":true}');
+  });
+
+  it("distinguishes terminal and retry-exhausted failures", async () => {
+    await expect(
+      acquireRecord({
+        adapter: WIKIDATA_WORK_FACTS_ADAPTER,
+        request: wikidataRequest("https://www.wikidata.org/missing"),
+        dependencies: {
+          transport: async () => okResponse({ status: 404 }),
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: "terminal_failure",
+    });
+    await expect(
+      acquireRecord({
+        adapter: {
+          ...WIKIDATA_WORK_FACTS_ADAPTER,
+          acquisition: {
+            ...WIKIDATA_WORK_FACTS_ADAPTER.acquisition,
+            retry: {
+              ...WIKIDATA_WORK_FACTS_ADAPTER.acquisition.retry,
+              ceiling: 1,
+            },
+          },
+        },
+        request: wikidataRequest("https://www.wikidata.org/unavailable"),
+        dependencies: {
+          transport: async () => okResponse({ status: 503 }),
+          sleep: async () => undefined,
+          random: () => 0,
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: "retry_exhausted",
+    });
+  });
+
+  it("fails closed for disablement and missing credentials", async () => {
+    await expect(
+      acquireRecord({
+        adapter: PENDING_ADAPTERS[0],
+        request: {
+          url: "https://openlibrary.org/works/OL1W.json",
+          fieldClass: "metadata",
+          fieldKey: "work.preferred_title",
+        },
+        dependencies: { transport: async () => okResponse() },
+      }),
+    ).rejects.toMatchObject({
+      code: "adapter_disabled",
+    });
+    await expect(
+      acquireRecord({
+        adapter: {
+          ...WIKIDATA_WORK_FACTS_ADAPTER,
+          acquisition: {
+            ...WIKIDATA_WORK_FACTS_ADAPTER.acquisition,
+            credentials: ["WIKIDATA_TOKEN"],
+          },
+        },
+        request: wikidataRequest(
+          "https://www.wikidata.org/wiki/Special:EntityData/Q1.json",
+        ),
+        dependencies: { transport: async () => okResponse() },
+      }),
+    ).rejects.toMatchObject({
+      code: "credentials_missing",
+    });
+  });
+
+  it("fails closed for undeclared hosts and field-policy bypasses", async () => {
+    await expect(
+      acquireRecord({
+        adapter: WIKIDATA_WORK_FACTS_ADAPTER,
+        request: wikidataRequest("https://example.com/Q190192"),
+        dependencies: { transport: async () => okResponse() },
+      }),
+    ).rejects.toMatchObject({ code: "host_not_allowed" });
+    await expect(
+      acquireRecord({
+        adapter: WIKIDATA_WORK_FACTS_ADAPTER,
+        request: {
+          url: "https://www.wikidata.org/wiki/Special:EntityData/Q190192.json",
+          fieldClass: "asset",
+          fieldKey: "edition.covers",
+        },
+        dependencies: { transport: async () => okResponse() },
+      }),
+    ).rejects.toThrow("may not acquire asset field edition.covers");
+  });
+
+  it("applies per-host request intervals across a bounded batch", async () => {
+    let clock = 0;
+    const starts: number[] = [];
+    const adapter = {
+      ...WIKIDATA_WORK_FACTS_ADAPTER,
+      acquisition: {
+        ...WIKIDATA_WORK_FACTS_ADAPTER.acquisition,
+        perHostConcurrency: 2,
+        minimumIntervalMs: 10,
+      },
+    };
+    const results = await acquireRecords({
+      adapter,
+      requests: [
+        wikidataRequest(
+          "https://www.wikidata.org/wiki/Special:EntityData/Q1.json",
+        ),
+        wikidataRequest(
+          "https://www.wikidata.org/wiki/Special:EntityData/Q2.json",
+        ),
+        wikidataRequest(
+          "https://www.wikidata.org/wiki/Special:EntityData/Q3.json",
+        ),
+      ],
+      dependencies: {
+        now: () => clock,
+        sleep: async (milliseconds) => {
+          clock += milliseconds;
+        },
+        transport: async () => {
+          starts.push(clock);
+          return okResponse();
+        },
+      },
+    });
+    expect(results).toHaveLength(3);
+    expect(starts).toEqual([0, 10, 20]);
+  });
+
+  it("never exceeds the declared per-host concurrency", async () => {
+    let active = 0;
+    let maximumActive = 0;
+    let release: () => void = () => undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let twoStarted: () => void = () => undefined;
+    const started = new Promise<void>((resolve) => {
+      twoStarted = resolve;
+    });
+    const adapter = {
+      ...WIKIDATA_WORK_FACTS_ADAPTER,
+      acquisition: {
+        ...WIKIDATA_WORK_FACTS_ADAPTER.acquisition,
+        perHostConcurrency: 2,
+        minimumIntervalMs: 0,
+      },
+    };
+    const pending = acquireRecords({
+      adapter,
+      requests: [
+        wikidataRequest(
+          "https://www.wikidata.org/wiki/Special:EntityData/Q1.json",
+        ),
+        wikidataRequest(
+          "https://www.wikidata.org/wiki/Special:EntityData/Q2.json",
+        ),
+        wikidataRequest(
+          "https://www.wikidata.org/wiki/Special:EntityData/Q3.json",
+        ),
+      ],
+      dependencies: {
+        transport: async () => {
+          active += 1;
+          maximumActive = Math.max(maximumActive, active);
+          if (active === 2) twoStarted();
+          await gate;
+          active -= 1;
+          return okResponse();
+        },
+      },
+    });
+    await started;
+    expect(maximumActive).toBe(2);
+    release();
+    await expect(pending).resolves.toHaveLength(3);
+    expect(maximumActive).toBe(2);
+  });
+
+  it("redacts common secret-bearing fields and values", () => {
+    expect(
+      sanitizeDiagnostic({
+        authorization: "Bearer super-secret",
+        nested: {
+          apiKey: "abc123",
+          message: "token=abc123&status=failed",
+        },
+      }),
+    ).toEqual({
+      authorization: "[REDACTED]",
+      nested: {
+        apiKey: "[REDACTED]",
+        message: "token=[REDACTED]&status=failed",
+      },
+    });
+  });
+});

--- a/src/db/catalog/enrichment/acquisition.test.ts
+++ b/src/db/catalog/enrichment/acquisition.test.ts
@@ -52,8 +52,16 @@ describe("provider-neutral acquisition resilience", () => {
     expect(result).toMatchObject({
       retries: 2,
       throttled: true,
+      throttles: 1,
       retryAfterMs: 2_000,
       responseBytes: Buffer.byteLength('{"ok":true}'),
+      statusClasses: {
+        "2xx": 1,
+        "3xx": 0,
+        "4xx": 1,
+        "5xx": 1,
+        other: 0,
+      },
     });
     expect(sleeps).toEqual([2_000, 2_200]);
   });
@@ -88,6 +96,13 @@ describe("provider-neutral acquisition resilience", () => {
       cacheHit: true,
       conditionalHit: true,
       responseBytes: 0,
+      statusClasses: {
+        "2xx": 0,
+        "3xx": 1,
+        "4xx": 0,
+        "5xx": 0,
+        other: 0,
+      },
     });
     expect(result.response.body).toBe('{"cached":true}');
   });
@@ -103,6 +118,17 @@ describe("provider-neutral acquisition resilience", () => {
       }),
     ).rejects.toMatchObject({
       code: "terminal_failure",
+      telemetry: {
+        retries: 0,
+        throttles: 0,
+        statusClasses: {
+          "2xx": 0,
+          "3xx": 0,
+          "4xx": 1,
+          "5xx": 0,
+          other: 0,
+        },
+      },
     });
     await expect(
       acquireRecord({
@@ -125,6 +151,17 @@ describe("provider-neutral acquisition resilience", () => {
       }),
     ).rejects.toMatchObject({
       code: "retry_exhausted",
+      telemetry: {
+        retries: 1,
+        throttles: 0,
+        statusClasses: {
+          "2xx": 0,
+          "3xx": 0,
+          "4xx": 0,
+          "5xx": 2,
+          other: 0,
+        },
+      },
     });
   });
 

--- a/src/db/catalog/enrichment/acquisition.ts
+++ b/src/db/catalog/enrichment/acquisition.ts
@@ -1,7 +1,11 @@
 import { sha256 } from "../identity";
 import type { CatalogFieldKey } from "../values";
 import { assertAdapterEnabled, authorizeField } from "./policies";
-import type { AdapterManifest, EnrichmentFieldClass } from "./types";
+import type {
+  AcquisitionStatusClass,
+  AdapterManifest,
+  EnrichmentFieldClass,
+} from "./types";
 
 const SENSITIVE_KEY =
   /authorization|cookie|credential|password|secret|token|api[-_]?key/i;
@@ -32,8 +36,17 @@ export type AcquisitionResult = {
   conditionalHit: boolean;
   retries: number;
   throttled: boolean;
+  throttles: number;
   retryAfterMs: number;
   responseBytes: number;
+  statusClasses: Record<AcquisitionStatusClass, number>;
+};
+
+export type AcquisitionFailureTelemetry = {
+  retries: number;
+  throttles: number;
+  retryAfterMs: number;
+  statusClasses: Record<AcquisitionStatusClass, number>;
 };
 
 export type AcquisitionDependencies = {
@@ -55,11 +68,22 @@ export class AcquisitionError extends Error {
     | "host_not_allowed"
     | "retry_exhausted"
     | "terminal_failure";
+  readonly telemetry: AcquisitionFailureTelemetry;
 
-  constructor(code: AcquisitionError["code"], message: string) {
+  constructor(
+    code: AcquisitionError["code"],
+    message: string,
+    telemetry: AcquisitionFailureTelemetry = {
+      retries: 0,
+      throttles: 0,
+      retryAfterMs: 0,
+      statusClasses: emptyStatusClasses(),
+    },
+  ) {
     super(message);
     this.name = "AcquisitionError";
     this.code = code;
+    this.telemetry = telemetry;
   }
 }
 
@@ -105,12 +129,22 @@ function retryableStatus(status: number): boolean {
   return status === 408 || status === 429 || status >= 500;
 }
 
-function statusClass(status: number): string {
+function statusClass(status: number): AcquisitionStatusClass {
   if (status >= 200 && status < 300) return "2xx";
   if (status >= 300 && status < 400) return "3xx";
   if (status >= 400 && status < 500) return "4xx";
   if (status >= 500 && status < 600) return "5xx";
   return "other";
+}
+
+function emptyStatusClasses(): Record<AcquisitionStatusClass, number> {
+  return {
+    "2xx": 0,
+    "3xx": 0,
+    "4xx": 0,
+    "5xx": 0,
+    other: 0,
+  };
 }
 
 function assertCredentials(
@@ -185,6 +219,7 @@ export async function acquireRecord(input: {
       ? await dependencies.cache.get(cacheKey)
       : undefined;
   const requestHeaders: Record<string, string> = { ...request.headers };
+  const statusClasses = emptyStatusClasses();
   if (
     cached &&
     adapter.acquisition.conditionalRetrieval === "etag_and_last_modified"
@@ -203,19 +238,27 @@ export async function acquireRecord(input: {
       conditionalHit: false,
       retries: 0,
       throttled: false,
+      throttles: 0,
       retryAfterMs: 0,
       responseBytes: Buffer.byteLength(cached.body),
+      statusClasses,
     };
   }
 
   let retries = 0;
   let throttled = false;
+  let throttles = 0;
   let retryAfterMs = 0;
   while (true) {
     const response = await dependencies.transport({
       ...request,
       headers: requestHeaders,
     });
+    statusClasses[statusClass(response.status)] += 1;
+    if (response.status === 429) {
+      throttled = true;
+      throttles += 1;
+    }
     if (response.status === 304 && cached) {
       return {
         response: cached,
@@ -223,8 +266,10 @@ export async function acquireRecord(input: {
         conditionalHit: true,
         retries,
         throttled,
+        throttles,
         retryAfterMs,
         responseBytes: 0,
+        statusClasses,
       };
     }
     if (response.status >= 200 && response.status < 300) {
@@ -242,25 +287,28 @@ export async function acquireRecord(input: {
         conditionalHit: false,
         retries,
         throttled,
+        throttles,
         retryAfterMs,
         responseBytes: Buffer.byteLength(response.body),
+        statusClasses,
       };
     }
     if (!retryableStatus(response.status)) {
       throw new AcquisitionError(
         "terminal_failure",
         `Provider request failed with terminal ${statusClass(response.status)} response`,
+        { retries, throttles, retryAfterMs, statusClasses },
       );
     }
     if (retries >= adapter.acquisition.retry.ceiling) {
       throw new AcquisitionError(
         "retry_exhausted",
         `Provider request exhausted the retry ceiling after ${retries} retries`,
+        { retries, throttles, retryAfterMs, statusClasses },
       );
     }
     const retryNumber = retries;
     retries += 1;
-    if (response.status === 429) throttled = true;
     const providerDelay = adapter.acquisition.retry.respectRetryAfter
       ? parseRetryAfter(header(response.headers, "retry-after"), now())
       : null;

--- a/src/db/catalog/enrichment/acquisition.ts
+++ b/src/db/catalog/enrichment/acquisition.ts
@@ -1,0 +1,320 @@
+import { sha256 } from "../identity";
+import type { CatalogFieldKey } from "../values";
+import { assertAdapterEnabled, authorizeField } from "./policies";
+import type { AdapterManifest, EnrichmentFieldClass } from "./types";
+
+const SENSITIVE_KEY =
+  /authorization|cookie|credential|password|secret|token|api[-_]?key/i;
+
+export type AcquisitionRequest = {
+  url: string;
+  fieldClass: EnrichmentFieldClass;
+  fieldKey: CatalogFieldKey;
+  headers?: Readonly<Record<string, string>>;
+  cacheKey?: string;
+};
+
+export type AcquisitionResponse = {
+  status: number;
+  headers: Readonly<Record<string, string | undefined>>;
+  body: string;
+  latencyMs: number;
+};
+
+export type CachedResponse = AcquisitionResponse & {
+  etag?: string;
+  lastModified?: string;
+};
+
+export type AcquisitionResult = {
+  response: AcquisitionResponse;
+  cacheHit: boolean;
+  conditionalHit: boolean;
+  retries: number;
+  throttled: boolean;
+  retryAfterMs: number;
+  responseBytes: number;
+};
+
+export type AcquisitionDependencies = {
+  transport: (request: AcquisitionRequest) => Promise<AcquisitionResponse>;
+  cache?: {
+    get(key: string): Promise<CachedResponse | undefined>;
+    set(key: string, response: CachedResponse): Promise<void>;
+  };
+  sleep?: (milliseconds: number) => Promise<void>;
+  now?: () => number;
+  random?: () => number;
+  credentials?: Readonly<Record<string, string | undefined>>;
+};
+
+export class AcquisitionError extends Error {
+  readonly code:
+    | "adapter_disabled"
+    | "credentials_missing"
+    | "host_not_allowed"
+    | "retry_exhausted"
+    | "terminal_failure";
+
+  constructor(code: AcquisitionError["code"], message: string) {
+    super(message);
+    this.name = "AcquisitionError";
+    this.code = code;
+  }
+}
+
+export function sanitizeDiagnostic(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sanitizeDiagnostic);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [
+        key,
+        SENSITIVE_KEY.test(key) ? "[REDACTED]" : sanitizeDiagnostic(entry),
+      ]),
+    );
+  }
+  if (typeof value !== "string") return value;
+  return value
+    .replace(/\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+/gi, "$1 [REDACTED]")
+    .replace(
+      /\b(api[-_]?key|password|secret|token)=([^&\s]+)/gi,
+      "$1=[REDACTED]",
+    );
+}
+
+function header(
+  headers: Readonly<Record<string, string | undefined>>,
+  name: string,
+): string | undefined {
+  const entry = Object.entries(headers).find(
+    ([key]) => key.toLowerCase() === name.toLowerCase(),
+  );
+  return entry?.[1];
+}
+
+function parseRetryAfter(raw: string | undefined, now: number): number | null {
+  if (!raw) return null;
+  const seconds = Number(raw);
+  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1_000;
+  const date = Date.parse(raw);
+  if (Number.isNaN(date)) return null;
+  return Math.max(0, date - now);
+}
+
+function retryableStatus(status: number): boolean {
+  return status === 408 || status === 429 || status >= 500;
+}
+
+function statusClass(status: number): string {
+  if (status >= 200 && status < 300) return "2xx";
+  if (status >= 300 && status < 400) return "3xx";
+  if (status >= 400 && status < 500) return "4xx";
+  if (status >= 500 && status < 600) return "5xx";
+  return "other";
+}
+
+function assertCredentials(
+  adapter: AdapterManifest,
+  credentials: AcquisitionDependencies["credentials"],
+) {
+  const missing = adapter.acquisition.credentials.filter(
+    (key) => !credentials?.[key],
+  );
+  if (missing.length) {
+    throw new AcquisitionError(
+      "credentials_missing",
+      `Acquisition refused: required credentials are missing for ${adapter.adapterId}`,
+    );
+  }
+}
+
+export async function acquireRecord(input: {
+  adapter: AdapterManifest;
+  request: AcquisitionRequest;
+  dependencies: AcquisitionDependencies;
+}): Promise<AcquisitionResult> {
+  const { adapter, request, dependencies } = input;
+  try {
+    assertAdapterEnabled(adapter);
+  } catch {
+    throw new AcquisitionError(
+      "adapter_disabled",
+      `Acquisition refused: ${adapter.adapterId} is not enabled`,
+    );
+  }
+  assertCredentials(adapter, dependencies.credentials);
+  const permission = authorizeField({
+    adapter,
+    fieldClass: request.fieldClass,
+    fieldKey: request.fieldKey,
+  });
+  if (adapter.acquisition.method === "disabled") {
+    throw new AcquisitionError(
+      "adapter_disabled",
+      `Acquisition refused: ${adapter.adapterId} has no approved acquisition method`,
+    );
+  }
+  if (adapter.acquisition.host) {
+    let requestHost: string;
+    try {
+      requestHost = new URL(request.url).hostname;
+    } catch {
+      throw new AcquisitionError(
+        "host_not_allowed",
+        `Acquisition refused: ${adapter.adapterId} received an invalid URL`,
+      );
+    }
+    if (requestHost !== adapter.acquisition.host) {
+      throw new AcquisitionError(
+        "host_not_allowed",
+        `Acquisition refused: ${adapter.adapterId} may access only its declared host`,
+      );
+    }
+  }
+
+  const sleep =
+    dependencies.sleep ??
+    ((milliseconds: number) =>
+      new Promise<void>((resolve) => setTimeout(resolve, milliseconds)));
+  const now = dependencies.now ?? Date.now;
+  const random = dependencies.random ?? Math.random;
+  const cacheKey = request.cacheKey ?? sha256(request.url);
+  const cacheAllowed = adapter.acquisition.cache && permission.cache;
+  const cached =
+    cacheAllowed && dependencies.cache
+      ? await dependencies.cache.get(cacheKey)
+      : undefined;
+  const requestHeaders: Record<string, string> = { ...request.headers };
+  if (
+    cached &&
+    adapter.acquisition.conditionalRetrieval === "etag_and_last_modified"
+  ) {
+    if (cached.etag) requestHeaders["If-None-Match"] = cached.etag;
+    if (cached.lastModified) {
+      requestHeaders["If-Modified-Since"] = cached.lastModified;
+    }
+  } else if (
+    cached &&
+    adapter.acquisition.conditionalRetrieval === "snapshot"
+  ) {
+    return {
+      response: cached,
+      cacheHit: true,
+      conditionalHit: false,
+      retries: 0,
+      throttled: false,
+      retryAfterMs: 0,
+      responseBytes: Buffer.byteLength(cached.body),
+    };
+  }
+
+  let retries = 0;
+  let throttled = false;
+  let retryAfterMs = 0;
+  while (true) {
+    const response = await dependencies.transport({
+      ...request,
+      headers: requestHeaders,
+    });
+    if (response.status === 304 && cached) {
+      return {
+        response: cached,
+        cacheHit: true,
+        conditionalHit: true,
+        retries,
+        throttled,
+        retryAfterMs,
+        responseBytes: 0,
+      };
+    }
+    if (response.status >= 200 && response.status < 300) {
+      const stored: CachedResponse = {
+        ...response,
+        etag: header(response.headers, "etag"),
+        lastModified: header(response.headers, "last-modified"),
+      };
+      if (cacheAllowed && dependencies.cache) {
+        await dependencies.cache.set(cacheKey, stored);
+      }
+      return {
+        response,
+        cacheHit: false,
+        conditionalHit: false,
+        retries,
+        throttled,
+        retryAfterMs,
+        responseBytes: Buffer.byteLength(response.body),
+      };
+    }
+    if (!retryableStatus(response.status)) {
+      throw new AcquisitionError(
+        "terminal_failure",
+        `Provider request failed with terminal ${statusClass(response.status)} response`,
+      );
+    }
+    if (retries >= adapter.acquisition.retry.ceiling) {
+      throw new AcquisitionError(
+        "retry_exhausted",
+        `Provider request exhausted the retry ceiling after ${retries} retries`,
+      );
+    }
+    const retryNumber = retries;
+    retries += 1;
+    if (response.status === 429) throttled = true;
+    const providerDelay = adapter.acquisition.retry.respectRetryAfter
+      ? parseRetryAfter(header(response.headers, "retry-after"), now())
+      : null;
+    const exponential = Math.min(
+      adapter.acquisition.retry.maximumDelayMs,
+      adapter.acquisition.retry.baseDelayMs * 2 ** retryNumber,
+    );
+    const jitter =
+      exponential * adapter.acquisition.retry.jitterRatio * random();
+    const delay = Math.max(providerDelay ?? 0, exponential + jitter);
+    retryAfterMs += providerDelay ?? 0;
+    await sleep(delay);
+  }
+}
+
+export async function acquireRecords(input: {
+  adapter: AdapterManifest;
+  requests: readonly AcquisitionRequest[];
+  dependencies: AcquisitionDependencies;
+}): Promise<AcquisitionResult[]> {
+  const { adapter, requests, dependencies } = input;
+  assertAdapterEnabled(adapter);
+  const concurrency = adapter.acquisition.perHostConcurrency;
+  const sleep =
+    dependencies.sleep ??
+    ((milliseconds: number) =>
+      new Promise<void>((resolve) => setTimeout(resolve, milliseconds)));
+  const now = dependencies.now ?? Date.now;
+  let nextIndex = 0;
+  let nextStartAt = 0;
+  const results = new Array<AcquisitionResult>(requests.length);
+
+  async function worker() {
+    while (true) {
+      const index = nextIndex;
+      nextIndex += 1;
+      const request = requests[index];
+      if (!request) return;
+      const reservedStart = Math.max(now(), nextStartAt);
+      nextStartAt = reservedStart + adapter.acquisition.minimumIntervalMs;
+      const delay = reservedStart - now();
+      if (delay > 0) await sleep(delay);
+      results[index] = await acquireRecord({
+        adapter,
+        request,
+        dependencies: { ...dependencies, sleep, now },
+      });
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, requests.length) }, () =>
+      worker(),
+    ),
+  );
+  return results;
+}

--- a/src/db/catalog/enrichment/fixtures.ts
+++ b/src/db/catalog/enrichment/fixtures.ts
@@ -1,0 +1,89 @@
+import type { CatalogImportRecord } from "../importer";
+import { ENRICHMENT_SAMPLE_MANIFEST } from "./sample-manifest";
+import type { ProviderRecord } from "./types";
+
+export const SAMPLE_BASELINE_IMPORT_RECORDS: CatalogImportRecord[] =
+  ENRICHMENT_SAMPLE_MANIFEST.works.map((work) => ({
+    sourceKey: "legacy_catalog",
+    recordKey: work.legacyRecordKey,
+    title: work.title,
+    authors: work.orderedCreators.map((name) => ({ name })),
+    categories: [],
+    isbn:
+      work.exactIdentifiers
+        .find((identifier) => identifier.startsWith("isbn13:"))
+        ?.slice("isbn13:".length) ?? undefined,
+  }));
+
+const RETRIEVED_AT = Date.UTC(2026, 6, 28, 12, 0, 0);
+
+export const SAMPLE_PROVIDER_RECORDS: ProviderRecord[] =
+  ENRICHMENT_SAMPLE_MANIFEST.works.flatMap((work, index) => {
+    const wikidataId = work.providerRelations.wikidata;
+    const editorial: ProviderRecord = {
+      adapterId: "bukie.editorial",
+      recordKey: `editorial:${work.workId}`,
+      sourceRevision: "diagnostic-five-editorial-v1",
+      retrievedAt: RETRIEVED_AT,
+      targetWorkId: work.workId,
+      title: work.title,
+      orderedCreators: work.orderedCreators,
+      evidence: [
+        {
+          fieldClass: "metadata",
+          fieldKey: "work.preferred_title",
+          value: work.title,
+          sourcePath: "title",
+          provenanceKind: "curated",
+          actorRef: "system:diagnostic-five-fixture",
+          reason: "Bukie-owned diagnostic evidence fixture",
+        },
+      ],
+      acquisition: {
+        successful: true,
+        cacheHit: true,
+        latencyMs: 0,
+        retries: 0,
+        status: 200,
+        responseBytes: 0,
+      },
+    };
+    const wikidata: ProviderRecord = {
+      adapterId: "wikidata.work-facts",
+      recordKey: wikidataId,
+      sourceRevision: `recorded-search-2026-07-28:${wikidataId}`,
+      retrievedAt: RETRIEVED_AT + index,
+      targetWorkId: work.workId,
+      title: work.title,
+      orderedCreators: work.orderedCreators,
+      providerWorkId: wikidataId,
+      identityConflicts:
+        work.title === "Dune"
+          ? ["same-title adaptations and series appeared ahead of the novel"]
+          : undefined,
+      evidence: [
+        {
+          fieldClass: "metadata",
+          fieldKey: "work.preferred_title",
+          value: work.title,
+          sourcePath: "labels.en.value",
+          provenanceKind: "imported",
+        },
+      ],
+      rawPayload: {
+        id: wikidataId,
+        label: work.title,
+        recordedFixture: true,
+      },
+      acquisition: {
+        successful: true,
+        cacheHit: false,
+        conditionalHit: false,
+        latencyMs: 20 + index,
+        retries: 0,
+        status: 200,
+        responseBytes: 100 + index,
+      },
+    };
+    return [editorial, wikidata];
+  });

--- a/src/db/catalog/enrichment/matching.ts
+++ b/src/db/catalog/enrichment/matching.ts
@@ -1,9 +1,9 @@
 import { normalizeSortText } from "../normalize";
 import type {
   AdapterManifest,
+  EnrichmentTargetWork,
   MatchDecision,
   ProviderRecord,
-  SampleWork,
 } from "./types";
 
 function sameOrderedCreators(
@@ -20,7 +20,7 @@ function sameOrderedCreators(
 export function matchProviderRecord(input: {
   adapter: AdapterManifest;
   record: ProviderRecord;
-  target: SampleWork;
+  target: EnrichmentTargetWork;
 }): MatchDecision {
   const { adapter, record, target } = input;
   if (record.state === "withdrawn") {

--- a/src/db/catalog/enrichment/matching.ts
+++ b/src/db/catalog/enrichment/matching.ts
@@ -1,0 +1,147 @@
+import { normalizeSortText } from "../normalize";
+import type {
+  AdapterManifest,
+  MatchDecision,
+  ProviderRecord,
+  SampleWork,
+} from "./types";
+
+function sameOrderedCreators(
+  left: readonly string[] | undefined,
+  right: readonly string[],
+): boolean {
+  if (!left || left.length !== right.length) return false;
+  return left.every(
+    (creator, index) =>
+      normalizeSortText(creator) === normalizeSortText(right[index] ?? ""),
+  );
+}
+
+export function matchProviderRecord(input: {
+  adapter: AdapterManifest;
+  record: ProviderRecord;
+  target: SampleWork;
+}): MatchDecision {
+  const { adapter, record, target } = input;
+  if (record.state === "withdrawn") {
+    return {
+      outcome: "withdrawn",
+      matchKind: "candidate",
+      mappingConfidence: 0,
+      reason: "Source record is withdrawn",
+    };
+  }
+  if (record.rejectedReason?.trim()) {
+    return {
+      outcome: "rejected",
+      matchKind: "candidate",
+      mappingConfidence: 0,
+      reason: record.rejectedReason.trim(),
+    };
+  }
+  if (record.identityConflicts?.length) {
+    return {
+      outcome: "ambiguous",
+      matchKind: "candidate",
+      mappingConfidence: 0.5,
+      reason: `Identity conflict requires review: ${[
+        ...record.identityConflicts,
+      ]
+        .sort()
+        .join("; ")}`,
+    };
+  }
+  if (
+    adapter.sourceKey === "bukie_editorial" &&
+    record.targetWorkId === target.workId
+  ) {
+    return {
+      outcome: "active",
+      matchKind: "curated",
+      mappingConfidence: 1,
+      reason: "Bukie editorial evidence names the internal work ID",
+    };
+  }
+
+  const titleMatches =
+    record.title !== undefined &&
+    normalizeSortText(record.title) === normalizeSortText(target.title);
+  const creatorsMatch = sameOrderedCreators(
+    record.orderedCreators,
+    target.orderedCreators,
+  );
+  const conflictsWithTarget =
+    (record.title !== undefined && !titleMatches) ||
+    (record.orderedCreators !== undefined && !creatorsMatch);
+  const recordIdentifiers = new Set(record.exactIdentifiers ?? []);
+  const exactIdentifier = target.exactIdentifiers
+    .filter((identifier) => recordIdentifiers.has(identifier))
+    .sort()[0];
+  if (exactIdentifier) {
+    if (conflictsWithTarget) {
+      return {
+        outcome: "ambiguous",
+        matchKind: "candidate",
+        mappingConfidence: 0.5,
+        reason: "Exact identifier conflicts with supplied work identity",
+      };
+    }
+    return {
+      outcome: "active",
+      matchKind: "exact_identifier",
+      mappingConfidence: 1,
+      reason: `Exact identifier match: ${exactIdentifier}`,
+    };
+  }
+
+  const providerRelation = target.providerRelations[adapter.sourceKey];
+  if (providerRelation && record.providerWorkId === providerRelation) {
+    if (conflictsWithTarget) {
+      return {
+        outcome: "ambiguous",
+        matchKind: "candidate",
+        mappingConfidence: 0.5,
+        reason:
+          "Provider-native relation conflicts with supplied work identity",
+      };
+    }
+    return {
+      outcome: "active",
+      matchKind: "source_relationship",
+      mappingConfidence: 1,
+      reason: `Existing provider-native work relation: ${providerRelation}`,
+    };
+  }
+
+  if (record.strongTuple && titleMatches && creatorsMatch) {
+    return {
+      outcome: "candidate",
+      matchKind: "candidate",
+      mappingConfidence: 0.85,
+      reason: "Strong structured tuple created a review candidate",
+    };
+  }
+  if (titleMatches && creatorsMatch) {
+    return {
+      outcome: "candidate",
+      matchKind: "candidate",
+      mappingConfidence: 0.7,
+      reason:
+        "Normalized title plus ordered creator is candidate evidence only",
+    };
+  }
+  if (titleMatches) {
+    return {
+      outcome: "unmatched",
+      matchKind: "candidate",
+      mappingConfidence: 0.2,
+      reason: "Title-only evidence cannot activate or propose an entity link",
+    };
+  }
+  return {
+    outcome: "unmatched",
+    matchKind: "candidate",
+    mappingConfidence: 0,
+    reason: "No conservative identity evidence matched",
+  };
+}

--- a/src/db/catalog/enrichment/persistence.pg.test.ts
+++ b/src/db/catalog/enrichment/persistence.pg.test.ts
@@ -60,6 +60,42 @@ describe.skipIf(!isolatedUrl)(
         fieldObservations: 9,
       });
       expect(second.currentHeadHash).toBe(first.currentHeadHash);
+
+      const changedRecords = SAMPLE_PROVIDER_RECORDS.map((record, index) =>
+        index === 0
+          ? {
+              ...record,
+              evidence: record.evidence.map((evidence) => ({
+                ...evidence,
+                value: "Changed title under reused source revision",
+              })),
+            }
+          : record,
+      );
+      const changedRun = buildEnrichmentRun({
+        manifest: ENRICHMENT_SAMPLE_MANIFEST,
+        requestedWorkIds: ENRICHMENT_SAMPLE_MANIFEST.works.map(
+          (work) => work.workId,
+        ),
+        records: changedRecords,
+      });
+      await expect(
+        persistEnrichmentRunPostgres({
+          url: target.url,
+          run: changedRun,
+        }),
+      ).rejects.toThrow("immutable sourceRecords row");
+      const afterConflict = await persistEnrichmentRunPostgres({
+        url: target.url,
+        run,
+      });
+      expect(afterConflict.created).toEqual({
+        metadataSources: 0,
+        sourceRecords: 0,
+        sourceRecordLinks: 0,
+        fieldObservations: 0,
+      });
+      expect(afterConflict.reused.fieldObservations).toBe(9);
     }, 120_000);
   },
 );

--- a/src/db/catalog/enrichment/persistence.pg.test.ts
+++ b/src/db/catalog/enrichment/persistence.pg.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { buildCatalogImportGraph } from "../importer";
+import { rebuildCatalogPostgres } from "../postgres-rebuild";
+import { resolveRebuildTarget } from "../rebuild-safety";
+import {
+  SAMPLE_BASELINE_IMPORT_RECORDS,
+  SAMPLE_PROVIDER_RECORDS,
+} from "./fixtures";
+import { persistEnrichmentRunPostgres } from "./persistence.pg";
+import { ENRICHMENT_SAMPLE_MANIFEST } from "./sample-manifest";
+import { buildEnrichmentRun } from "./workflow";
+
+const isolatedUrl = process.env.CATALOG_TEST_POSTGRES_URL;
+
+describe.skipIf(!isolatedUrl)(
+  "Postgres five-work enrichment persistence",
+  () => {
+    it("is idempotent and preserves current heads on an isolated target", async () => {
+      const target = resolveRebuildTarget({
+        rawTarget: `postgres:${isolatedUrl}`,
+        confirmDisposable: true,
+        env: { NODE_ENV: "test" },
+      });
+      if (target.driver !== "postgres") {
+        throw new Error("Expected an isolated Postgres target");
+      }
+      const graph = buildCatalogImportGraph(SAMPLE_BASELINE_IMPORT_RECORDS);
+      const run = buildEnrichmentRun({
+        requestedWorkIds: ENRICHMENT_SAMPLE_MANIFEST.works.map(
+          (work) => work.workId,
+        ),
+        records: SAMPLE_PROVIDER_RECORDS,
+      });
+      await rebuildCatalogPostgres({ url: target.url, graph });
+      const first = await persistEnrichmentRunPostgres({
+        url: target.url,
+        run,
+      });
+      const second = await persistEnrichmentRunPostgres({
+        url: target.url,
+        run,
+      });
+      expect(first.created).toEqual({
+        metadataSources: 2,
+        sourceRecords: 10,
+        sourceRecordLinks: 10,
+        fieldObservations: 9,
+      });
+      expect(second.created).toEqual({
+        metadataSources: 0,
+        sourceRecords: 0,
+        sourceRecordLinks: 0,
+        fieldObservations: 0,
+      });
+      expect(second.reused).toEqual({
+        metadataSources: 2,
+        sourceRecords: 10,
+        sourceRecordLinks: 10,
+        fieldObservations: 9,
+      });
+      expect(second.currentHeadHash).toBe(first.currentHeadHash);
+    }, 120_000);
+  },
+);

--- a/src/db/catalog/enrichment/persistence.pg.test.ts
+++ b/src/db/catalog/enrichment/persistence.pg.test.ts
@@ -26,6 +26,7 @@ describe.skipIf(!isolatedUrl)(
       }
       const graph = buildCatalogImportGraph(SAMPLE_BASELINE_IMPORT_RECORDS);
       const run = buildEnrichmentRun({
+        manifest: ENRICHMENT_SAMPLE_MANIFEST,
         requestedWorkIds: ENRICHMENT_SAMPLE_MANIFEST.works.map(
           (work) => work.workId,
         ),

--- a/src/db/catalog/enrichment/persistence.pg.ts
+++ b/src/db/catalog/enrichment/persistence.pg.ts
@@ -1,3 +1,4 @@
+import { and, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import { hashCanonicalJson } from "../identity";
@@ -7,7 +8,10 @@ import {
   sourceRecordLinksPg,
   sourceRecordsPg,
 } from "../schema.pg";
-import { prepareEnrichmentPersistenceRows } from "./persistence";
+import {
+  assertEnrichmentPersistenceRow,
+  prepareEnrichmentPersistenceRows,
+} from "./persistence";
 import type { EnrichmentRunArtifact } from "./types";
 
 const TABLE_NAMES = {
@@ -86,6 +90,60 @@ export async function persistEnrichmentRunPostgres(input: {
             rows.fieldObservations as (typeof fieldObservationsPg.$inferInsert)[],
           )
           .onConflictDoNothing();
+      }
+      for (const expected of rows.metadataSources) {
+        const id = String(expected.id);
+        const [actual] = await tx
+          .select()
+          .from(metadataSourcesPg)
+          .where(eq(metadataSourcesPg.id, id))
+          .limit(1);
+        assertEnrichmentPersistenceRow("metadataSources", expected, actual, id);
+      }
+      for (const expected of rows.sourceRecords) {
+        const id = String(expected.id);
+        const [actual] = await tx
+          .select()
+          .from(sourceRecordsPg)
+          .where(eq(sourceRecordsPg.id, id))
+          .limit(1);
+        assertEnrichmentPersistenceRow("sourceRecords", expected, actual, id);
+      }
+      for (const expected of rows.sourceRecordLinks) {
+        const sourceRecordId = String(expected.sourceRecordId);
+        const entityType = String(expected.entityType);
+        const entityId = String(expected.entityId);
+        const [actual] = await tx
+          .select()
+          .from(sourceRecordLinksPg)
+          .where(
+            and(
+              eq(sourceRecordLinksPg.sourceRecordId, sourceRecordId),
+              eq(sourceRecordLinksPg.entityType, entityType),
+              eq(sourceRecordLinksPg.entityId, entityId),
+            ),
+          )
+          .limit(1);
+        assertEnrichmentPersistenceRow(
+          "sourceRecordLinks",
+          expected,
+          actual,
+          `${sourceRecordId}:${entityType}:${entityId}`,
+        );
+      }
+      for (const expected of rows.fieldObservations) {
+        const id = String(expected.id);
+        const [actual] = await tx
+          .select()
+          .from(fieldObservationsPg)
+          .where(eq(fieldObservationsPg.id, id))
+          .limit(1);
+        assertEnrichmentPersistenceRow(
+          "fieldObservations",
+          expected,
+          actual,
+          id,
+        );
       }
     });
     const after = Object.fromEntries(

--- a/src/db/catalog/enrichment/persistence.pg.ts
+++ b/src/db/catalog/enrichment/persistence.pg.ts
@@ -1,0 +1,123 @@
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { hashCanonicalJson } from "../identity";
+import {
+  fieldObservationsPg,
+  metadataSourcesPg,
+  sourceRecordLinksPg,
+  sourceRecordsPg,
+} from "../schema.pg";
+import { prepareEnrichmentPersistenceRows } from "./persistence";
+import type { EnrichmentRunArtifact } from "./types";
+
+const TABLE_NAMES = {
+  metadataSources: "metadata_sources",
+  sourceRecords: "source_records",
+  sourceRecordLinks: "source_record_links",
+  fieldObservations: "field_observations",
+} as const;
+
+type PersistenceTable = keyof typeof TABLE_NAMES;
+
+export async function persistEnrichmentRunPostgres(input: {
+  url: string;
+  run: EnrichmentRunArtifact;
+}) {
+  if (input.run.proposedResolutionHeads.length !== 0) {
+    throw new Error(
+      "Enrichment persistence refused: proposed current heads are not permitted",
+    );
+  }
+  const rows = prepareEnrichmentPersistenceRows(input.run, "postgres");
+  const client = postgres(input.url, { max: 1 });
+  const db = drizzle(client);
+  const countRows = async (table: PersistenceTable) => {
+    const result = await client.unsafe(
+      `select count(*)::int as count from "${TABLE_NAMES[table]}"`,
+    );
+    return Number(result[0]?.count ?? 0);
+  };
+  const currentHeadHash = async () =>
+    hashCanonicalJson(
+      await client.unsafe(
+        `select entity_type, entity_id, field_key, resolution_id
+         from field_resolution_heads
+         order by entity_type, entity_id, field_key`,
+      ),
+    );
+
+  try {
+    const before = Object.fromEntries(
+      await Promise.all(
+        (Object.keys(TABLE_NAMES) as PersistenceTable[]).map(async (key) => [
+          key,
+          await countRows(key),
+        ]),
+      ),
+    ) as Record<PersistenceTable, number>;
+    const headsBefore = await currentHeadHash();
+    await db.transaction(async (tx) => {
+      if (rows.metadataSources.length) {
+        await tx
+          .insert(metadataSourcesPg)
+          .values(
+            rows.metadataSources as (typeof metadataSourcesPg.$inferInsert)[],
+          )
+          .onConflictDoNothing();
+      }
+      if (rows.sourceRecords.length) {
+        await tx
+          .insert(sourceRecordsPg)
+          .values(rows.sourceRecords as (typeof sourceRecordsPg.$inferInsert)[])
+          .onConflictDoNothing();
+      }
+      if (rows.sourceRecordLinks.length) {
+        await tx
+          .insert(sourceRecordLinksPg)
+          .values(
+            rows.sourceRecordLinks as (typeof sourceRecordLinksPg.$inferInsert)[],
+          )
+          .onConflictDoNothing();
+      }
+      if (rows.fieldObservations.length) {
+        await tx
+          .insert(fieldObservationsPg)
+          .values(
+            rows.fieldObservations as (typeof fieldObservationsPg.$inferInsert)[],
+          )
+          .onConflictDoNothing();
+      }
+    });
+    const after = Object.fromEntries(
+      await Promise.all(
+        (Object.keys(TABLE_NAMES) as PersistenceTable[]).map(async (key) => [
+          key,
+          await countRows(key),
+        ]),
+      ),
+    ) as Record<PersistenceTable, number>;
+    const headsAfter = await currentHeadHash();
+    if (headsAfter !== headsBefore) {
+      throw new Error(
+        "Enrichment persistence invariant failed: current resolution heads changed",
+      );
+    }
+    return {
+      created: Object.fromEntries(
+        (Object.keys(rows) as PersistenceTable[]).map((key) => [
+          key,
+          after[key] - before[key],
+        ]),
+      ) as Record<PersistenceTable, number>,
+      reused: Object.fromEntries(
+        (Object.keys(rows) as PersistenceTable[]).map((key) => [
+          key,
+          rows[key].length - (after[key] - before[key]),
+        ]),
+      ) as Record<PersistenceTable, number>,
+      currentHeadHash: headsAfter,
+    };
+  } finally {
+    await client.end({ timeout: 5_000 });
+  }
+}

--- a/src/db/catalog/enrichment/persistence.test.ts
+++ b/src/db/catalog/enrichment/persistence.test.ts
@@ -22,6 +22,7 @@ describe("enrichment persistence parity and idempotency", () => {
   const workIds = ENRICHMENT_SAMPLE_MANIFEST.works.map((work) => work.workId);
   const graph = buildCatalogImportGraph(SAMPLE_BASELINE_IMPORT_RECORDS);
   const run = buildEnrichmentRun({
+    manifest: ENRICHMENT_SAMPLE_MANIFEST,
     requestedWorkIds: workIds,
     records: SAMPLE_PROVIDER_RECORDS,
   });

--- a/src/db/catalog/enrichment/persistence.test.ts
+++ b/src/db/catalog/enrichment/persistence.test.ts
@@ -114,4 +114,41 @@ describe("enrichment persistence parity and idempotency", () => {
     });
     expect(normalizeSqlite(sqlite)).toEqual(postgres);
   });
+
+  it("fails closed and rolls back when a reused source revision changes", () => {
+    rebuildCatalogSqlite({ sqlitePath, graph });
+    const changedRecords = SAMPLE_PROVIDER_RECORDS.map((record, index) =>
+      index === 0
+        ? {
+            ...record,
+            evidence: record.evidence.map((evidence) => ({
+              ...evidence,
+              value: "Changed title under reused source revision",
+            })),
+          }
+        : record,
+    );
+    const changedRun = buildEnrichmentRun({
+      manifest: ENRICHMENT_SAMPLE_MANIFEST,
+      requestedWorkIds: workIds,
+      records: changedRecords,
+    });
+    const { raw } = openCatalogSqlite(sqlitePath);
+    try {
+      persistEnrichmentRunSqlite(raw, run);
+      expect(() => persistEnrichmentRunSqlite(raw, changedRun)).toThrow(
+        "immutable sourceRecords row",
+      );
+      const afterConflict = persistEnrichmentRunSqlite(raw, run);
+      expect(afterConflict.created).toEqual({
+        metadataSources: 0,
+        sourceRecords: 0,
+        sourceRecordLinks: 0,
+        fieldObservations: 0,
+      });
+      expect(afterConflict.reused.fieldObservations).toBe(9);
+    } finally {
+      raw.close();
+    }
+  });
 });

--- a/src/db/catalog/enrichment/persistence.test.ts
+++ b/src/db/catalog/enrichment/persistence.test.ts
@@ -1,0 +1,116 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildCatalogImportGraph } from "../importer";
+import { openCatalogSqlite, rebuildCatalogSqlite } from "../sqlite-rebuild";
+import {
+  SAMPLE_BASELINE_IMPORT_RECORDS,
+  SAMPLE_PROVIDER_RECORDS,
+} from "./fixtures";
+import {
+  enrichmentSqliteSnapshot,
+  persistEnrichmentRunSqlite,
+  prepareEnrichmentPersistenceRows,
+} from "./persistence";
+import { ENRICHMENT_SAMPLE_MANIFEST } from "./sample-manifest";
+import { buildEnrichmentRun } from "./workflow";
+
+describe("enrichment persistence parity and idempotency", () => {
+  let directory: string;
+  let sqlitePath: string;
+  const workIds = ENRICHMENT_SAMPLE_MANIFEST.works.map((work) => work.workId);
+  const graph = buildCatalogImportGraph(SAMPLE_BASELINE_IMPORT_RECORDS);
+  const run = buildEnrichmentRun({
+    requestedWorkIds: workIds,
+    records: SAMPLE_PROVIDER_RECORDS,
+  });
+
+  beforeEach(() => {
+    directory = mkdtempSync(path.join(tmpdir(), "bukie-enrichment-test-"));
+    sqlitePath = path.join(directory, "catalog-enrichment-test.sqlite");
+  });
+
+  afterEach(() => {
+    rmSync(directory, { recursive: true, force: true });
+  });
+
+  it("persists the same run twice without duplicates or current-head changes", () => {
+    rebuildCatalogSqlite({ sqlitePath, graph });
+    const { raw } = openCatalogSqlite(sqlitePath);
+    try {
+      const headsBefore = raw
+        .prepare("select count(*) as count from field_resolution_heads")
+        .get() as { count: number };
+      const first = persistEnrichmentRunSqlite(raw, run);
+      const firstSnapshot = enrichmentSqliteSnapshot(raw, run);
+      const second = persistEnrichmentRunSqlite(raw, run);
+      const secondSnapshot = enrichmentSqliteSnapshot(raw, run);
+      const headsAfter = raw
+        .prepare("select count(*) as count from field_resolution_heads")
+        .get() as { count: number };
+
+      expect(first.created).toEqual({
+        metadataSources: 2,
+        sourceRecords: 10,
+        sourceRecordLinks: 10,
+        fieldObservations: 9,
+      });
+      expect(second.created).toEqual({
+        metadataSources: 0,
+        sourceRecords: 0,
+        sourceRecordLinks: 0,
+        fieldObservations: 0,
+      });
+      expect(second.reused).toEqual({
+        metadataSources: 2,
+        sourceRecords: 10,
+        sourceRecordLinks: 10,
+        fieldObservations: 9,
+      });
+      expect(firstSnapshot.hash).toBe(secondSnapshot.hash);
+      expect(first.currentHeadHash).toBe(second.currentHeadHash);
+      expect(headsAfter.count).toBe(headsBefore.count);
+    } finally {
+      raw.close();
+    }
+  });
+
+  it("serializes equivalent logical rows for SQLite and Postgres", () => {
+    const sqlite = prepareEnrichmentPersistenceRows(run, "sqlite");
+    const postgres = prepareEnrichmentPersistenceRows(run, "postgres");
+    const normalizeSqlite = (rows: typeof sqlite) => ({
+      ...rows,
+      metadataSources: rows.metadataSources.map((row) => ({
+        ...row,
+        metadataPolicy:
+          typeof row.metadataPolicy === "string"
+            ? JSON.parse(row.metadataPolicy)
+            : row.metadataPolicy,
+        assetPolicy:
+          typeof row.assetPolicy === "string"
+            ? JSON.parse(row.assetPolicy)
+            : row.assetPolicy,
+      })),
+      sourceRecords: rows.sourceRecords.map((row) => ({
+        ...row,
+        payloadJson:
+          typeof row.payloadJson === "string"
+            ? JSON.parse(row.payloadJson)
+            : row.payloadJson,
+      })),
+      fieldObservations: rows.fieldObservations.map((row) => ({
+        ...row,
+        valueJson:
+          typeof row.valueJson === "string"
+            ? JSON.parse(row.valueJson)
+            : row.valueJson,
+        parentIdsJson:
+          typeof row.parentIdsJson === "string"
+            ? JSON.parse(row.parentIdsJson)
+            : row.parentIdsJson,
+      })),
+    });
+    expect(normalizeSqlite(sqlite)).toEqual(postgres);
+  });
+});

--- a/src/db/catalog/enrichment/persistence.ts
+++ b/src/db/catalog/enrichment/persistence.ts
@@ -1,0 +1,234 @@
+import type Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { canonicalJson, hashCanonicalJson } from "../identity";
+import {
+  fieldObservations,
+  fieldResolutionHeads,
+  metadataSources,
+  sourceRecordLinks,
+  sourceRecords,
+} from "../schema";
+import type { EnrichmentRunArtifact } from "./types";
+
+export type EnrichmentPersistenceRows = {
+  metadataSources: Record<string, unknown>[];
+  sourceRecords: Record<string, unknown>[];
+  sourceRecordLinks: Record<string, unknown>[];
+  fieldObservations: Record<string, unknown>[];
+};
+
+function parseJson(value: unknown): unknown {
+  return typeof value === "string" ? JSON.parse(value) : value;
+}
+
+export function prepareEnrichmentPersistenceRows(
+  run: EnrichmentRunArtifact,
+  dialect: "sqlite" | "postgres",
+): EnrichmentPersistenceRows {
+  const json = (value: unknown) =>
+    dialect === "postgres" ? parseJson(value) : value;
+  return {
+    metadataSources: run.metadataSources.map((row) => ({
+      ...row,
+      metadataPolicy: json(row.metadataPolicy),
+      assetPolicy: json(row.assetPolicy),
+    })),
+    sourceRecords: run.sourceRecords.map(
+      ({ upstreamRecordKey: _, ...row }) => ({
+        ...row,
+        payloadJson: row.payloadJson === null ? null : json(row.payloadJson),
+      }),
+    ),
+    sourceRecordLinks: run.sourceRecordLinks.map(
+      ({ id: _, outcome: __, ...row }) => row,
+    ),
+    fieldObservations: run.fieldObservations.map((row) => ({
+      ...row,
+      valueJson: json(row.valueJson),
+      parentIdsJson:
+        row.parentIdsJson === null ? null : json(row.parentIdsJson),
+    })),
+  };
+}
+
+function rowCount(
+  raw: InstanceType<typeof Database>,
+  table: keyof EnrichmentPersistenceRows,
+): number {
+  const tableName = {
+    metadataSources: "metadata_sources",
+    sourceRecords: "source_records",
+    sourceRecordLinks: "source_record_links",
+    fieldObservations: "field_observations",
+  }[table];
+  return Number(
+    (
+      raw.prepare(`select count(*) as count from ${tableName}`).get() as {
+        count: number;
+      }
+    ).count,
+  );
+}
+
+function currentHeadHash(raw: InstanceType<typeof Database>): string {
+  return hashCanonicalJson(
+    raw
+      .prepare(
+        `select entity_type, entity_id, field_key, resolution_id
+         from field_resolution_heads
+         order by entity_type, entity_id, field_key`,
+      )
+      .all(),
+  );
+}
+
+export function persistEnrichmentRunSqlite(
+  raw: InstanceType<typeof Database>,
+  run: EnrichmentRunArtifact,
+) {
+  if (run.proposedResolutionHeads.length !== 0) {
+    throw new Error(
+      "Enrichment persistence refused: proposed current heads are not permitted",
+    );
+  }
+  const rows = prepareEnrichmentPersistenceRows(run, "sqlite");
+  const before = Object.fromEntries(
+    (Object.keys(rows) as Array<keyof EnrichmentPersistenceRows>).map((key) => [
+      key,
+      rowCount(raw, key),
+    ]),
+  ) as Record<keyof EnrichmentPersistenceRows, number>;
+  const headsBefore = currentHeadHash(raw);
+  const db = drizzle(raw);
+  const persist = raw.transaction(() => {
+    if (rows.metadataSources.length) {
+      db.insert(metadataSources)
+        .values(rows.metadataSources as (typeof metadataSources.$inferInsert)[])
+        .onConflictDoNothing()
+        .run();
+    }
+    if (rows.sourceRecords.length) {
+      db.insert(sourceRecords)
+        .values(rows.sourceRecords as (typeof sourceRecords.$inferInsert)[])
+        .onConflictDoNothing()
+        .run();
+    }
+    if (rows.sourceRecordLinks.length) {
+      db.insert(sourceRecordLinks)
+        .values(
+          rows.sourceRecordLinks as (typeof sourceRecordLinks.$inferInsert)[],
+        )
+        .onConflictDoNothing()
+        .run();
+    }
+    if (rows.fieldObservations.length) {
+      db.insert(fieldObservations)
+        .values(
+          rows.fieldObservations as (typeof fieldObservations.$inferInsert)[],
+        )
+        .onConflictDoNothing()
+        .run();
+    }
+  });
+  persist.immediate();
+  const after = Object.fromEntries(
+    (Object.keys(rows) as Array<keyof EnrichmentPersistenceRows>).map((key) => [
+      key,
+      rowCount(raw, key),
+    ]),
+  ) as Record<keyof EnrichmentPersistenceRows, number>;
+  const headsAfter = currentHeadHash(raw);
+  if (headsAfter !== headsBefore) {
+    throw new Error(
+      "Enrichment persistence invariant failed: current resolution heads changed",
+    );
+  }
+  return {
+    created: Object.fromEntries(
+      (Object.keys(rows) as Array<keyof EnrichmentPersistenceRows>).map(
+        (key) => [key, after[key] - before[key]],
+      ),
+    ) as Record<keyof EnrichmentPersistenceRows, number>,
+    reused: Object.fromEntries(
+      (Object.keys(rows) as Array<keyof EnrichmentPersistenceRows>).map(
+        (key) => [key, rows[key].length - (after[key] - before[key])],
+      ),
+    ) as Record<keyof EnrichmentPersistenceRows, number>,
+    currentHeadHash: headsAfter,
+  };
+}
+
+export function enrichmentSqliteSnapshot(
+  raw: InstanceType<typeof Database>,
+  run: EnrichmentRunArtifact,
+) {
+  const sourceIds = run.metadataSources.map((source) => String(source.id));
+  const placeholders = sourceIds.map(() => "?").join(", ");
+  const metadataRows =
+    sourceIds.length === 0
+      ? []
+      : raw
+          .prepare(
+            `select * from metadata_sources where id in (${placeholders}) order by id`,
+          )
+          .all(...sourceIds);
+  const sourceRows =
+    sourceIds.length === 0
+      ? []
+      : raw
+          .prepare(
+            `select * from source_records where source_id in (${placeholders}) order by id`,
+          )
+          .all(...sourceIds);
+  const sourceRecordIds = sourceRows.map((row) =>
+    String((row as { id: string }).id),
+  );
+  const recordPlaceholders = sourceRecordIds.map(() => "?").join(", ");
+  const linkRows =
+    sourceRecordIds.length === 0
+      ? []
+      : raw
+          .prepare(
+            `select * from source_record_links
+             where source_record_id in (${recordPlaceholders})
+             order by source_record_id, entity_type, entity_id`,
+          )
+          .all(...sourceRecordIds);
+  const observationRows =
+    sourceRecordIds.length === 0
+      ? []
+      : raw
+          .prepare(
+            `select * from field_observations
+             where source_record_id in (${recordPlaceholders})
+             order by id`,
+          )
+          .all(...sourceRecordIds);
+  const currentHeads = raw
+    .prepare(
+      `select entity_type, entity_id, field_key, resolution_id
+       from field_resolution_heads
+       order by entity_type, entity_id, field_key`,
+    )
+    .all();
+  const snapshot = {
+    metadataSources: metadataRows,
+    sourceRecords: sourceRows,
+    sourceRecordLinks: linkRows,
+    fieldObservations: observationRows,
+    currentHeads,
+  };
+  return {
+    snapshot,
+    hash: hashCanonicalJson(snapshot),
+    canonical: canonicalJson(snapshot),
+  };
+}
+
+export const ENRICHMENT_PERSISTENCE_TABLES = {
+  metadataSources,
+  sourceRecords,
+  sourceRecordLinks,
+  fieldObservations,
+  fieldResolutionHeads,
+} as const;

--- a/src/db/catalog/enrichment/persistence.ts
+++ b/src/db/catalog/enrichment/persistence.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { and, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { canonicalJson, hashCanonicalJson } from "../identity";
 import {
@@ -16,6 +17,92 @@ export type EnrichmentPersistenceRows = {
   sourceRecordLinks: Record<string, unknown>[];
   fieldObservations: Record<string, unknown>[];
 };
+
+const SEMANTIC_ROW_KEYS = {
+  metadataSources: [
+    "id",
+    "key",
+    "name",
+    "termsUrl",
+    "attributionUrl",
+    "reviewedAt",
+    "approvalState",
+    "metadataPolicy",
+    "assetPolicy",
+    "payloadPolicy",
+    "refreshIntervalMs",
+  ],
+  sourceRecords: [
+    "id",
+    "sourceId",
+    "recordKey",
+    "sourceRevision",
+    "sourceModifiedAt",
+    "payloadJson",
+    "payloadHash",
+    "importerVersion",
+    "sourceRowHash",
+    "state",
+  ],
+  sourceRecordLinks: [
+    "sourceRecordId",
+    "entityType",
+    "entityId",
+    "matchKind",
+    "mappingConfidence",
+    "state",
+    "actorRef",
+    "reason",
+  ],
+  fieldObservations: [
+    "id",
+    "sourceRecordId",
+    "entityType",
+    "entityId",
+    "fieldKey",
+    "valueJson",
+    "comparisonHash",
+    "provenanceKind",
+    "sourcePath",
+    "sourceModifiedAt",
+    "mappingConfidence",
+    "state",
+    "actorRef",
+    "reason",
+    "derivationName",
+    "derivationVersion",
+    "parentIdsJson",
+  ],
+} as const satisfies Record<keyof EnrichmentPersistenceRows, readonly string[]>;
+
+function projectedRow(
+  row: Readonly<Record<string, unknown>>,
+  keys: readonly string[],
+): Record<string, unknown> {
+  return Object.fromEntries(keys.map((key) => [key, row[key]]));
+}
+
+export function assertEnrichmentPersistenceRow(
+  table: keyof EnrichmentPersistenceRows,
+  expected: Readonly<Record<string, unknown>>,
+  actual: Readonly<Record<string, unknown>> | undefined,
+  identity: string,
+): void {
+  if (!actual) {
+    throw new Error(
+      `Enrichment persistence conflict: ${table} row ${identity} was not persisted`,
+    );
+  }
+  const keys = SEMANTIC_ROW_KEYS[table];
+  if (
+    canonicalJson(projectedRow(expected, keys)) !==
+    canonicalJson(projectedRow(actual, keys))
+  ) {
+    throw new Error(
+      `Enrichment persistence conflict: immutable ${table} row ${identity} differs from the recorded revision`,
+    );
+  }
+}
 
 function parseJson(value: unknown): unknown {
   return typeof value === "string" ? JSON.parse(value) : value;
@@ -128,6 +215,55 @@ export function persistEnrichmentRunSqlite(
         )
         .onConflictDoNothing()
         .run();
+    }
+    for (const expected of rows.metadataSources) {
+      const id = String(expected.id);
+      const actual = db
+        .select()
+        .from(metadataSources)
+        .where(eq(metadataSources.id, id))
+        .get();
+      assertEnrichmentPersistenceRow("metadataSources", expected, actual, id);
+    }
+    for (const expected of rows.sourceRecords) {
+      const id = String(expected.id);
+      const actual = db
+        .select()
+        .from(sourceRecords)
+        .where(eq(sourceRecords.id, id))
+        .get();
+      assertEnrichmentPersistenceRow("sourceRecords", expected, actual, id);
+    }
+    for (const expected of rows.sourceRecordLinks) {
+      const sourceRecordId = String(expected.sourceRecordId);
+      const entityType = String(expected.entityType);
+      const entityId = String(expected.entityId);
+      const actual = db
+        .select()
+        .from(sourceRecordLinks)
+        .where(
+          and(
+            eq(sourceRecordLinks.sourceRecordId, sourceRecordId),
+            eq(sourceRecordLinks.entityType, entityType),
+            eq(sourceRecordLinks.entityId, entityId),
+          ),
+        )
+        .get();
+      assertEnrichmentPersistenceRow(
+        "sourceRecordLinks",
+        expected,
+        actual,
+        `${sourceRecordId}:${entityType}:${entityId}`,
+      );
+    }
+    for (const expected of rows.fieldObservations) {
+      const id = String(expected.id);
+      const actual = db
+        .select()
+        .from(fieldObservations)
+        .where(eq(fieldObservations.id, id))
+        .get();
+      assertEnrichmentPersistenceRow("fieldObservations", expected, actual, id);
     }
   });
   persist.immediate();

--- a/src/db/catalog/enrichment/policies.ts
+++ b/src/db/catalog/enrichment/policies.ts
@@ -1,0 +1,368 @@
+import { canonicalJson, deterministicCatalogId } from "../identity";
+import type {
+  AdapterManifest,
+  EnrichmentFieldClass,
+  FieldPermission,
+} from "./types";
+
+const POLICY_REVIEW_DATE = "2026-07-28";
+const NEXT_POLICY_REVIEW_DATE = "2027-01-28";
+
+const denied = (): FieldPermission => ({
+  allowedFields: [],
+  fetch: false,
+  cache: false,
+  retain: "none",
+  transform: false,
+  display: false,
+});
+
+const pendingManifest = (input: {
+  sourceKey: string;
+  sourceName: string;
+  adapterId: string;
+  disabledReason: string;
+}): AdapterManifest => ({
+  sourceId: deterministicCatalogId(
+    "metadata_source",
+    "enrichment",
+    input.sourceKey,
+  ),
+  sourceKey: input.sourceKey,
+  sourceName: input.sourceName,
+  adapterId: input.adapterId,
+  adapterVersion: "1.0.0",
+  sourcePolicyVersion: "pending-2026-07-28",
+  policyReviewDate: POLICY_REVIEW_DATE,
+  policySources: [],
+  state: "pending",
+  disabledReason: input.disabledReason,
+  nextReviewDate: NEXT_POLICY_REVIEW_DATE,
+  permissions: {
+    metadata: denied(),
+    text: denied(),
+    asset: denied(),
+  },
+  acquisition: {
+    method: "disabled",
+    host: null,
+    perHostConcurrency: 1,
+    minimumIntervalMs: 0,
+    credentials: [],
+    cache: false,
+    conditionalRetrieval: "none",
+    retry: {
+      ceiling: 0,
+      baseDelayMs: 0,
+      maximumDelayMs: 0,
+      jitterRatio: 0,
+      respectRetryAfter: true,
+    },
+  },
+  attribution: {
+    required: false,
+    text: null,
+    url: null,
+    placement: null,
+  },
+  withdrawal: {
+    tombstone: true,
+    purgeRawPayload: true,
+    purgeCachedAssets: true,
+    recomputeProposals: true,
+  },
+  sourceRevision: { kind: "provider_revision", required: true },
+  proposedEvidenceOnly: true,
+});
+
+export const BUKIE_EDITORIAL_ADAPTER = {
+  sourceId: deterministicCatalogId(
+    "metadata_source",
+    "enrichment",
+    "bukie_editorial",
+  ),
+  sourceKey: "bukie_editorial",
+  sourceName: "Bukie-owned editorial evidence",
+  adapterId: "bukie.editorial",
+  adapterVersion: "1.0.0",
+  sourcePolicyVersion: "bukie-editorial-2026-07-28",
+  policyReviewDate: POLICY_REVIEW_DATE,
+  policySources: ["docs/research/book-detail-enrichment.md"],
+  state: "enabled",
+  disabledReason: null,
+  nextReviewDate: NEXT_POLICY_REVIEW_DATE,
+  permissions: {
+    metadata: {
+      allowedFields: ["work.preferred_title"],
+      fetch: true,
+      cache: true,
+      retain: "selected_fields",
+      transform: true,
+      display: true,
+    },
+    text: {
+      allowedFields: ["work.description"],
+      fetch: true,
+      cache: true,
+      retain: "full",
+      transform: true,
+      display: true,
+    },
+    asset: denied(),
+  },
+  acquisition: {
+    method: "repository_artifact",
+    host: null,
+    perHostConcurrency: 1,
+    minimumIntervalMs: 0,
+    credentials: [],
+    cache: true,
+    conditionalRetrieval: "snapshot",
+    retry: {
+      ceiling: 0,
+      baseDelayMs: 0,
+      maximumDelayMs: 0,
+      jitterRatio: 0,
+      respectRetryAfter: true,
+    },
+  },
+  attribution: {
+    required: true,
+    text: "Bukie editorial",
+    url: null,
+    placement: "internal evidence audit",
+  },
+  withdrawal: {
+    tombstone: true,
+    purgeRawPayload: false,
+    purgeCachedAssets: true,
+    recomputeProposals: true,
+  },
+  sourceRevision: { kind: "content_hash", required: true },
+  proposedEvidenceOnly: true,
+} as const satisfies AdapterManifest;
+
+export const WIKIDATA_WORK_FACTS_ADAPTER = {
+  sourceId: deterministicCatalogId("metadata_source", "enrichment", "wikidata"),
+  sourceKey: "wikidata",
+  sourceName: "Wikidata structured work facts",
+  adapterId: "wikidata.work-facts",
+  adapterVersion: "1.0.0",
+  sourcePolicyVersion: "wikidata-cc0-2026-07-28",
+  policyReviewDate: POLICY_REVIEW_DATE,
+  policySources: [
+    "https://www.wikidata.org/wiki/Wikidata:Licensing",
+    "https://www.wikidata.org/wiki/Wikidata:Data_access",
+  ],
+  state: "enabled",
+  disabledReason: null,
+  nextReviewDate: NEXT_POLICY_REVIEW_DATE,
+  permissions: {
+    metadata: {
+      allowedFields: ["work.preferred_title"],
+      fetch: true,
+      cache: true,
+      retain: "full",
+      transform: true,
+      display: false,
+    },
+    text: denied(),
+    asset: denied(),
+  },
+  acquisition: {
+    method: "wikimedia_api",
+    host: "www.wikidata.org",
+    perHostConcurrency: 1,
+    minimumIntervalMs: 1_000,
+    credentials: [],
+    cache: true,
+    conditionalRetrieval: "etag_and_last_modified",
+    retry: {
+      ceiling: 3,
+      baseDelayMs: 1_000,
+      maximumDelayMs: 30_000,
+      jitterRatio: 0.2,
+      respectRetryAfter: true,
+    },
+  },
+  attribution: {
+    required: false,
+    text: "Wikidata",
+    url: "https://www.wikidata.org/",
+    placement: "internal evidence audit",
+  },
+  withdrawal: {
+    tombstone: true,
+    purgeRawPayload: false,
+    purgeCachedAssets: true,
+    recomputeProposals: true,
+  },
+  sourceRevision: { kind: "provider_revision", required: true },
+  proposedEvidenceOnly: true,
+} as const satisfies AdapterManifest;
+
+export const PENDING_ADAPTERS = [
+  pendingManifest({
+    sourceKey: "open_library_metadata",
+    sourceName: "Open Library metadata",
+    adapterId: "open-library.metadata",
+    disabledReason:
+      "Metadata retention, display, and bulk-access policy require separate approval",
+  }),
+  pendingManifest({
+    sourceKey: "open_library_descriptions",
+    sourceName: "Open Library descriptions",
+    adapterId: "open-library.descriptions",
+    disabledReason:
+      "Contributed prose may retain third-party rights; no approved text policy exists",
+  }),
+  pendingManifest({
+    sourceKey: "open_library_covers",
+    sourceName: "Open Library Covers",
+    adapterId: "open-library.covers",
+    disabledReason:
+      "Asset identity, caching, transformation, and display rights require separate approval",
+  }),
+  pendingManifest({
+    sourceKey: "google_books",
+    sourceName: "Google Books",
+    adapterId: "google-books",
+    disabledReason:
+      "Caching, branding, quota, retention, and third-party-content terms are pending",
+  }),
+  pendingManifest({
+    sourceKey: "official_publishers",
+    sourceName: "Official publisher text and assets",
+    adapterId: "publisher.official",
+    disabledReason:
+      "Public pages are not an approved feed or reusable text/asset license",
+  }),
+  pendingManifest({
+    sourceKey: "worldcat_oclc",
+    sourceName: "WorldCat/OCLC data",
+    adapterId: "worldcat.oclc",
+    disabledReason: "Licensed API and data-use terms are not approved",
+  }),
+  pendingManifest({
+    sourceKey: "commercial_isbn",
+    sourceName: "Bowker and commercial ISBN feeds",
+    adapterId: "isbn.commercial",
+    disabledReason:
+      "Contract scope, retention, display, and withdrawal terms are not approved",
+  }),
+  pendingManifest({
+    sourceKey: "wikipedia_prose",
+    sourceName: "Wikipedia prose",
+    adapterId: "wikipedia.prose",
+    disabledReason:
+      "CC BY-SA attribution, share-alike, copying, spoiler, and drift policy is not approved",
+  }),
+  pendingManifest({
+    sourceKey: "retailer_competitor_search",
+    sourceName: "Retailer, competitor, and search-result content",
+    adapterId: "web-content.retailer-competitor-search",
+    disabledReason:
+      "Scraping and catalog ingestion from these surfaces are prohibited",
+  }),
+] as const;
+
+export const ENRICHMENT_ADAPTERS = [
+  BUKIE_EDITORIAL_ADAPTER,
+  WIKIDATA_WORK_FACTS_ADAPTER,
+  ...PENDING_ADAPTERS,
+] as const satisfies readonly AdapterManifest[];
+
+const adaptersById = new Map<string, AdapterManifest>(
+  ENRICHMENT_ADAPTERS.map((adapter) => [adapter.adapterId, adapter]),
+);
+
+export function getAdapterManifest(adapterId: string): AdapterManifest {
+  const adapter = adaptersById.get(adapterId);
+  if (!adapter) {
+    throw new Error(`Enrichment policy refused: unknown adapter ${adapterId}`);
+  }
+  return adapter;
+}
+
+export function assertAdapterEnabled(adapter: AdapterManifest): void {
+  if (adapter.state !== "enabled") {
+    throw new Error(
+      `Enrichment policy refused: ${adapter.adapterId} is ${adapter.state}: ${adapter.disabledReason ?? "no approved policy"}`,
+    );
+  }
+}
+
+export function authorizeField(input: {
+  adapter: AdapterManifest;
+  fieldClass: EnrichmentFieldClass;
+  fieldKey: string;
+}): FieldPermission {
+  assertAdapterEnabled(input.adapter);
+  const permission = input.adapter.permissions[input.fieldClass];
+  if (
+    !permission.fetch ||
+    !permission.allowedFields.includes(
+      input.fieldKey as (typeof permission.allowedFields)[number],
+    )
+  ) {
+    throw new Error(
+      `Enrichment policy refused: ${input.adapter.adapterId} may not acquire ${input.fieldClass} field ${input.fieldKey}`,
+    );
+  }
+  return permission;
+}
+
+export function metadataSourceRow(
+  adapter: AdapterManifest,
+): Record<string, unknown> {
+  const metadataPolicy = canonicalJson({
+    acquisition: adapter.acquisition,
+    adapterId: adapter.adapterId,
+    adapterVersion: adapter.adapterVersion,
+    attribution: adapter.attribution,
+    cache: adapter.permissions.metadata.cache || adapter.permissions.text.cache,
+    display:
+      adapter.permissions.metadata.display || adapter.permissions.text.display,
+    fieldPermission: adapter.permissions.metadata,
+    nextReviewDate: adapter.nextReviewDate,
+    policyReviewDate: adapter.policyReviewDate,
+    policySources: adapter.policySources,
+    proposedEvidenceOnly: adapter.proposedEvidenceOnly,
+    sourceRevision: adapter.sourceRevision,
+    sourcePolicyVersion: adapter.sourcePolicyVersion,
+    textPermission: adapter.permissions.text,
+    transform:
+      adapter.permissions.metadata.transform ||
+      adapter.permissions.text.transform,
+    withdrawal: adapter.withdrawal,
+  });
+  const assetPolicy = canonicalJson({
+    cache: adapter.permissions.asset.cache,
+    display: adapter.permissions.asset.display,
+    fieldPermission: adapter.permissions.asset,
+    purgeOnWithdrawal: adapter.withdrawal.purgeCachedAssets,
+    transform: adapter.permissions.asset.transform,
+    withdrawal: adapter.withdrawal,
+  });
+  const payloadPolicies = Object.values(adapter.permissions).map(
+    (permission) => permission.retain,
+  );
+  const payloadPolicy = payloadPolicies.includes("full")
+    ? "full"
+    : payloadPolicies.includes("selected_fields")
+      ? "selected_fields"
+      : "none";
+  return {
+    id: adapter.sourceId,
+    key: adapter.sourceKey,
+    name: adapter.sourceName,
+    termsUrl: adapter.policySources[0] ?? null,
+    attributionUrl: adapter.attribution.url,
+    reviewedAt: Date.parse(`${adapter.policyReviewDate}T00:00:00Z`),
+    approvalState: adapter.state === "enabled" ? "approved" : adapter.state,
+    metadataPolicy,
+    assetPolicy,
+    payloadPolicy,
+    refreshIntervalMs: null,
+  };
+}

--- a/src/db/catalog/enrichment/policy-matching.test.ts
+++ b/src/db/catalog/enrichment/policy-matching.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+import { matchProviderRecord } from "./matching";
+import {
+  BUKIE_EDITORIAL_ADAPTER,
+  ENRICHMENT_ADAPTERS,
+  getAdapterManifest,
+  PENDING_ADAPTERS,
+  WIKIDATA_WORK_FACTS_ADAPTER,
+} from "./policies";
+import {
+  assertSampleScope,
+  ENRICHMENT_SAMPLE_MANIFEST,
+} from "./sample-manifest";
+import type { ProviderRecord } from "./types";
+
+const dune = ENRICHMENT_SAMPLE_MANIFEST.works[0];
+
+function wikidataRecord(
+  overrides: Partial<ProviderRecord> = {},
+): ProviderRecord {
+  return {
+    adapterId: WIKIDATA_WORK_FACTS_ADAPTER.adapterId,
+    recordKey: "Q190192",
+    sourceRevision: "fixture-revision",
+    retrievedAt: 1,
+    targetWorkId: dune.workId,
+    title: dune.title,
+    orderedCreators: dune.orderedCreators,
+    providerWorkId: "Q190192",
+    evidence: [],
+    ...overrides,
+  };
+}
+
+describe("enrichment policies and five-work scope", () => {
+  it("declares separate metadata, text, and asset permissions for every adapter", () => {
+    for (const adapter of ENRICHMENT_ADAPTERS) {
+      expect(Object.keys(adapter.permissions).sort()).toEqual([
+        "asset",
+        "metadata",
+        "text",
+      ]);
+      for (const permission of Object.values(adapter.permissions)) {
+        expect(permission).toMatchObject({
+          fetch: expect.any(Boolean),
+          cache: expect.any(Boolean),
+          retain: expect.stringMatching(/^(none|selected_fields|full)$/),
+          transform: expect.any(Boolean),
+          display: expect.any(Boolean),
+        });
+      }
+      expect(adapter.proposedEvidenceOnly).toBe(true);
+    }
+  });
+
+  it("enables only Bukie editorial and Wikidata work facts", () => {
+    expect(BUKIE_EDITORIAL_ADAPTER.state).toBe("enabled");
+    expect(WIKIDATA_WORK_FACTS_ADAPTER.state).toBe("enabled");
+    expect(PENDING_ADAPTERS).toHaveLength(9);
+    for (const adapter of PENDING_ADAPTERS) {
+      expect(adapter.state).toBe("pending");
+      expect(adapter.disabledReason).toBeTruthy();
+      expect(adapter.nextReviewDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(
+        Object.values(adapter.permissions).every(
+          (permission) =>
+            !permission.fetch &&
+            !permission.display &&
+            permission.allowedFields.length === 0,
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("fails closed outside the explicit versioned sample manifest", () => {
+    expect(ENRICHMENT_SAMPLE_MANIFEST.version).toBe("2026-07-28.v1");
+    expect(ENRICHMENT_SAMPLE_MANIFEST.works).toHaveLength(5);
+    expect(() =>
+      assertSampleScope(["ffffffff-ffff-5fff-8fff-ffffffffffff"]),
+    ).toThrow("outside bukie-enrichment-diagnostic-five");
+    expect(() => assertSampleScope([dune.workId, dune.workId])).toThrow(
+      "duplicate work IDs",
+    );
+  });
+
+  it("does not expose an unregistered provider adapter", () => {
+    expect(() => getAdapterManifest("unregistered.provider")).toThrow(
+      "unknown adapter",
+    );
+  });
+});
+
+describe("conservative provider-neutral matching", () => {
+  it("activates exact provider-native work relations", () => {
+    expect(
+      matchProviderRecord({
+        adapter: WIKIDATA_WORK_FACTS_ADAPTER,
+        record: wikidataRecord(),
+        target: dune,
+      }),
+    ).toMatchObject({
+      outcome: "active",
+      matchKind: "source_relationship",
+      mappingConfidence: 1,
+    });
+  });
+
+  it("keeps title plus ordered creator as a candidate only", () => {
+    expect(
+      matchProviderRecord({
+        adapter: WIKIDATA_WORK_FACTS_ADAPTER,
+        record: wikidataRecord({ providerWorkId: "Q999999" }),
+        target: dune,
+      }),
+    ).toMatchObject({ outcome: "candidate", matchKind: "candidate" });
+  });
+
+  it("never activates title-only evidence", () => {
+    expect(
+      matchProviderRecord({
+        adapter: WIKIDATA_WORK_FACTS_ADAPTER,
+        record: wikidataRecord({
+          providerWorkId: undefined,
+          orderedCreators: undefined,
+        }),
+        target: dune,
+      }),
+    ).toMatchObject({ outcome: "unmatched", mappingConfidence: 0.2 });
+  });
+
+  it("routes ambiguity, conflicts, and withdrawals away from active links", () => {
+    expect(
+      matchProviderRecord({
+        adapter: WIKIDATA_WORK_FACTS_ADAPTER,
+        record: wikidataRecord({
+          identityConflicts: ["same-title film", "edition-like claims"],
+        }),
+        target: dune,
+      }),
+    ).toMatchObject({ outcome: "ambiguous" });
+    expect(
+      matchProviderRecord({
+        adapter: WIKIDATA_WORK_FACTS_ADAPTER,
+        record: wikidataRecord({ state: "withdrawn" }),
+        target: dune,
+      }),
+    ).toMatchObject({ outcome: "withdrawn" });
+    expect(
+      matchProviderRecord({
+        adapter: WIKIDATA_WORK_FACTS_ADAPTER,
+        record: wikidataRecord({
+          rejectedReason: "Provider record was manually rejected",
+        }),
+        target: dune,
+      }),
+    ).toMatchObject({ outcome: "rejected" });
+    expect(
+      matchProviderRecord({
+        adapter: WIKIDATA_WORK_FACTS_ADAPTER,
+        record: wikidataRecord({ title: "A different work" }),
+        target: dune,
+      }),
+    ).toMatchObject({
+      outcome: "ambiguous",
+      reason: "Provider-native relation conflicts with supplied work identity",
+    });
+  });
+
+  it("uses the internal work ID as Bukie editorial identity", () => {
+    expect(
+      matchProviderRecord({
+        adapter: BUKIE_EDITORIAL_ADAPTER,
+        record: {
+          ...wikidataRecord(),
+          adapterId: BUKIE_EDITORIAL_ADAPTER.adapterId,
+          providerWorkId: undefined,
+        },
+        target: dune,
+      }),
+    ).toMatchObject({ outcome: "active", matchKind: "curated" });
+  });
+});

--- a/src/db/catalog/enrichment/policy-matching.test.ts
+++ b/src/db/catalog/enrichment/policy-matching.test.ts
@@ -7,11 +7,9 @@ import {
   PENDING_ADAPTERS,
   WIKIDATA_WORK_FACTS_ADAPTER,
 } from "./policies";
-import {
-  assertSampleScope,
-  ENRICHMENT_SAMPLE_MANIFEST,
-} from "./sample-manifest";
+import { ENRICHMENT_SAMPLE_MANIFEST } from "./sample-manifest";
 import type { ProviderRecord } from "./types";
+import { resolveEnrichmentScope } from "./workflow";
 
 const dune = ENRICHMENT_SAMPLE_MANIFEST.works[0];
 
@@ -76,11 +74,16 @@ describe("enrichment policies and five-work scope", () => {
     expect(ENRICHMENT_SAMPLE_MANIFEST.version).toBe("2026-07-28.v1");
     expect(ENRICHMENT_SAMPLE_MANIFEST.works).toHaveLength(5);
     expect(() =>
-      assertSampleScope(["ffffffff-ffff-5fff-8fff-ffffffffffff"]),
+      resolveEnrichmentScope(ENRICHMENT_SAMPLE_MANIFEST, [
+        "ffffffff-ffff-5fff-8fff-ffffffffffff",
+      ]),
     ).toThrow("outside bukie-enrichment-diagnostic-five");
-    expect(() => assertSampleScope([dune.workId, dune.workId])).toThrow(
-      "duplicate work IDs",
-    );
+    expect(() =>
+      resolveEnrichmentScope(ENRICHMENT_SAMPLE_MANIFEST, [
+        dune.workId,
+        dune.workId,
+      ]),
+    ).toThrow("duplicate work IDs");
   });
 
   it("does not expose an unregistered provider adapter", () => {

--- a/src/db/catalog/enrichment/sample-manifest.ts
+++ b/src/db/catalog/enrichment/sample-manifest.ts
@@ -1,0 +1,91 @@
+import { deterministicCatalogId } from "../identity";
+import type { EnrichmentSampleManifest, SampleWork } from "./types";
+
+export const ENRICHMENT_SAMPLE_MANIFEST = {
+  id: "bukie-enrichment-diagnostic-five",
+  version: "2026-07-28.v1",
+  reviewedAt: "2026-07-28",
+  works: [
+    {
+      workId: "7adeda04-34e2-5a7d-a101-de0578138b29",
+      legacyRecordKey: "c44b0f05-536d-4ce2-a6d5-75a2614ec119",
+      title: "Dune",
+      orderedCreators: ["Frank Herbert"],
+      providerRelations: { wikidata: "Q190192" },
+      exactIdentifiers: ["isbn13:9780441172719"],
+    },
+    {
+      workId: "00a218bd-3005-59cd-9c23-13efb48abe5a",
+      legacyRecordKey: "a8f901a5-6b85-500d-910a-5c47d0c3971a",
+      title: "Moby-Dick",
+      orderedCreators: ["Herman Melville"],
+      providerRelations: { wikidata: "Q174596" },
+      exactIdentifiers: [],
+    },
+    {
+      workId: "00a01d7f-3f29-5c95-a292-c70a4e5dbb4f",
+      legacyRecordKey: "cd0586eb-7932-4bbe-b596-83ae57d45020",
+      title: "The City and the Stars",
+      orderedCreators: ["Arthur C. Clarke"],
+      providerRelations: { wikidata: "Q386544" },
+      exactIdentifiers: [],
+    },
+    {
+      workId: "03ac5ae7-dcf1-5fe7-b6ac-b8f171459fb3",
+      legacyRecordKey: "09004e91-66f4-5e15-bb04-2a67e8602509",
+      title: "Born a Crime",
+      orderedCreators: ["Trevor Noah"],
+      providerRelations: { wikidata: "Q29831237" },
+      exactIdentifiers: [],
+    },
+    {
+      workId: "0100088c-3aca-5e52-9e7a-fb89192e9248",
+      legacyRecordKey: "408ab9ec-43d5-5845-a94d-ccc63eb10ee4",
+      title: "Faithful Place",
+      orderedCreators: ["Tana French"],
+      providerRelations: { wikidata: "Q5431286" },
+      exactIdentifiers: [],
+    },
+  ],
+} as const satisfies EnrichmentSampleManifest;
+
+const sampleById = new Map<string, SampleWork>(
+  ENRICHMENT_SAMPLE_MANIFEST.works.map((work) => [work.workId, work]),
+);
+
+export function getSampleWork(workId: string): SampleWork {
+  const work = sampleById.get(workId);
+  if (!work) {
+    throw new Error(
+      `Enrichment scope refused: work ${workId} is outside ${ENRICHMENT_SAMPLE_MANIFEST.id}@${ENRICHMENT_SAMPLE_MANIFEST.version}`,
+    );
+  }
+  return work;
+}
+
+export function assertSampleScope(workIds: readonly string[]): SampleWork[] {
+  if (workIds.length === 0) {
+    throw new Error(
+      "Enrichment scope refused: at least one work ID is required",
+    );
+  }
+  if (new Set(workIds).size !== workIds.length) {
+    throw new Error(
+      "Enrichment scope refused: duplicate work IDs are not allowed",
+    );
+  }
+  return [...workIds].sort().map(getSampleWork);
+}
+
+for (const work of ENRICHMENT_SAMPLE_MANIFEST.works) {
+  const derived = deterministicCatalogId(
+    "work",
+    "legacy_catalog",
+    work.legacyRecordKey,
+  );
+  if (derived !== work.workId) {
+    throw new Error(
+      `Enrichment sample manifest is inconsistent for ${work.title}`,
+    );
+  }
+}

--- a/src/db/catalog/enrichment/sample-manifest.ts
+++ b/src/db/catalog/enrichment/sample-manifest.ts
@@ -1,5 +1,5 @@
 import { deterministicCatalogId } from "../identity";
-import type { EnrichmentSampleManifest, SampleWork } from "./types";
+import type { EnrichmentScopeManifest } from "./types";
 
 export const ENRICHMENT_SAMPLE_MANIFEST = {
   id: "bukie-enrichment-diagnostic-five",
@@ -47,35 +47,7 @@ export const ENRICHMENT_SAMPLE_MANIFEST = {
       exactIdentifiers: [],
     },
   ],
-} as const satisfies EnrichmentSampleManifest;
-
-const sampleById = new Map<string, SampleWork>(
-  ENRICHMENT_SAMPLE_MANIFEST.works.map((work) => [work.workId, work]),
-);
-
-export function getSampleWork(workId: string): SampleWork {
-  const work = sampleById.get(workId);
-  if (!work) {
-    throw new Error(
-      `Enrichment scope refused: work ${workId} is outside ${ENRICHMENT_SAMPLE_MANIFEST.id}@${ENRICHMENT_SAMPLE_MANIFEST.version}`,
-    );
-  }
-  return work;
-}
-
-export function assertSampleScope(workIds: readonly string[]): SampleWork[] {
-  if (workIds.length === 0) {
-    throw new Error(
-      "Enrichment scope refused: at least one work ID is required",
-    );
-  }
-  if (new Set(workIds).size !== workIds.length) {
-    throw new Error(
-      "Enrichment scope refused: duplicate work IDs are not allowed",
-    );
-  }
-  return [...workIds].sort().map(getSampleWork);
-}
+} as const satisfies EnrichmentScopeManifest;
 
 for (const work of ENRICHMENT_SAMPLE_MANIFEST.works) {
   const derived = deterministicCatalogId(

--- a/src/db/catalog/enrichment/types.ts
+++ b/src/db/catalog/enrichment/types.ts
@@ -77,7 +77,7 @@ export type AdapterManifest = {
   proposedEvidenceOnly: true;
 };
 
-export type SampleWork = {
+export type EnrichmentTargetWork = {
   workId: string;
   legacyRecordKey: string;
   title: string;
@@ -86,11 +86,11 @@ export type SampleWork = {
   exactIdentifiers: readonly string[];
 };
 
-export type EnrichmentSampleManifest = {
+export type EnrichmentScopeManifest = {
   id: string;
   version: string;
   reviewedAt: string;
-  works: readonly SampleWork[];
+  works: readonly EnrichmentTargetWork[];
 };
 
 export type EnrichmentEvidence = {

--- a/src/db/catalog/enrichment/types.ts
+++ b/src/db/catalog/enrichment/types.ts
@@ -6,6 +6,7 @@ import type {
 
 export type EnrichmentFieldClass = "metadata" | "text" | "asset";
 export type AdapterState = "enabled" | "pending" | "suspended" | "retired";
+export type AcquisitionStatusClass = "2xx" | "3xx" | "4xx" | "5xx" | "other";
 export type LinkOutcome =
   | "unmatched"
   | "candidate"
@@ -126,9 +127,24 @@ export type ProviderRecord = {
     latencyMs?: number;
     retries?: number;
     status?: number;
+    statusClasses?: Partial<Record<AcquisitionStatusClass, number>>;
+    throttles?: number;
     retryAfterMs?: number;
     responseBytes?: number;
   };
+};
+
+export type EnrichmentRunFailure = {
+  kind: "policy" | "acquisition" | "provider" | "parsing" | "normalization";
+  adapterId: string;
+  recordKey?: string;
+  status?: number;
+  statusClasses?: Partial<Record<AcquisitionStatusClass, number>>;
+  throttles?: number;
+  retries?: number;
+  retryAfterMs?: number;
+  latencyMs?: number;
+  responseBytes?: number;
 };
 
 export type MatchDecision = {
@@ -199,7 +215,7 @@ export type EnrichmentRunReport = {
   conditionalHits: number;
   latencyMs: number;
   retries: number;
-  statusClasses: Record<"2xx" | "3xx" | "4xx" | "5xx" | "other", number>;
+  statusClasses: Record<AcquisitionStatusClass, number>;
   throttles: number;
   retryAfterMs: number;
   responseBytes: number;

--- a/src/db/catalog/enrichment/types.ts
+++ b/src/db/catalog/enrichment/types.ts
@@ -1,0 +1,241 @@
+import type {
+  CatalogEntityType,
+  CatalogFieldKey,
+  ProvenanceKind,
+} from "../values";
+
+export type EnrichmentFieldClass = "metadata" | "text" | "asset";
+export type AdapterState = "enabled" | "pending" | "suspended" | "retired";
+export type LinkOutcome =
+  | "unmatched"
+  | "candidate"
+  | "ambiguous"
+  | "active"
+  | "rejected"
+  | "withdrawn";
+
+export type FieldPermission = {
+  allowedFields: readonly CatalogFieldKey[];
+  fetch: boolean;
+  cache: boolean;
+  retain: "none" | "selected_fields" | "full";
+  transform: boolean;
+  display: boolean;
+};
+
+export type AdapterManifest = {
+  sourceId: string;
+  sourceKey: string;
+  sourceName: string;
+  adapterId: string;
+  adapterVersion: string;
+  sourcePolicyVersion: string;
+  policyReviewDate: string;
+  policySources: readonly string[];
+  state: AdapterState;
+  disabledReason: string | null;
+  nextReviewDate: string;
+  permissions: Record<EnrichmentFieldClass, FieldPermission>;
+  acquisition: {
+    method:
+      | "repository_artifact"
+      | "wikimedia_api"
+      | "licensed_api"
+      | "licensed_feed"
+      | "manual"
+      | "disabled";
+    host: string | null;
+    perHostConcurrency: number;
+    minimumIntervalMs: number;
+    credentials: readonly string[];
+    cache: boolean;
+    conditionalRetrieval: "etag_and_last_modified" | "snapshot" | "none";
+    retry: {
+      ceiling: number;
+      baseDelayMs: number;
+      maximumDelayMs: number;
+      jitterRatio: number;
+      respectRetryAfter: boolean;
+    };
+  };
+  attribution: {
+    required: boolean;
+    text: string | null;
+    url: string | null;
+    placement: string | null;
+  };
+  withdrawal: {
+    tombstone: boolean;
+    purgeRawPayload: boolean;
+    purgeCachedAssets: boolean;
+    recomputeProposals: boolean;
+  };
+  sourceRevision: {
+    kind: "content_hash" | "provider_revision" | "snapshot";
+    required: boolean;
+  };
+  proposedEvidenceOnly: true;
+};
+
+export type SampleWork = {
+  workId: string;
+  legacyRecordKey: string;
+  title: string;
+  orderedCreators: readonly string[];
+  providerRelations: Readonly<Record<string, string>>;
+  exactIdentifiers: readonly string[];
+};
+
+export type EnrichmentSampleManifest = {
+  id: string;
+  version: string;
+  reviewedAt: string;
+  works: readonly SampleWork[];
+};
+
+export type EnrichmentEvidence = {
+  fieldClass: EnrichmentFieldClass;
+  fieldKey: CatalogFieldKey;
+  value: unknown;
+  sourcePath: string;
+  provenanceKind: ProvenanceKind;
+  actorRef?: string;
+  reason?: string;
+};
+
+export type ProviderRecord = {
+  adapterId: string;
+  recordKey: string;
+  sourceRevision: string;
+  retrievedAt: number;
+  targetWorkId: string;
+  title?: string;
+  orderedCreators?: readonly string[];
+  providerWorkId?: string;
+  exactIdentifiers?: readonly string[];
+  strongTuple?: Readonly<Record<string, string>>;
+  identityConflicts?: readonly string[];
+  rejectedReason?: string;
+  state?: "active" | "withdrawn";
+  evidence: readonly EnrichmentEvidence[];
+  rawPayload?: unknown;
+  acquisition?: {
+    successful: boolean;
+    cacheHit?: boolean;
+    conditionalHit?: boolean;
+    latencyMs?: number;
+    retries?: number;
+    status?: number;
+    retryAfterMs?: number;
+    responseBytes?: number;
+  };
+};
+
+export type MatchDecision = {
+  outcome: LinkOutcome;
+  matchKind:
+    | "exact_identifier"
+    | "source_relationship"
+    | "curated"
+    | "candidate";
+  mappingConfidence: number;
+  reason: string;
+};
+
+export type EnrichmentSourceRecord = {
+  id: string;
+  sourceId: string;
+  recordKey: string;
+  upstreamRecordKey: string;
+  sourceRevision: string;
+  sourceModifiedAt: number | null;
+  retrievedAt: number;
+  payloadJson: string | null;
+  payloadHash: string | null;
+  importerVersion: string;
+  sourceRowHash: string;
+  state: "active" | "withdrawn" | "deleted";
+};
+
+export type EnrichmentSourceLink = {
+  id: string;
+  sourceRecordId: string;
+  entityType: CatalogEntityType;
+  entityId: string;
+  matchKind: MatchDecision["matchKind"];
+  mappingConfidence: number;
+  state: "active" | "candidate" | "rejected";
+  outcome: LinkOutcome;
+  actorRef: string | null;
+  reason: string;
+  createdAt: number;
+};
+
+export type EnrichmentObservation = {
+  id: string;
+  sourceRecordId: string;
+  entityType: CatalogEntityType;
+  entityId: string;
+  fieldKey: CatalogFieldKey;
+  valueJson: string;
+  comparisonHash: string;
+  provenanceKind: ProvenanceKind;
+  sourcePath: string;
+  sourceModifiedAt: number | null;
+  retrievedAt: number;
+  mappingConfidence: number;
+  state: "active" | "stale" | "withdrawn" | "invalid";
+  actorRef: string | null;
+  reason: string | null;
+  derivationName: string | null;
+  derivationVersion: string | null;
+  parentIdsJson: string | null;
+};
+
+export type EnrichmentRunReport = {
+  requestedRecords: number;
+  successfulRequests: number;
+  cacheHits: number;
+  conditionalHits: number;
+  latencyMs: number;
+  retries: number;
+  statusClasses: Record<"2xx" | "3xx" | "4xx" | "5xx" | "other", number>;
+  throttles: number;
+  retryAfterMs: number;
+  responseBytes: number;
+  sourceRevisionAgeMs: number;
+  links: Record<LinkOutcome, number>;
+  observations: {
+    created: number;
+    reused: number;
+    rejected: number;
+    omitted: number;
+  };
+  policyBlocks: number;
+  acquisitionFailures: number;
+  providerFailures: number;
+  parsingFailures: number;
+  normalizationFailures: number;
+  reviewQueueCandidates: number;
+};
+
+export type EnrichmentRunArtifact = {
+  runId: string;
+  manifestId: string;
+  manifestVersion: string;
+  contentHash: string;
+  requestedWorkIds: readonly string[];
+  adapterSnapshots: readonly {
+    adapterId: string;
+    adapterVersion: string;
+    sourcePolicyVersion: string;
+    sourceRevision: string;
+    snapshotId: string;
+  }[];
+  metadataSources: readonly Record<string, unknown>[];
+  sourceRecords: readonly EnrichmentSourceRecord[];
+  sourceRecordLinks: readonly EnrichmentSourceLink[];
+  fieldObservations: readonly EnrichmentObservation[];
+  proposedResolutionHeads: readonly [];
+  report: EnrichmentRunReport;
+};

--- a/src/db/catalog/enrichment/workflow.test.ts
+++ b/src/db/catalog/enrichment/workflow.test.ts
@@ -2,13 +2,45 @@ import { describe, expect, it } from "vitest";
 import { canonicalJson, hashCanonicalJson } from "../identity";
 import { SAMPLE_PROVIDER_RECORDS } from "./fixtures";
 import { ENRICHMENT_SAMPLE_MANIFEST } from "./sample-manifest";
-import { buildEnrichmentRun } from "./workflow";
+import type { ProviderRecord } from "./types";
+import { buildEnrichmentRun as buildEnrichmentRunForManifest } from "./workflow";
+
+function buildEnrichmentRun(input: {
+  requestedWorkIds: readonly string[];
+  records: readonly ProviderRecord[];
+}) {
+  return buildEnrichmentRunForManifest({
+    manifest: ENRICHMENT_SAMPLE_MANIFEST,
+    ...input,
+  });
+}
 
 const workIds: string[] = ENRICHMENT_SAMPLE_MANIFEST.works.map(
   (work) => work.workId,
 );
 
 describe("isolated five-work enrichment workflow", () => {
+  it("takes scope identity and targets from an injected manifest", () => {
+    const manifest = {
+      ...ENRICHMENT_SAMPLE_MANIFEST,
+      id: "future-approved-batch",
+      version: "v2",
+      works: [ENRICHMENT_SAMPLE_MANIFEST.works[1]],
+    };
+    const records = SAMPLE_PROVIDER_RECORDS.filter(
+      (record) => record.targetWorkId === manifest.works[0].workId,
+    );
+    const run = buildEnrichmentRunForManifest({
+      manifest,
+      requestedWorkIds: [manifest.works[0].workId],
+      records,
+    });
+
+    expect(run.manifestId).toBe("future-approved-batch");
+    expect(run.manifestVersion).toBe("v2");
+    expect(run.requestedWorkIds).toEqual([manifest.works[0].workId]);
+  });
+
   it("builds deterministic source records, links, and immutable observations", () => {
     const first = buildEnrichmentRun({
       requestedWorkIds: workIds,

--- a/src/db/catalog/enrichment/workflow.test.ts
+++ b/src/db/catalog/enrichment/workflow.test.ts
@@ -2,12 +2,13 @@ import { describe, expect, it } from "vitest";
 import { canonicalJson, hashCanonicalJson } from "../identity";
 import { SAMPLE_PROVIDER_RECORDS } from "./fixtures";
 import { ENRICHMENT_SAMPLE_MANIFEST } from "./sample-manifest";
-import type { ProviderRecord } from "./types";
+import type { EnrichmentRunFailure, ProviderRecord } from "./types";
 import { buildEnrichmentRun as buildEnrichmentRunForManifest } from "./workflow";
 
 function buildEnrichmentRun(input: {
   requestedWorkIds: readonly string[];
   records: readonly ProviderRecord[];
+  failures?: readonly EnrichmentRunFailure[];
 }) {
   return buildEnrichmentRunForManifest({
     manifest: ENRICHMENT_SAMPLE_MANIFEST,
@@ -181,6 +182,111 @@ describe("isolated five-work enrichment workflow", () => {
         records: [SAMPLE_PROVIDER_RECORDS[0], SAMPLE_PROVIDER_RECORDS[0]],
       }),
     ).toThrow("duplicate source record revision");
+  });
+
+  it("hashes structured identity tuples without delimiter collisions", () => {
+    const base = SAMPLE_PROVIDER_RECORDS[0];
+    const left = buildEnrichmentRun({
+      requestedWorkIds: [base.targetWorkId],
+      records: [{ ...base, recordKey: "record@part", sourceRevision: "v1" }],
+    });
+    const right = buildEnrichmentRun({
+      requestedWorkIds: [base.targetWorkId],
+      records: [{ ...base, recordKey: "record", sourceRevision: "part@v1" }],
+    });
+    expect(left.sourceRecords[0].id).not.toBe(right.sourceRecords[0].id);
+    expect(left.sourceRecords[0].recordKey).not.toBe(
+      right.sourceRecords[0].recordKey,
+    );
+
+    const firstSnapshot = buildEnrichmentRun({
+      requestedWorkIds: [base.targetWorkId],
+      records: [
+        { ...base, recordKey: "first", sourceRevision: "a+b" },
+        { ...base, recordKey: "second", sourceRevision: "c" },
+      ],
+    });
+    const secondSnapshot = buildEnrichmentRun({
+      requestedWorkIds: [base.targetWorkId],
+      records: [
+        { ...base, recordKey: "first", sourceRevision: "a" },
+        { ...base, recordKey: "second", sourceRevision: "b+c" },
+      ],
+    });
+    expect(firstSnapshot.adapterSnapshots[0].sourceRevision).not.toBe(
+      secondSnapshot.adapterSnapshots[0].sourceRevision,
+    );
+    expect(firstSnapshot.adapterSnapshots[0].snapshotId).not.toBe(
+      secondSnapshot.adapterSnapshots[0].snapshotId,
+    );
+  });
+
+  it("accounts for policy, acquisition, provider, parsing, and normalization outcomes", () => {
+    const rejected = {
+      ...SAMPLE_PROVIDER_RECORDS[0],
+      rejectedReason: "Reviewed identity rejection",
+      acquisition: {
+        successful: true,
+        status: 200,
+        statusClasses: { "2xx": 1 },
+        throttles: 0,
+      },
+    };
+    const run = buildEnrichmentRun({
+      requestedWorkIds: [rejected.targetWorkId],
+      records: [rejected],
+      failures: [
+        { kind: "policy", adapterId: "pending", recordKey: "policy" },
+        {
+          kind: "acquisition",
+          adapterId: "wikidata.work-facts",
+          recordKey: "network",
+          retries: 2,
+        },
+        {
+          kind: "provider",
+          adapterId: "wikidata.work-facts",
+          recordKey: "Q1",
+          statusClasses: { "4xx": 1, "5xx": 1 },
+          throttles: 1,
+          retryAfterMs: 2_000,
+        },
+        {
+          kind: "parsing",
+          adapterId: "wikidata.work-facts",
+          recordKey: "parse",
+        },
+        {
+          kind: "normalization",
+          adapterId: "wikidata.work-facts",
+          recordKey: "normalize",
+        },
+      ],
+    });
+
+    expect(run.report).toMatchObject({
+      requestedRecords: 6,
+      successfulRequests: 1,
+      policyBlocks: 1,
+      acquisitionFailures: 1,
+      providerFailures: 1,
+      parsingFailures: 1,
+      normalizationFailures: 1,
+      retries: 2,
+      throttles: 1,
+      retryAfterMs: 2_000,
+      statusClasses: {
+        "2xx": 1,
+        "4xx": 1,
+        "5xx": 1,
+      },
+      observations: {
+        created: 0,
+        reused: 0,
+        rejected: 1,
+        omitted: 0,
+      },
+    });
   });
 
   it("records withdrawal without creating observations or heads", () => {

--- a/src/db/catalog/enrichment/workflow.test.ts
+++ b/src/db/catalog/enrichment/workflow.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+import { canonicalJson, hashCanonicalJson } from "../identity";
+import { SAMPLE_PROVIDER_RECORDS } from "./fixtures";
+import { ENRICHMENT_SAMPLE_MANIFEST } from "./sample-manifest";
+import { buildEnrichmentRun } from "./workflow";
+
+const workIds: string[] = ENRICHMENT_SAMPLE_MANIFEST.works.map(
+  (work) => work.workId,
+);
+
+describe("isolated five-work enrichment workflow", () => {
+  it("builds deterministic source records, links, and immutable observations", () => {
+    const first = buildEnrichmentRun({
+      requestedWorkIds: workIds,
+      records: SAMPLE_PROVIDER_RECORDS,
+    });
+    const second = buildEnrichmentRun({
+      requestedWorkIds: [...workIds].reverse(),
+      records: [...SAMPLE_PROVIDER_RECORDS].reverse(),
+    });
+
+    expect(first).toEqual(second);
+    expect(hashCanonicalJson(first)).toBe(hashCanonicalJson(second));
+    expect(first.sourceRecords).toHaveLength(10);
+    expect(first.sourceRecordLinks).toHaveLength(10);
+    expect(first.fieldObservations).toHaveLength(9);
+    expect(first.proposedResolutionHeads).toEqual([]);
+    expect(first.report.links).toMatchObject({
+      active: 9,
+      ambiguous: 1,
+      candidate: 0,
+      unmatched: 0,
+    });
+    expect(first.report.observations).toEqual({
+      created: 9,
+      reused: 0,
+      rejected: 0,
+      omitted: 1,
+    });
+    expect(first.report.reviewQueueCandidates).toBe(1);
+  });
+
+  it("contains only the requested sample and approved adapters", () => {
+    const run = buildEnrichmentRun({
+      requestedWorkIds: workIds,
+      records: SAMPLE_PROVIDER_RECORDS,
+    });
+    expect(new Set(run.requestedWorkIds)).toEqual(new Set(workIds));
+    expect(
+      run.sourceRecordLinks.every((link) => workIds.includes(link.entityId)),
+    ).toBe(true);
+    expect(run.metadataSources.map((source) => source.key).sort()).toEqual([
+      "bukie_editorial",
+      "wikidata",
+    ]);
+    expect(canonicalJson(run)).not.toMatch(
+      /open_library|google_books|worldcat|wikipedia_prose/,
+    );
+  });
+
+  it("creates no display resolution or current-head mutation", () => {
+    const run = buildEnrichmentRun({
+      requestedWorkIds: workIds,
+      records: SAMPLE_PROVIDER_RECORDS,
+    });
+    expect(run.proposedResolutionHeads).toHaveLength(0);
+    expect(
+      run.metadataSources.every((source) =>
+        String(source.metadataPolicy).includes('"proposedEvidenceOnly":true'),
+      ),
+    ).toBe(true);
+    const policyBySource = new Map(
+      run.metadataSources.map((source) => [
+        source.key,
+        JSON.parse(String(source.metadataPolicy)),
+      ]),
+    );
+    expect(policyBySource.get("bukie_editorial")?.display).toBe(true);
+    expect(policyBySource.get("wikidata")?.display).toBe(false);
+    expect(
+      run.metadataSources.every(
+        (source) => JSON.parse(String(source.assetPolicy)).display === false,
+      ),
+    ).toBe(true);
+  });
+
+  it("fails closed for unrequested or out-of-manifest target IDs", () => {
+    const outside = {
+      ...SAMPLE_PROVIDER_RECORDS[0],
+      targetWorkId: "ffffffff-ffff-5fff-8fff-ffffffffffff",
+    };
+    expect(() =>
+      buildEnrichmentRun({
+        requestedWorkIds: workIds,
+        records: [outside],
+      }),
+    ).toThrow("targets an unrequested work");
+    expect(() =>
+      buildEnrichmentRun({
+        requestedWorkIds: [outside.targetWorkId],
+        records: [outside],
+      }),
+    ).toThrow("outside bukie-enrichment-diagnostic-five");
+  });
+
+  it("fails closed for pending policy, absent field permission, and missing revision", () => {
+    expect(() =>
+      buildEnrichmentRun({
+        requestedWorkIds: [workIds[0]],
+        records: [
+          {
+            ...SAMPLE_PROVIDER_RECORDS[0],
+            adapterId: "open-library.metadata",
+          },
+        ],
+      }),
+    ).toThrow("is pending");
+    expect(() =>
+      buildEnrichmentRun({
+        requestedWorkIds: [workIds[0]],
+        records: [
+          {
+            ...SAMPLE_PROVIDER_RECORDS[0],
+            evidence: [
+              {
+                fieldClass: "asset",
+                fieldKey: "edition.covers",
+                value: "/covers/not-allowed.webp",
+                sourcePath: "cover",
+                provenanceKind: "curated",
+              },
+            ],
+          },
+        ],
+      }),
+    ).toThrow("may not acquire asset field edition.covers");
+    expect(() =>
+      buildEnrichmentRun({
+        requestedWorkIds: [workIds[0]],
+        records: [{ ...SAMPLE_PROVIDER_RECORDS[0], sourceRevision: "" }],
+      }),
+    ).toThrow("requires a source revision");
+  });
+
+  it("fails closed when deterministic source-revision identity is duplicated", () => {
+    expect(() =>
+      buildEnrichmentRun({
+        requestedWorkIds: [workIds[0]],
+        records: [SAMPLE_PROVIDER_RECORDS[0], SAMPLE_PROVIDER_RECORDS[0]],
+      }),
+    ).toThrow("duplicate source record revision");
+  });
+
+  it("records withdrawal without creating observations or heads", () => {
+    const withdrawn = buildEnrichmentRun({
+      requestedWorkIds: [workIds[0]],
+      records: [
+        {
+          ...SAMPLE_PROVIDER_RECORDS[0],
+          state: "withdrawn",
+        },
+      ],
+    });
+    expect(withdrawn.sourceRecords[0]?.state).toBe("withdrawn");
+    expect(withdrawn.sourceRecordLinks[0]?.outcome).toBe("withdrawn");
+    expect(withdrawn.fieldObservations).toHaveLength(0);
+    expect(withdrawn.proposedResolutionHeads).toHaveLength(0);
+  });
+
+  it("refuses sensitive or policy-prohibited raw payload retention", () => {
+    expect(() =>
+      buildEnrichmentRun({
+        requestedWorkIds: [workIds[0]],
+        records: [
+          {
+            ...SAMPLE_PROVIDER_RECORDS[0],
+            rawPayload: { authorization: "Bearer secret-value" },
+          },
+        ],
+      }),
+    ).toThrow("sensitive payload fields");
+    expect(() =>
+      buildEnrichmentRun({
+        requestedWorkIds: [workIds[0]],
+        records: [
+          {
+            ...SAMPLE_PROVIDER_RECORDS[0],
+            rawPayload: { title: "Dune" },
+          },
+        ],
+      }),
+    ).toThrow("raw payload retention is not permitted");
+  });
+});

--- a/src/db/catalog/enrichment/workflow.ts
+++ b/src/db/catalog/enrichment/workflow.ts
@@ -12,8 +12,10 @@ import {
   metadataSourceRow,
 } from "./policies";
 import type {
+  AcquisitionStatusClass,
   AdapterManifest,
   EnrichmentRunArtifact,
+  EnrichmentRunFailure,
   EnrichmentRunReport,
   EnrichmentScopeManifest,
   EnrichmentTargetWork,
@@ -121,6 +123,38 @@ function incrementStatus(
   report.statusClasses[key] += 1;
 }
 
+function addStatusClasses(
+  report: EnrichmentRunReport,
+  statuses: Partial<Record<AcquisitionStatusClass, number>> | undefined,
+): boolean {
+  if (!statuses) return false;
+  for (const key of Object.keys(
+    report.statusClasses,
+  ) as AcquisitionStatusClass[]) {
+    report.statusClasses[key] += statuses[key] ?? 0;
+  }
+  return true;
+}
+
+function recordFailure(
+  report: EnrichmentRunReport,
+  failure: EnrichmentRunFailure,
+): void {
+  if (failure.kind === "policy") report.policyBlocks += 1;
+  else if (failure.kind === "acquisition") report.acquisitionFailures += 1;
+  else if (failure.kind === "provider") report.providerFailures += 1;
+  else if (failure.kind === "parsing") report.parsingFailures += 1;
+  else report.normalizationFailures += 1;
+  if (!addStatusClasses(report, failure.statusClasses)) {
+    incrementStatus(report, failure.status);
+  }
+  report.throttles += failure.throttles ?? 0;
+  report.retries += failure.retries ?? 0;
+  report.retryAfterMs += failure.retryAfterMs ?? 0;
+  report.latencyMs += failure.latencyMs ?? 0;
+  report.responseBytes += failure.responseBytes ?? 0;
+}
+
 function containsSensitiveKey(value: unknown): boolean {
   if (Array.isArray(value)) return value.some(containsSensitiveKey);
   if (!value || typeof value !== "object") return false;
@@ -196,6 +230,7 @@ export function buildEnrichmentRun(input: {
   manifest: EnrichmentScopeManifest;
   requestedWorkIds: readonly string[];
   records: readonly ProviderRecord[];
+  failures?: readonly EnrichmentRunFailure[];
 }): EnrichmentRunArtifact {
   const { requestedWorks, workById } = resolveEnrichmentScope(
     input.manifest,
@@ -205,8 +240,12 @@ export function buildEnrichmentRun(input: {
   const records = [...input.records].sort((left, right) =>
     canonicalJson(left).localeCompare(canonicalJson(right)),
   );
+  const failures = [...(input.failures ?? [])].sort((left, right) =>
+    canonicalJson(left).localeCompare(canonicalJson(right)),
+  );
   const report = emptyReport();
-  report.requestedRecords = records.length;
+  report.requestedRecords = records.length + failures.length;
+  for (const failure of failures) recordFailure(report, failure);
   const adapters = new Map<string, AdapterManifest>();
   const recordRevisions = new Set<string>();
   for (const record of records) {
@@ -218,7 +257,11 @@ export function buildEnrichmentRun(input: {
     const adapter = getAdapterManifest(record.adapterId);
     assertAdapterEnabled(adapter);
     assertRecordRevision(adapter, record);
-    const recordRevisionKey = `${adapter.adapterId}:${record.recordKey}:${record.sourceRevision}`;
+    const recordRevisionKey = canonicalJson({
+      adapterId: adapter.adapterId,
+      recordKey: record.recordKey,
+      sourceRevision: record.sourceRevision,
+    });
     if (recordRevisions.has(recordRevisionKey)) {
       throw new Error(
         `Enrichment identity refused: duplicate source record revision ${recordRevisionKey}`,
@@ -245,6 +288,7 @@ export function buildEnrichmentRun(input: {
       .sort((left, right) => left.adapterId.localeCompare(right.adapterId)),
     manifestId: input.manifest.id,
     manifestVersion: input.manifest.version,
+    failures,
     records,
     requestedWorkIds: [...requestedIds].sort(),
     runnerVersion: ENRICHMENT_RUNNER_VERSION,
@@ -278,11 +322,14 @@ export function buildEnrichmentRun(input: {
       report.reviewQueueCandidates += 1;
     }
     const payload = retainedPayload(adapter, record);
-    const upstreamRevisionKey = `${record.recordKey}@${record.sourceRevision}`;
+    const sourceRevisionIdentity = hashCanonicalJson({
+      recordKey: record.recordKey,
+      sourceRevision: record.sourceRevision,
+    });
     const sourceRecordId = deterministicCatalogId(
       "source_record_revision",
       adapter.sourceKey,
-      upstreamRevisionKey,
+      sourceRevisionIdentity,
     );
     const payloadJson = payload === null ? null : canonicalJson(payload);
     const sourceRowHash = hashCanonicalJson({
@@ -294,7 +341,7 @@ export function buildEnrichmentRun(input: {
     sourceRecords.push({
       id: sourceRecordId,
       sourceId: adapter.sourceId,
-      recordKey: upstreamRevisionKey,
+      recordKey: sourceRevisionIdentity,
       upstreamRecordKey: record.recordKey,
       sourceRevision: record.sourceRevision,
       sourceModifiedAt: null,
@@ -308,7 +355,11 @@ export function buildEnrichmentRun(input: {
     const linkId = deterministicCatalogId(
       "source_record_link",
       sourceRecordId,
-      `work:${record.targetWorkId}:${match.outcome}`,
+      hashCanonicalJson({
+        entityId: record.targetWorkId,
+        entityType: "work",
+        outcome: match.outcome,
+      }),
     );
     sourceRecordLinks.push({
       id: linkId,
@@ -339,15 +390,21 @@ export function buildEnrichmentRun(input: {
     report.retries += acquisition?.retries ?? 0;
     report.retryAfterMs += acquisition?.retryAfterMs ?? 0;
     report.responseBytes += acquisition?.responseBytes ?? 0;
-    report.throttles += Number((acquisition?.retryAfterMs ?? 0) > 0);
-    incrementStatus(report, acquisition?.status);
+    report.throttles += acquisition?.throttles ?? 0;
+    if (!addStatusClasses(report, acquisition?.statusClasses)) {
+      incrementStatus(report, acquisition?.status);
+    }
     report.sourceRevisionAgeMs = Math.max(
       report.sourceRevisionAgeMs,
       latestRetrievedAt - record.retrievedAt,
     );
 
     if (match.outcome !== "active") {
-      report.observations.omitted += record.evidence.length;
+      if (match.outcome === "rejected") {
+        report.observations.rejected += record.evidence.length;
+      } else {
+        report.observations.omitted += record.evidence.length;
+      }
       continue;
     }
     for (const evidence of record.evidence) {
@@ -355,7 +412,12 @@ export function buildEnrichmentRun(input: {
       const observationId = deterministicCatalogId(
         "field_observation",
         sourceRecordId,
-        `work:${record.targetWorkId}:${evidence.fieldKey}:${comparisonHash}`,
+        hashCanonicalJson({
+          comparisonHash,
+          entityId: record.targetWorkId,
+          entityType: "work",
+          fieldKey: evidence.fieldKey,
+        }),
       );
       fieldObservations.push({
         id: observationId,
@@ -383,11 +445,11 @@ export function buildEnrichmentRun(input: {
 
   const adapterSnapshots = [...adapters.values()]
     .map((adapter) => {
-      const sourceRevision = records
+      const sourceRevisions = records
         .filter((record) => record.adapterId === adapter.adapterId)
         .map((record) => record.sourceRevision)
-        .sort()
-        .join("+");
+        .sort();
+      const sourceRevision = hashCanonicalJson(sourceRevisions);
       return {
         adapterId: adapter.adapterId,
         adapterVersion: adapter.adapterVersion,

--- a/src/db/catalog/enrichment/workflow.ts
+++ b/src/db/catalog/enrichment/workflow.ts
@@ -11,20 +11,55 @@ import {
   getAdapterManifest,
   metadataSourceRow,
 } from "./policies";
-import {
-  assertSampleScope,
-  ENRICHMENT_SAMPLE_MANIFEST,
-  getSampleWork,
-} from "./sample-manifest";
 import type {
   AdapterManifest,
   EnrichmentRunArtifact,
   EnrichmentRunReport,
+  EnrichmentScopeManifest,
+  EnrichmentTargetWork,
   LinkOutcome,
   ProviderRecord,
 } from "./types";
 
 export const ENRICHMENT_RUNNER_VERSION = "catalog-enrichment-runner-v1";
+
+export function resolveEnrichmentScope(
+  manifest: EnrichmentScopeManifest,
+  workIds: readonly string[],
+): {
+  requestedWorks: EnrichmentTargetWork[];
+  workById: Map<string, EnrichmentTargetWork>;
+} {
+  if (workIds.length === 0) {
+    throw new Error(
+      "Enrichment scope refused: at least one work ID is required",
+    );
+  }
+  if (new Set(workIds).size !== workIds.length) {
+    throw new Error(
+      "Enrichment scope refused: duplicate work IDs are not allowed",
+    );
+  }
+  const workById = new Map<string, EnrichmentTargetWork>();
+  for (const work of manifest.works) {
+    if (workById.has(work.workId)) {
+      throw new Error(
+        `Enrichment scope refused: manifest ${manifest.id}@${manifest.version} contains duplicate work ${work.workId}`,
+      );
+    }
+    workById.set(work.workId, work);
+  }
+  const requestedWorks = [...workIds].sort().map((workId) => {
+    const work = workById.get(workId);
+    if (!work) {
+      throw new Error(
+        `Enrichment scope refused: work ${workId} is outside ${manifest.id}@${manifest.version}`,
+      );
+    }
+    return work;
+  });
+  return { requestedWorks, workById };
+}
 
 function emptyReport(): EnrichmentRunReport {
   return {
@@ -158,10 +193,14 @@ function assertRecordRevision(
 }
 
 export function buildEnrichmentRun(input: {
+  manifest: EnrichmentScopeManifest;
   requestedWorkIds: readonly string[];
   records: readonly ProviderRecord[];
 }): EnrichmentRunArtifact {
-  const requestedWorks = assertSampleScope(input.requestedWorkIds);
+  const { requestedWorks, workById } = resolveEnrichmentScope(
+    input.manifest,
+    input.requestedWorkIds,
+  );
   const requestedIds = new Set(requestedWorks.map((work) => work.workId));
   const records = [...input.records].sort((left, right) =>
     canonicalJson(left).localeCompare(canonicalJson(right)),
@@ -204,15 +243,15 @@ export function buildEnrichmentRun(input: {
         sourcePolicyVersion: adapter.sourcePolicyVersion,
       }))
       .sort((left, right) => left.adapterId.localeCompare(right.adapterId)),
-    manifestId: ENRICHMENT_SAMPLE_MANIFEST.id,
-    manifestVersion: ENRICHMENT_SAMPLE_MANIFEST.version,
+    manifestId: input.manifest.id,
+    manifestVersion: input.manifest.version,
     records,
     requestedWorkIds: [...requestedIds].sort(),
     runnerVersion: ENRICHMENT_RUNNER_VERSION,
   });
   const runId = deterministicCatalogId(
     "enrichment_run",
-    ENRICHMENT_SAMPLE_MANIFEST.id,
+    input.manifest.id,
     runInputHash,
   );
   const sourceRecords: EnrichmentRunArtifact["sourceRecords"][number][] = [];
@@ -227,7 +266,12 @@ export function buildEnrichmentRun(input: {
 
   for (const record of records) {
     const adapter = getAdapterManifest(record.adapterId);
-    const target = getSampleWork(record.targetWorkId);
+    const target = workById.get(record.targetWorkId);
+    if (!target) {
+      throw new Error(
+        `Enrichment scope refused: provider record ${record.recordKey} targets work ${record.targetWorkId} outside ${input.manifest.id}@${input.manifest.version}`,
+      );
+    }
     const match = matchProviderRecord({ adapter, record, target });
     report.links[match.outcome] += 1;
     if (match.outcome === "candidate" || match.outcome === "ambiguous") {
@@ -354,7 +398,7 @@ export function buildEnrichmentRun(input: {
           adapter.sourceKey,
           hashCanonicalJson({
             adapterVersion: adapter.adapterVersion,
-            manifestVersion: ENRICHMENT_SAMPLE_MANIFEST.version,
+            manifestVersion: input.manifest.version,
             sourcePolicyVersion: adapter.sourcePolicyVersion,
             sourceRevision,
           }),
@@ -373,8 +417,8 @@ export function buildEnrichmentRun(input: {
   fieldObservations.sort((left, right) => left.id.localeCompare(right.id));
   const artifactWithoutHash = {
     runId,
-    manifestId: ENRICHMENT_SAMPLE_MANIFEST.id,
-    manifestVersion: ENRICHMENT_SAMPLE_MANIFEST.version,
+    manifestId: input.manifest.id,
+    manifestVersion: input.manifest.version,
     requestedWorkIds: [...requestedIds].sort(),
     adapterSnapshots,
     metadataSources,

--- a/src/db/catalog/enrichment/workflow.ts
+++ b/src/db/catalog/enrichment/workflow.ts
@@ -1,0 +1,391 @@
+import {
+  canonicalJson,
+  deterministicCatalogId,
+  hashCanonicalJson,
+} from "../identity";
+import { sanitizeDiagnostic } from "./acquisition";
+import { matchProviderRecord } from "./matching";
+import {
+  assertAdapterEnabled,
+  authorizeField,
+  getAdapterManifest,
+  metadataSourceRow,
+} from "./policies";
+import {
+  assertSampleScope,
+  ENRICHMENT_SAMPLE_MANIFEST,
+  getSampleWork,
+} from "./sample-manifest";
+import type {
+  AdapterManifest,
+  EnrichmentRunArtifact,
+  EnrichmentRunReport,
+  LinkOutcome,
+  ProviderRecord,
+} from "./types";
+
+export const ENRICHMENT_RUNNER_VERSION = "catalog-enrichment-runner-v1";
+
+function emptyReport(): EnrichmentRunReport {
+  return {
+    requestedRecords: 0,
+    successfulRequests: 0,
+    cacheHits: 0,
+    conditionalHits: 0,
+    latencyMs: 0,
+    retries: 0,
+    statusClasses: {
+      "2xx": 0,
+      "3xx": 0,
+      "4xx": 0,
+      "5xx": 0,
+      other: 0,
+    },
+    throttles: 0,
+    retryAfterMs: 0,
+    responseBytes: 0,
+    sourceRevisionAgeMs: 0,
+    links: {
+      unmatched: 0,
+      candidate: 0,
+      ambiguous: 0,
+      active: 0,
+      rejected: 0,
+      withdrawn: 0,
+    },
+    observations: {
+      created: 0,
+      reused: 0,
+      rejected: 0,
+      omitted: 0,
+    },
+    policyBlocks: 0,
+    acquisitionFailures: 0,
+    providerFailures: 0,
+    parsingFailures: 0,
+    normalizationFailures: 0,
+    reviewQueueCandidates: 0,
+  };
+}
+
+function incrementStatus(
+  report: EnrichmentRunReport,
+  status: number | undefined,
+) {
+  if (status === undefined) return;
+  const key =
+    status >= 200 && status < 300
+      ? "2xx"
+      : status >= 300 && status < 400
+        ? "3xx"
+        : status >= 400 && status < 500
+          ? "4xx"
+          : status >= 500 && status < 600
+            ? "5xx"
+            : "other";
+  report.statusClasses[key] += 1;
+}
+
+function containsSensitiveKey(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(containsSensitiveKey);
+  if (!value || typeof value !== "object") return false;
+  return Object.entries(value).some(
+    ([key, entry]) =>
+      /authorization|cookie|credential|password|secret|token|api[-_]?key/i.test(
+        key,
+      ) || containsSensitiveKey(entry),
+  );
+}
+
+function retainedPayload(
+  adapter: AdapterManifest,
+  record: ProviderRecord,
+): unknown | null {
+  if (record.state === "withdrawn" && adapter.withdrawal.purgeRawPayload) {
+    return null;
+  }
+  const permissions = record.evidence.map(
+    (entry) => adapter.permissions[entry.fieldClass],
+  );
+  if (record.rawPayload !== undefined) {
+    if (containsSensitiveKey(record.rawPayload)) {
+      throw new Error(
+        `Enrichment retention refused: sensitive payload fields were supplied for ${adapter.adapterId}`,
+      );
+    }
+    if (!permissions.some((permission) => permission.retain === "full")) {
+      throw new Error(
+        `Enrichment retention refused: raw payload retention is not permitted for ${adapter.adapterId}`,
+      );
+    }
+    return sanitizeDiagnostic(record.rawPayload);
+  }
+  if (
+    permissions.some(
+      (permission) =>
+        permission.retain === "selected_fields" || permission.retain === "full",
+    )
+  ) {
+    return {
+      evidence: record.evidence.map((entry) => ({
+        fieldClass: entry.fieldClass,
+        fieldKey: entry.fieldKey,
+        sourcePath: entry.sourcePath,
+        value: entry.value,
+      })),
+      recordKey: record.recordKey,
+      targetWorkId: record.targetWorkId,
+    };
+  }
+  return null;
+}
+
+function linkState(outcome: LinkOutcome): "active" | "candidate" | "rejected" {
+  if (outcome === "active") return "active";
+  if (outcome === "rejected") return "rejected";
+  return "candidate";
+}
+
+function assertRecordRevision(
+  adapter: AdapterManifest,
+  record: ProviderRecord,
+) {
+  if (adapter.sourceRevision.required && !record.sourceRevision.trim()) {
+    throw new Error(
+      `Enrichment identity refused: ${adapter.adapterId} requires a source revision`,
+    );
+  }
+}
+
+export function buildEnrichmentRun(input: {
+  requestedWorkIds: readonly string[];
+  records: readonly ProviderRecord[];
+}): EnrichmentRunArtifact {
+  const requestedWorks = assertSampleScope(input.requestedWorkIds);
+  const requestedIds = new Set(requestedWorks.map((work) => work.workId));
+  const records = [...input.records].sort((left, right) =>
+    canonicalJson(left).localeCompare(canonicalJson(right)),
+  );
+  const report = emptyReport();
+  report.requestedRecords = records.length;
+  const adapters = new Map<string, AdapterManifest>();
+  const recordRevisions = new Set<string>();
+  for (const record of records) {
+    if (!requestedIds.has(record.targetWorkId)) {
+      throw new Error(
+        `Enrichment scope refused: provider record ${record.recordKey} targets an unrequested work`,
+      );
+    }
+    const adapter = getAdapterManifest(record.adapterId);
+    assertAdapterEnabled(adapter);
+    assertRecordRevision(adapter, record);
+    const recordRevisionKey = `${adapter.adapterId}:${record.recordKey}:${record.sourceRevision}`;
+    if (recordRevisions.has(recordRevisionKey)) {
+      throw new Error(
+        `Enrichment identity refused: duplicate source record revision ${recordRevisionKey}`,
+      );
+    }
+    recordRevisions.add(recordRevisionKey);
+    adapters.set(adapter.adapterId, adapter);
+    for (const evidence of record.evidence) {
+      authorizeField({
+        adapter,
+        fieldClass: evidence.fieldClass,
+        fieldKey: evidence.fieldKey,
+      });
+    }
+  }
+
+  const runInputHash = hashCanonicalJson({
+    adapters: [...adapters.values()]
+      .map((adapter) => ({
+        adapterId: adapter.adapterId,
+        adapterVersion: adapter.adapterVersion,
+        sourcePolicyVersion: adapter.sourcePolicyVersion,
+      }))
+      .sort((left, right) => left.adapterId.localeCompare(right.adapterId)),
+    manifestId: ENRICHMENT_SAMPLE_MANIFEST.id,
+    manifestVersion: ENRICHMENT_SAMPLE_MANIFEST.version,
+    records,
+    requestedWorkIds: [...requestedIds].sort(),
+    runnerVersion: ENRICHMENT_RUNNER_VERSION,
+  });
+  const runId = deterministicCatalogId(
+    "enrichment_run",
+    ENRICHMENT_SAMPLE_MANIFEST.id,
+    runInputHash,
+  );
+  const sourceRecords: EnrichmentRunArtifact["sourceRecords"][number][] = [];
+  const sourceRecordLinks: EnrichmentRunArtifact["sourceRecordLinks"][number][] =
+    [];
+  const fieldObservations: EnrichmentRunArtifact["fieldObservations"][number][] =
+    [];
+  const latestRetrievedAt = Math.max(
+    0,
+    ...records.map((record) => record.retrievedAt),
+  );
+
+  for (const record of records) {
+    const adapter = getAdapterManifest(record.adapterId);
+    const target = getSampleWork(record.targetWorkId);
+    const match = matchProviderRecord({ adapter, record, target });
+    report.links[match.outcome] += 1;
+    if (match.outcome === "candidate" || match.outcome === "ambiguous") {
+      report.reviewQueueCandidates += 1;
+    }
+    const payload = retainedPayload(adapter, record);
+    const upstreamRevisionKey = `${record.recordKey}@${record.sourceRevision}`;
+    const sourceRecordId = deterministicCatalogId(
+      "source_record_revision",
+      adapter.sourceKey,
+      upstreamRevisionKey,
+    );
+    const payloadJson = payload === null ? null : canonicalJson(payload);
+    const sourceRowHash = hashCanonicalJson({
+      payload,
+      recordKey: record.recordKey,
+      sourceRevision: record.sourceRevision,
+      state: record.state ?? "active",
+    });
+    sourceRecords.push({
+      id: sourceRecordId,
+      sourceId: adapter.sourceId,
+      recordKey: upstreamRevisionKey,
+      upstreamRecordKey: record.recordKey,
+      sourceRevision: record.sourceRevision,
+      sourceModifiedAt: null,
+      retrievedAt: record.retrievedAt,
+      payloadJson,
+      payloadHash: payloadJson ? hashCanonicalJson(payload) : null,
+      importerVersion: ENRICHMENT_RUNNER_VERSION,
+      sourceRowHash,
+      state: record.state === "withdrawn" ? "withdrawn" : "active",
+    });
+    const linkId = deterministicCatalogId(
+      "source_record_link",
+      sourceRecordId,
+      `work:${record.targetWorkId}:${match.outcome}`,
+    );
+    sourceRecordLinks.push({
+      id: linkId,
+      sourceRecordId,
+      entityType: "work",
+      entityId: record.targetWorkId,
+      matchKind: match.matchKind,
+      mappingConfidence: match.mappingConfidence,
+      state: linkState(match.outcome),
+      outcome: match.outcome,
+      actorRef:
+        match.matchKind === "curated" || match.outcome === "rejected"
+          ? "system:catalog-enrichment"
+          : null,
+      reason: match.reason,
+      createdAt: record.retrievedAt,
+    });
+
+    const acquisition = record.acquisition;
+    if (acquisition?.successful) report.successfulRequests += 1;
+    else if (acquisition) {
+      if ((acquisition.status ?? 0) >= 400) report.providerFailures += 1;
+      else report.acquisitionFailures += 1;
+    }
+    report.cacheHits += Number(acquisition?.cacheHit ?? false);
+    report.conditionalHits += Number(acquisition?.conditionalHit ?? false);
+    report.latencyMs += acquisition?.latencyMs ?? 0;
+    report.retries += acquisition?.retries ?? 0;
+    report.retryAfterMs += acquisition?.retryAfterMs ?? 0;
+    report.responseBytes += acquisition?.responseBytes ?? 0;
+    report.throttles += Number((acquisition?.retryAfterMs ?? 0) > 0);
+    incrementStatus(report, acquisition?.status);
+    report.sourceRevisionAgeMs = Math.max(
+      report.sourceRevisionAgeMs,
+      latestRetrievedAt - record.retrievedAt,
+    );
+
+    if (match.outcome !== "active") {
+      report.observations.omitted += record.evidence.length;
+      continue;
+    }
+    for (const evidence of record.evidence) {
+      const comparisonHash = hashCanonicalJson(evidence.value);
+      const observationId = deterministicCatalogId(
+        "field_observation",
+        sourceRecordId,
+        `work:${record.targetWorkId}:${evidence.fieldKey}:${comparisonHash}`,
+      );
+      fieldObservations.push({
+        id: observationId,
+        sourceRecordId,
+        entityType: "work",
+        entityId: record.targetWorkId,
+        fieldKey: evidence.fieldKey,
+        valueJson: canonicalJson(evidence.value),
+        comparisonHash,
+        provenanceKind: evidence.provenanceKind,
+        sourcePath: evidence.sourcePath,
+        sourceModifiedAt: null,
+        retrievedAt: record.retrievedAt,
+        mappingConfidence: match.mappingConfidence,
+        state: record.state === "withdrawn" ? "withdrawn" : "active",
+        actorRef: evidence.actorRef ?? null,
+        reason: evidence.reason ?? null,
+        derivationName: null,
+        derivationVersion: null,
+        parentIdsJson: null,
+      });
+      report.observations.created += 1;
+    }
+  }
+
+  const adapterSnapshots = [...adapters.values()]
+    .map((adapter) => {
+      const sourceRevision = records
+        .filter((record) => record.adapterId === adapter.adapterId)
+        .map((record) => record.sourceRevision)
+        .sort()
+        .join("+");
+      return {
+        adapterId: adapter.adapterId,
+        adapterVersion: adapter.adapterVersion,
+        sourcePolicyVersion: adapter.sourcePolicyVersion,
+        sourceRevision,
+        snapshotId: deterministicCatalogId(
+          "source_snapshot",
+          adapter.sourceKey,
+          hashCanonicalJson({
+            adapterVersion: adapter.adapterVersion,
+            manifestVersion: ENRICHMENT_SAMPLE_MANIFEST.version,
+            sourcePolicyVersion: adapter.sourcePolicyVersion,
+            sourceRevision,
+          }),
+        ),
+      };
+    })
+    .sort((left, right) => left.adapterId.localeCompare(right.adapterId));
+
+  const metadataSources = [...adapters.values()]
+    .map(metadataSourceRow)
+    .sort((left, right) =>
+      canonicalJson(left).localeCompare(canonicalJson(right)),
+    );
+  sourceRecords.sort((left, right) => left.id.localeCompare(right.id));
+  sourceRecordLinks.sort((left, right) => left.id.localeCompare(right.id));
+  fieldObservations.sort((left, right) => left.id.localeCompare(right.id));
+  const artifactWithoutHash = {
+    runId,
+    manifestId: ENRICHMENT_SAMPLE_MANIFEST.id,
+    manifestVersion: ENRICHMENT_SAMPLE_MANIFEST.version,
+    requestedWorkIds: [...requestedIds].sort(),
+    adapterSnapshots,
+    metadataSources,
+    sourceRecords,
+    sourceRecordLinks,
+    fieldObservations,
+    proposedResolutionHeads: [] as const,
+    report,
+  };
+  return {
+    ...artifactWithoutHash,
+    contentHash: hashCanonicalJson(artifactWithoutHash),
+  };
+}


### PR DESCRIPTION
## Summary

- add provider-neutral, field-specific policy manifests for Bukie editorial evidence and Wikidata work-fact candidates
- inject versioned scope manifests into the generic enrichment engine while keeping the executable command locked to the diagnostic five
- acquire, match, report, and persist deterministic proposed evidence without writing resolutions, current heads, or reader-facing projections

## Five-work execution boundary

The executable workflow accepts only `bukie-enrichment-diagnostic-five@2026-07-28.v1`:

- Dune — `7adeda04-34e2-5a7d-a101-de0578138b29`
- Moby-Dick — `00a218bd-3005-59cd-9c23-13efb48abe5a`
- The City and the Stars — `00a01d7f-3f29-5c95-a292-c70a4e5dbb4f`
- Born a Crime — `03ac5ae7-dcf1-5fe7-b6ac-b8f171459fb3`
- Faithful Place — `0100088c-3aca-5e52-9e7a-fb89192e9248`

Requests outside that manifest fail before acquisition or persistence. The command builds its baseline directly from the manifest and never loads or scans the approximately 500-work catalog. The engine receives the manifest as an input so #135 can later supply reviewed, checkpointed batches without rewriting adapters, matching, normalization, or persistence.

## Approved and disabled providers

- enabled as proposed evidence only: `bukie.editorial`, `wikidata.work-facts`
- explicitly pending with disabled reasons and review dates: Open Library metadata/descriptions/covers, Google Books, official publishers, WorldCat/OCLC, commercial ISBN feeds, Wikipedia prose, and retailer/competitor/search content
- every adapter declares separate metadata, text, and asset permissions plus stable versions, acquisition controls, retention, attribution, withdrawal, and review policy

No provider is scraped. Automated acquisition coverage uses injected fixtures and fakes.

## Identity and rights safeguards

- deterministic UUIDv5 identities cover runs, snapshots, source-record revisions, proposed links, and observations
- collision-safe canonical tuple hashes are used instead of delimiter-concatenated identity keys
- persistence verifies every reused row is semantically identical and rolls back the transaction on immutable-revision conflicts
- exact identifiers and provider-native relations are strongest; title plus ordered creator remains a candidate; title alone never activates a link
- ambiguous, adaptation, translation, and edition conflicts remain review outcomes
- Wikidata candidates are work-level only and cannot become edition authority
- field policy, retention policy, credentials, source revisions, retry ceilings, and sensitive-payload checks fail closed
- pending providers cannot create display-eligible evidence or resolution heads

## Idempotency and database parity

The disposable SQLite workflow persists the same recorded revision twice:

- first pass: 2 sources, 10 source records, 10 links, and 9 observations created
- second pass: 0 logical rows created; all existing rows reused
- identical isolated snapshot hash after both passes
- identical complete current-resolution-head hash before and after both transactions

SQLite and Postgres serializers produce equivalent logical rows. CI now provisions an isolated PostgreSQL 16 service and runs the enrichment persistence acceptance test against `CATALOG_TEST_POSTGRES_URL`, including idempotency, current-head isolation, and immutable-conflict rollback coverage.

## Validation

- `bun run lint`
- `bun run test` — 209 passed, 2 environment-gated local skips
- `bun run build:ci`
- `bunx tsc --noEmit`
- targeted enrichment, catalog, importer, identity, normalization, resolver, schema-parity, retry, cache, policy, telemetry, identity-collision, immutable-conflict, and withdrawal coverage
- disposable five-work workflow run twice with stable hashes
- dedicated isolated PostgreSQL CI job
- `git diff --check`

Storybook and Playwright are inapplicable because this is a backend/database-only change with no reader-facing behavior.

## Known sample gaps

- Dune's Wikidata result remains ambiguous because same-title adaptations and series results were present; its observation is omitted and queued for review
- the other four recorded Wikidata work relations activate conservatively
- first-publication fields, descriptions, covers, catalog-wide execution, promotion, and reader-facing changes remain deferred to #132–#136

## Write-isolation confirmation

- no catalog-wide scan or backfill
- no production or preview database mutation
- no current public resolution-head, projection, preferred-edition, cover-pointer, page-metadata, or structured-data writes
- no pending-provider writes or display eligibility
- no prohibited raw payload or secret committed

Closes #131
