### PR TITLE
feat(catalog): resolve work first publication

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,7 @@ jobs:
         run: >-
           bun run test --
           src/db/catalog/enrichment/persistence.pg.test.ts
+          src/db/catalog/work-first-publication.pg.test.ts
           --no-file-parallelism
         env:
           CATALOG_TEST_POSTGRES_URL: postgresql://bukie_test:bukie_test@127.0.0.1:5432/bukie_catalog_test

--- a/docs/catalog-enrichment.md
+++ b/docs/catalog-enrichment.md
@@ -71,7 +71,7 @@ isolated target, and they cannot create or advance current resolution heads.
 | Adapter | State | Metadata | Text | Assets | Operational decision |
 |---|---|---|---|---|---|
 | `bukie.editorial` | enabled | `work.preferred_title` | `work.description` | none | Bukie-owned evidence; internal actor/reason audit required |
-| `wikidata.work-facts` | enabled | `work.preferred_title` candidate | none | none | CC0 structured work facts only; no edition authority and no Wikipedia prose |
+| `wikidata.work-facts` | enabled | `work.preferred_title` and `work.first_publication_date` candidates | none | none | CC0 structured work facts only; no edition authority and no Wikipedia prose |
 | `open-library.metadata` | pending | none | none | none | Retention, display, and bulk-access policy pending |
 | `open-library.descriptions` | pending | none | none | none | Third-party prose rights policy pending |
 | `open-library.covers` | pending | none | none | none | Identity, caching, transformation, and asset-display policy pending |

--- a/docs/database-architecture.md
+++ b/docs/database-architecture.md
@@ -78,18 +78,19 @@ status and retrieval date as permitted by ADR 0016.
 ## Enrichment boundary
 
 The [book-detail enrichment benchmark](./research/book-detail-enrichment.md)
-recommends a future nullable, provenance-resolved work first-publication fact.
-It is separate from the preferred edition's publication date and must not
-change the current period filters or publication sort unless a later product
-decision explicitly does so.
+defines a nullable, provenance-resolved work first-publication fact. It is
+stored as `first_publication_date` plus precision and a derived sort date on
+`works`, resolved under `work.first_publication_date`. It is separate from the
+preferred edition's publication date and does not change period filters or
+publication sorting.
 
-The approved semantic shape is
-`first_publication_date` plus precision and a derived sort date on `works`,
-resolved under `work.first_publication_date`. It is not present in the current
-21-table runtime schema. A focused implementation must update SQLite and
-Postgres together, add resolution and projection tests, and backfill only from
-approved work evidence. Edition dates are never copied as an inferred
-work-level fact.
+The dedicated resolver promotes one explicitly selected work at a time. It
+advances immutable resolution history, the current head, and the three work
+projection columns in one transaction. Compatible partial dates select the
+greatest supported precision; conflicts and ineligible evidence clear the
+projection. Proposed-only enrichment evidence cannot be promoted. Migrations
+initialize every existing work projection to null and never copy an edition
+date.
 
 All other enrichment continues through source records, immutable observations,
 resolution heads, and the existing display-eligibility checks. Dry runs write
@@ -101,7 +102,9 @@ The issue #131
 isolated proposed-evidence boundary for the versioned five-work diagnostic
 manifest. It registers only Bukie editorial and Wikidata work-fact adapters as
 enabled, keeps every other researched provider pending, and exposes no current
-resolution-head write path.
+resolution-head write path. The first-publication resolver remains a separate
+explicit promotion boundary and does not turn that diagnostic workflow into a
+catalog-wide write path.
 
 ## Initialization
 

--- a/docs/decisions/0016-catalog-metadata-provenance.md
+++ b/docs/decisions/0016-catalog-metadata-provenance.md
@@ -352,9 +352,9 @@ explicitly an ISO partial date. IDs are opaque text UUIDs.
 | | `preferred_title` | R,P | Selected work title; non-empty |
 | | `sort_title` | D | Normalized title for ordering, never displayed |
 | | `description` | O,P | Selected work-level description |
-| | `first_publication_date` | O,P | Recommended ISO partial date of the work's first publication; not yet implemented |
-| | `first_publication_precision` | O,D | Recommended `year`, `month` or `day`, consistent with the work date |
-| | `first_publication_sort_date` | O,D | Recommended full ISO date for sorting only |
+| | `first_publication_date` | O,P | ISO partial date of the work's first publication, selected only from eligible work evidence |
+| | `first_publication_precision` | O,D | `year`, `month` or `day`, consistent with the work date |
+| | `first_publication_sort_date` | O,D | Full ISO date for sorting only; not used by current catalog sorting |
 | | `preferred_edition_id` | O,D | Selected display edition; must belong to this work |
 | | `created_at`, `updated_at` | R | Catalog audit timestamps |
 | `editions` | `id` | R | Internal immutable edition ID; existing `books.id` is copied exactly |

--- a/drizzle/0005_cuddly_bloodscream.sql
+++ b/drizzle/0005_cuddly_bloodscream.sql
@@ -1,0 +1,116 @@
+PRAGMA defer_foreign_keys=ON;--> statement-breakpoint
+CREATE TABLE `__new_field_observations` (
+	`id` text PRIMARY KEY NOT NULL,
+	`source_record_id` text NOT NULL,
+	`entity_type` text NOT NULL,
+	`entity_id` text NOT NULL,
+	`field_key` text NOT NULL,
+	`value_json` text NOT NULL,
+	`comparison_hash` text NOT NULL,
+	`provenance_kind` text NOT NULL,
+	`source_path` text,
+	`source_modified_at` integer,
+	`retrieved_at` integer NOT NULL,
+	`mapping_confidence` real NOT NULL,
+	`state` text NOT NULL,
+	`actor_ref` text,
+	`reason` text,
+	`derivation_name` text,
+	`derivation_version` text,
+	`parent_ids_json` text,
+	FOREIGN KEY (`source_record_id`) REFERENCES `source_records`(`id`) ON UPDATE no action ON DELETE restrict,
+	CONSTRAINT "field_observations_target_ck" CHECK("__new_field_observations"."entity_type" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and "__new_field_observations"."field_key" in ('work.preferred_title', 'work.description', 'work.first_publication_date', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')),
+	CONSTRAINT "field_observations_json_ck" CHECK(json_valid("__new_field_observations"."value_json") and ("__new_field_observations"."parent_ids_json" is null or json_valid("__new_field_observations"."parent_ids_json"))),
+	CONSTRAINT "field_observations_hash_ck" CHECK(length("__new_field_observations"."comparison_hash") = 64),
+	CONSTRAINT "field_observations_provenance_ck" CHECK("__new_field_observations"."provenance_kind" in ('curated', 'imported', 'derived', 'synthetic')),
+	CONSTRAINT "field_observations_state_ck" CHECK("__new_field_observations"."state" in ('active', 'stale', 'withdrawn', 'invalid')),
+	CONSTRAINT "field_observations_confidence_ck" CHECK("__new_field_observations"."mapping_confidence" between 0 and 1),
+	CONSTRAINT "field_observations_curated_ck" CHECK("__new_field_observations"."provenance_kind" <> 'curated'
+        or (length(trim("__new_field_observations"."actor_ref")) > 0 and length(trim("__new_field_observations"."reason")) > 0)),
+	CONSTRAINT "field_observations_derived_ck" CHECK("__new_field_observations"."provenance_kind" <> 'derived'
+        or (
+          length(trim("__new_field_observations"."derivation_name")) > 0
+          and length(trim("__new_field_observations"."derivation_version")) > 0
+          and json_valid("__new_field_observations"."parent_ids_json")
+        ))
+);--> statement-breakpoint
+INSERT INTO `__new_field_observations` SELECT * FROM `field_observations`;--> statement-breakpoint
+CREATE TABLE `__new_field_resolutions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`entity_type` text NOT NULL,
+	`entity_id` text NOT NULL,
+	`field_key` text NOT NULL,
+	`selected_observation_id` text,
+	`state` text NOT NULL,
+	`reason` text NOT NULL,
+	`previous_resolution_id` text,
+	`actor_ref` text NOT NULL,
+	`resolver_version` text NOT NULL,
+	`resolved_at` integer NOT NULL,
+	FOREIGN KEY (`selected_observation_id`) REFERENCES `__new_field_observations`(`id`) ON UPDATE no action ON DELETE restrict,
+	FOREIGN KEY (`previous_resolution_id`) REFERENCES `__new_field_resolutions`(`id`) ON UPDATE no action ON DELETE restrict,
+	CONSTRAINT "field_resolutions_target_ck" CHECK("__new_field_resolutions"."entity_type" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and "__new_field_resolutions"."field_key" in ('work.preferred_title', 'work.description', 'work.first_publication_date', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')),
+	CONSTRAINT "field_resolutions_state_ck" CHECK("__new_field_resolutions"."state" in ('present', 'missing', 'conflicting', 'stale', 'withdrawn')),
+	CONSTRAINT "field_resolutions_selection_ck" CHECK((
+        "__new_field_resolutions"."state" in ('present', 'stale')
+        and "__new_field_resolutions"."selected_observation_id" is not null
+      ) or (
+        "__new_field_resolutions"."state" in ('missing', 'conflicting', 'withdrawn')
+        and "__new_field_resolutions"."selected_observation_id" is null
+      )),
+	CONSTRAINT "field_resolutions_nonempty_ck" CHECK(length(trim("__new_field_resolutions"."reason")) > 0
+        and length(trim("__new_field_resolutions"."actor_ref")) > 0
+        and length(trim("__new_field_resolutions"."resolver_version")) > 0)
+);--> statement-breakpoint
+INSERT INTO `__new_field_resolutions` SELECT * FROM `field_resolutions`;--> statement-breakpoint
+CREATE TABLE `__new_field_resolution_heads` (
+	`entity_type` text NOT NULL,
+	`entity_id` text NOT NULL,
+	`field_key` text NOT NULL,
+	`resolution_id` text NOT NULL,
+	PRIMARY KEY(`entity_type`, `entity_id`, `field_key`),
+	FOREIGN KEY (`resolution_id`) REFERENCES `__new_field_resolutions`(`id`) ON UPDATE no action ON DELETE restrict,
+	CONSTRAINT "field_resolution_heads_target_ck" CHECK("__new_field_resolution_heads"."entity_type" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and "__new_field_resolution_heads"."field_key" in ('work.preferred_title', 'work.description', 'work.first_publication_date', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count'))
+);--> statement-breakpoint
+INSERT INTO `__new_field_resolution_heads` SELECT * FROM `field_resolution_heads`;--> statement-breakpoint
+DROP TABLE `field_resolution_heads`;--> statement-breakpoint
+DROP TABLE `field_resolutions`;--> statement-breakpoint
+DROP TABLE `field_observations`;--> statement-breakpoint
+ALTER TABLE `__new_field_observations` RENAME TO `field_observations`;--> statement-breakpoint
+ALTER TABLE `__new_field_resolutions` RENAME TO `field_resolutions`;--> statement-breakpoint
+ALTER TABLE `__new_field_resolution_heads` RENAME TO `field_resolution_heads`;--> statement-breakpoint
+CREATE UNIQUE INDEX `field_observations_identity_uq` ON `field_observations` (`id`);--> statement-breakpoint
+CREATE INDEX `field_observations_source_field_state_idx` ON `field_observations` (`source_record_id`,`field_key`,`state`);--> statement-breakpoint
+CREATE INDEX `field_observations_target_field_idx` ON `field_observations` (`entity_type`,`entity_id`,`field_key`);--> statement-breakpoint
+CREATE INDEX `field_resolutions_target_history_idx` ON `field_resolutions` (`entity_type`,`entity_id`,`field_key`,`resolved_at`);--> statement-breakpoint
+CREATE UNIQUE INDEX `field_resolution_heads_resolution_uq` ON `field_resolution_heads` (`resolution_id`);--> statement-breakpoint
+CREATE INDEX `field_resolution_heads_lookup_idx` ON `field_resolution_heads` (`entity_type`,`entity_id`,`field_key`);--> statement-breakpoint
+ALTER TABLE `works` ADD `first_publication_date` text;--> statement-breakpoint
+ALTER TABLE `works` ADD `first_publication_precision` text CONSTRAINT "works_first_publication_precision_ck" CHECK(`first_publication_precision` is null or `first_publication_precision` in ('year', 'month', 'day'));--> statement-breakpoint
+ALTER TABLE `works` ADD `first_publication_sort_date` text CONSTRAINT "works_first_publication_date_ck" CHECK((
+	`first_publication_date` is null
+	and `first_publication_precision` is null
+	and `first_publication_sort_date` is null
+) or (
+	`first_publication_date` is not null
+	and `first_publication_precision` is not null
+	and `first_publication_sort_date` is not null
+	and (
+		(
+			`first_publication_precision` = 'year'
+			and length(`first_publication_date`) = 4
+			and `first_publication_sort_date` = `first_publication_date` || '-01-01'
+		) or (
+			`first_publication_precision` = 'month'
+			and length(`first_publication_date`) = 7
+			and substr(`first_publication_date`, 5, 1) = '-'
+			and `first_publication_sort_date` = `first_publication_date` || '-01'
+		) or (
+			`first_publication_precision` = 'day'
+			and length(`first_publication_date`) = 10
+			and substr(`first_publication_date`, 5, 1) = '-'
+			and substr(`first_publication_date`, 8, 1) = '-'
+			and `first_publication_sort_date` = `first_publication_date`
+		)
+	)
+));

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,2154 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "531095e7-2607-47f1-9c41-88dcc646840a",
+  "prevId": "2538f62d-e049-4d25-a844-51b839b3ee5e",
+  "tables": {
+    "authors": {
+      "name": "authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_name": {
+          "name": "sort_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authors_sort_name_idx": {
+          "name": "authors_sort_name_idx",
+          "columns": [
+            "sort_name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "authors_name_nonempty_ck": {
+          "name": "authors_name_nonempty_ck",
+          "value": "length(trim(\"authors\".\"display_name\")) > 0"
+        },
+        "authors_sort_name_ck": {
+          "name": "authors_sort_name_ck",
+          "value": "\"authors\".\"sort_name\" is null or length(trim(\"authors\".\"sort_name\")) > 0"
+        }
+      }
+    },
+    "catalog_change_events": {
+      "name": "catalog_change_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "catalog_change_events_type_created_idx": {
+          "name": "catalog_change_events_type_created_idx",
+          "columns": [
+            "change_type",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "catalog_change_events_type_ck": {
+          "name": "catalog_change_events_type_ck",
+          "value": "\"catalog_change_events\".\"change_type\" in ('work_merge', 'work_split', 'edition_reassignment')"
+        },
+        "catalog_change_events_json_ck": {
+          "name": "catalog_change_events_json_ck",
+          "value": "json_valid(\"catalog_change_events\".\"payload_json\")"
+        },
+        "catalog_change_events_nonempty_ck": {
+          "name": "catalog_change_events_nonempty_ck",
+          "value": "length(trim(\"catalog_change_events\".\"actor_ref\")) > 0 and length(trim(\"catalog_change_events\".\"reason\")) > 0"
+        }
+      }
+    },
+    "categories": {
+      "name": "categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "categories_slug_uq": {
+          "name": "categories_slug_uq",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "categories_nonempty_ck": {
+          "name": "categories_nonempty_ck",
+          "value": "length(trim(\"categories\".\"slug\")) > 0 and length(trim(\"categories\".\"label\")) > 0"
+        },
+        "categories_status_ck": {
+          "name": "categories_status_ck",
+          "value": "\"categories\".\"status\" in ('active', 'retired')"
+        }
+      }
+    },
+    "cover_assets": {
+      "name": "cover_assets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_policy_id": {
+          "name": "source_policy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cover_assets_object_key_uq": {
+          "name": "cover_assets_object_key_uq",
+          "columns": [
+            "object_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "cover_assets_source_policy_id_metadata_sources_id_fk": {
+          "name": "cover_assets_source_policy_id_metadata_sources_id_fk",
+          "tableFrom": "cover_assets",
+          "tableTo": "metadata_sources",
+          "columnsFrom": [
+            "source_policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "cover_assets_object_key_ck": {
+          "name": "cover_assets_object_key_ck",
+          "value": "length(trim(\"cover_assets\".\"object_key\")) > 0 and substr(\"cover_assets\".\"object_key\", 1, 8) = '/covers/'"
+        },
+        "cover_assets_state_ck": {
+          "name": "cover_assets_state_ck",
+          "value": "\"cover_assets\".\"state\" in ('available', 'missing', 'withdrawn', 'failed')"
+        },
+        "cover_assets_dimensions_ck": {
+          "name": "cover_assets_dimensions_ck",
+          "value": "(\"cover_assets\".\"width\" is null or \"cover_assets\".\"width\" > 0)\n        and (\"cover_assets\".\"height\" is null or \"cover_assets\".\"height\" > 0)\n        and (\"cover_assets\".\"bytes\" is null or \"cover_assets\".\"bytes\" > 0)"
+        }
+      }
+    },
+    "edition_covers": {
+      "name": "edition_covers",
+      "columns": {
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cover_asset_id": {
+          "name": "cover_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "edition_covers_position_uq": {
+          "name": "edition_covers_position_uq",
+          "columns": [
+            "edition_id",
+            "position"
+          ],
+          "isUnique": true
+        },
+        "edition_covers_primary_uq": {
+          "name": "edition_covers_primary_uq",
+          "columns": [
+            "edition_id"
+          ],
+          "isUnique": true,
+          "where": "\"edition_covers\".\"is_primary\" = 1"
+        },
+        "edition_covers_owner_position_idx": {
+          "name": "edition_covers_owner_position_idx",
+          "columns": [
+            "edition_id",
+            "position"
+          ],
+          "isUnique": false
+        },
+        "edition_covers_primary_lookup_idx": {
+          "name": "edition_covers_primary_lookup_idx",
+          "columns": [
+            "edition_id",
+            "is_primary"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "edition_covers_edition_id_editions_id_fk": {
+          "name": "edition_covers_edition_id_editions_id_fk",
+          "tableFrom": "edition_covers",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edition_covers_cover_asset_id_cover_assets_id_fk": {
+          "name": "edition_covers_cover_asset_id_cover_assets_id_fk",
+          "tableFrom": "edition_covers",
+          "tableTo": "cover_assets",
+          "columnsFrom": [
+            "cover_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edition_covers_pk": {
+          "columns": [
+            "edition_id",
+            "cover_asset_id"
+          ],
+          "name": "edition_covers_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "edition_covers_position_ck": {
+          "name": "edition_covers_position_ck",
+          "value": "\"edition_covers\".\"position\" >= 0"
+        }
+      }
+    },
+    "edition_identifiers": {
+      "name": "edition_identifiers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheme": {
+          "name": "scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_normalized": {
+          "name": "value_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_display": {
+          "name": "value_display",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "edition_identifiers_value_uq": {
+          "name": "edition_identifiers_value_uq",
+          "columns": [
+            "scheme",
+            "value_normalized"
+          ],
+          "isUnique": true
+        },
+        "edition_identifiers_primary_uq": {
+          "name": "edition_identifiers_primary_uq",
+          "columns": [
+            "edition_id"
+          ],
+          "isUnique": true,
+          "where": "\"edition_identifiers\".\"is_primary\" = 1"
+        },
+        "edition_identifiers_owner_idx": {
+          "name": "edition_identifiers_owner_idx",
+          "columns": [
+            "edition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "edition_identifiers_edition_id_editions_id_fk": {
+          "name": "edition_identifiers_edition_id_editions_id_fk",
+          "tableFrom": "edition_identifiers",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "edition_identifiers_scheme_ck": {
+          "name": "edition_identifiers_scheme_ck",
+          "value": "\"edition_identifiers\".\"scheme\" in ('isbn10', 'isbn13')"
+        },
+        "edition_identifiers_value_ck": {
+          "name": "edition_identifiers_value_ck",
+          "value": "length(trim(\"edition_identifiers\".\"value_normalized\")) > 0"
+        }
+      }
+    },
+    "edition_languages": {
+      "name": "edition_languages",
+      "columns": {
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language_tag": {
+          "name": "language_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "edition_languages_position_uq": {
+          "name": "edition_languages_position_uq",
+          "columns": [
+            "edition_id",
+            "position"
+          ],
+          "isUnique": true
+        },
+        "edition_languages_owner_position_idx": {
+          "name": "edition_languages_owner_position_idx",
+          "columns": [
+            "edition_id",
+            "position"
+          ],
+          "isUnique": false
+        },
+        "edition_languages_language_edition_idx": {
+          "name": "edition_languages_language_edition_idx",
+          "columns": [
+            "language_tag",
+            "edition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "edition_languages_edition_id_editions_id_fk": {
+          "name": "edition_languages_edition_id_editions_id_fk",
+          "tableFrom": "edition_languages",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edition_languages_language_tag_languages_tag_fk": {
+          "name": "edition_languages_language_tag_languages_tag_fk",
+          "tableFrom": "edition_languages",
+          "tableTo": "languages",
+          "columnsFrom": [
+            "language_tag"
+          ],
+          "columnsTo": [
+            "tag"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edition_languages_pk": {
+          "columns": [
+            "edition_id",
+            "language_tag"
+          ],
+          "name": "edition_languages_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "edition_languages_position_ck": {
+          "name": "edition_languages_position_ck",
+          "value": "\"edition_languages\".\"position\" >= 0"
+        }
+      }
+    },
+    "edition_publishers": {
+      "name": "edition_publishers",
+      "columns": {
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "publisher_id": {
+          "name": "publisher_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "edition_publishers_position_uq": {
+          "name": "edition_publishers_position_uq",
+          "columns": [
+            "edition_id",
+            "position"
+          ],
+          "isUnique": true
+        },
+        "edition_publishers_owner_position_idx": {
+          "name": "edition_publishers_owner_position_idx",
+          "columns": [
+            "edition_id",
+            "position"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "edition_publishers_edition_id_editions_id_fk": {
+          "name": "edition_publishers_edition_id_editions_id_fk",
+          "tableFrom": "edition_publishers",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edition_publishers_publisher_id_publishers_id_fk": {
+          "name": "edition_publishers_publisher_id_publishers_id_fk",
+          "tableFrom": "edition_publishers",
+          "tableTo": "publishers",
+          "columnsFrom": [
+            "publisher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edition_publishers_pk": {
+          "columns": [
+            "edition_id",
+            "publisher_id"
+          ],
+          "name": "edition_publishers_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "edition_publishers_position_ck": {
+          "name": "edition_publishers_position_ck",
+          "value": "\"edition_publishers\".\"position\" >= 0"
+        },
+        "edition_publishers_role_ck": {
+          "name": "edition_publishers_role_ck",
+          "value": "\"edition_publishers\".\"role\" is null or \"edition_publishers\".\"role\" in ('publisher', 'co_publisher', 'imprint', 'distributor')"
+        }
+      }
+    },
+    "editions": {
+      "name": "editions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publication_date": {
+          "name": "publication_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publication_precision": {
+          "name": "publication_precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publication_sort_date": {
+          "name": "publication_sort_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pages": {
+          "name": "pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cataloged_at": {
+          "name": "cataloged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "editions_work_id_idx": {
+          "name": "editions_work_id_idx",
+          "columns": [
+            "work_id"
+          ],
+          "isUnique": false
+        },
+        "editions_publication_sort_work_idx": {
+          "name": "editions_publication_sort_work_idx",
+          "columns": [
+            "publication_sort_date",
+            "work_id"
+          ],
+          "isUnique": false
+        },
+        "editions_cataloged_work_idx": {
+          "name": "editions_cataloged_work_idx",
+          "columns": [
+            "cataloged_at",
+            "work_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "editions_work_id_works_id_fk": {
+          "name": "editions_work_id_works_id_fk",
+          "tableFrom": "editions",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "editions_title_ck": {
+          "name": "editions_title_ck",
+          "value": "\"editions\".\"title\" is null or length(trim(\"editions\".\"title\")) > 0"
+        },
+        "editions_subtitle_ck": {
+          "name": "editions_subtitle_ck",
+          "value": "\"editions\".\"subtitle\" is null or length(trim(\"editions\".\"subtitle\")) > 0"
+        },
+        "editions_format_ck": {
+          "name": "editions_format_ck",
+          "value": "\"editions\".\"format\" is null or \"editions\".\"format\" in ('hardcover', 'paperback', 'ebook', 'audiobook', 'other')"
+        },
+        "editions_pages_ck": {
+          "name": "editions_pages_ck",
+          "value": "\"editions\".\"pages\" is null or \"editions\".\"pages\" > 0"
+        },
+        "editions_publication_precision_ck": {
+          "name": "editions_publication_precision_ck",
+          "value": "\"editions\".\"publication_precision\" is null or \"editions\".\"publication_precision\" in ('year', 'month', 'day')"
+        },
+        "editions_publication_date_ck": {
+          "name": "editions_publication_date_ck",
+          "value": "(\n        \"editions\".\"publication_date\" is null\n        and \"editions\".\"publication_precision\" is null\n        and \"editions\".\"publication_sort_date\" is null\n      ) or (\n        \"editions\".\"publication_precision\" = 'year'\n        and length(\"editions\".\"publication_date\") = 4\n        and \"editions\".\"publication_sort_date\" = \"editions\".\"publication_date\" || '-01-01'\n      ) or (\n        \"editions\".\"publication_precision\" = 'month'\n        and length(\"editions\".\"publication_date\") = 7\n        and substr(\"editions\".\"publication_date\", 5, 1) = '-'\n        and \"editions\".\"publication_sort_date\" = \"editions\".\"publication_date\" || '-01'\n      ) or (\n        \"editions\".\"publication_precision\" = 'day'\n        and length(\"editions\".\"publication_date\") = 10\n        and substr(\"editions\".\"publication_date\", 5, 1) = '-'\n        and substr(\"editions\".\"publication_date\", 8, 1) = '-'\n        and \"editions\".\"publication_sort_date\" = \"editions\".\"publication_date\"\n      )"
+        }
+      }
+    },
+    "entity_aliases": {
+      "name": "entity_aliases",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_id": {
+          "name": "from_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_id": {
+          "name": "to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "entity_aliases_target_idx": {
+          "name": "entity_aliases_target_idx",
+          "columns": [
+            "entity_type",
+            "to_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "entity_aliases_pk": {
+          "columns": [
+            "entity_type",
+            "from_id"
+          ],
+          "name": "entity_aliases_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "entity_aliases_ck": {
+          "name": "entity_aliases_ck",
+          "value": "\"entity_aliases\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset')\n        and \"entity_aliases\".\"from_id\" <> \"entity_aliases\".\"to_id\"\n        and length(trim(\"entity_aliases\".\"reason\")) > 0"
+        }
+      }
+    },
+    "field_observations": {
+      "name": "field_observations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_json": {
+          "name": "value_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comparison_hash": {
+          "name": "comparison_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provenance_kind": {
+          "name": "provenance_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_modified_at": {
+          "name": "source_modified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retrieved_at": {
+          "name": "retrieved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mapping_confidence": {
+          "name": "mapping_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "derivation_name": {
+          "name": "derivation_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "derivation_version": {
+          "name": "derivation_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_ids_json": {
+          "name": "parent_ids_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "field_observations_identity_uq": {
+          "name": "field_observations_identity_uq",
+          "columns": [
+            "id"
+          ],
+          "isUnique": true
+        },
+        "field_observations_source_field_state_idx": {
+          "name": "field_observations_source_field_state_idx",
+          "columns": [
+            "source_record_id",
+            "field_key",
+            "state"
+          ],
+          "isUnique": false
+        },
+        "field_observations_target_field_idx": {
+          "name": "field_observations_target_field_idx",
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "field_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "field_observations_source_record_id_source_records_id_fk": {
+          "name": "field_observations_source_record_id_source_records_id_fk",
+          "tableFrom": "field_observations",
+          "tableTo": "source_records",
+          "columnsFrom": [
+            "source_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "field_observations_target_ck": {
+          "name": "field_observations_target_ck",
+          "value": "\"field_observations\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and \"field_observations\".\"field_key\" in ('work.preferred_title', 'work.description', 'work.first_publication_date', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')"
+        },
+        "field_observations_json_ck": {
+          "name": "field_observations_json_ck",
+          "value": "json_valid(\"field_observations\".\"value_json\") and (\"field_observations\".\"parent_ids_json\" is null or json_valid(\"field_observations\".\"parent_ids_json\"))"
+        },
+        "field_observations_hash_ck": {
+          "name": "field_observations_hash_ck",
+          "value": "length(\"field_observations\".\"comparison_hash\") = 64"
+        },
+        "field_observations_provenance_ck": {
+          "name": "field_observations_provenance_ck",
+          "value": "\"field_observations\".\"provenance_kind\" in ('curated', 'imported', 'derived', 'synthetic')"
+        },
+        "field_observations_state_ck": {
+          "name": "field_observations_state_ck",
+          "value": "\"field_observations\".\"state\" in ('active', 'stale', 'withdrawn', 'invalid')"
+        },
+        "field_observations_confidence_ck": {
+          "name": "field_observations_confidence_ck",
+          "value": "\"field_observations\".\"mapping_confidence\" between 0 and 1"
+        },
+        "field_observations_curated_ck": {
+          "name": "field_observations_curated_ck",
+          "value": "\"field_observations\".\"provenance_kind\" <> 'curated'\n        or (length(trim(\"field_observations\".\"actor_ref\")) > 0 and length(trim(\"field_observations\".\"reason\")) > 0)"
+        },
+        "field_observations_derived_ck": {
+          "name": "field_observations_derived_ck",
+          "value": "\"field_observations\".\"provenance_kind\" <> 'derived'\n        or (\n          length(trim(\"field_observations\".\"derivation_name\")) > 0\n          and length(trim(\"field_observations\".\"derivation_version\")) > 0\n          and json_valid(\"field_observations\".\"parent_ids_json\")\n        )"
+        }
+      }
+    },
+    "field_resolution_heads": {
+      "name": "field_resolution_heads",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolution_id": {
+          "name": "resolution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "field_resolution_heads_resolution_uq": {
+          "name": "field_resolution_heads_resolution_uq",
+          "columns": [
+            "resolution_id"
+          ],
+          "isUnique": true
+        },
+        "field_resolution_heads_lookup_idx": {
+          "name": "field_resolution_heads_lookup_idx",
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "field_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "field_resolution_heads_resolution_id_field_resolutions_id_fk": {
+          "name": "field_resolution_heads_resolution_id_field_resolutions_id_fk",
+          "tableFrom": "field_resolution_heads",
+          "tableTo": "field_resolutions",
+          "columnsFrom": [
+            "resolution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "field_resolution_heads_pk": {
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "field_key"
+          ],
+          "name": "field_resolution_heads_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "field_resolution_heads_target_ck": {
+          "name": "field_resolution_heads_target_ck",
+          "value": "\"field_resolution_heads\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and \"field_resolution_heads\".\"field_key\" in ('work.preferred_title', 'work.description', 'work.first_publication_date', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')"
+        }
+      }
+    },
+    "field_resolutions": {
+      "name": "field_resolutions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "selected_observation_id": {
+          "name": "selected_observation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "previous_resolution_id": {
+          "name": "previous_resolution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolver_version": {
+          "name": "resolver_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "field_resolutions_target_history_idx": {
+          "name": "field_resolutions_target_history_idx",
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "field_key",
+            "resolved_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "field_resolutions_selected_observation_id_field_observations_id_fk": {
+          "name": "field_resolutions_selected_observation_id_field_observations_id_fk",
+          "tableFrom": "field_resolutions",
+          "tableTo": "field_observations",
+          "columnsFrom": [
+            "selected_observation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "field_resolutions_previous_resolution_id_field_resolutions_id_fk": {
+          "name": "field_resolutions_previous_resolution_id_field_resolutions_id_fk",
+          "tableFrom": "field_resolutions",
+          "tableTo": "field_resolutions",
+          "columnsFrom": [
+            "previous_resolution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "field_resolutions_target_ck": {
+          "name": "field_resolutions_target_ck",
+          "value": "\"field_resolutions\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and \"field_resolutions\".\"field_key\" in ('work.preferred_title', 'work.description', 'work.first_publication_date', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')"
+        },
+        "field_resolutions_state_ck": {
+          "name": "field_resolutions_state_ck",
+          "value": "\"field_resolutions\".\"state\" in ('present', 'missing', 'conflicting', 'stale', 'withdrawn')"
+        },
+        "field_resolutions_selection_ck": {
+          "name": "field_resolutions_selection_ck",
+          "value": "(\n        \"field_resolutions\".\"state\" in ('present', 'stale')\n        and \"field_resolutions\".\"selected_observation_id\" is not null\n      ) or (\n        \"field_resolutions\".\"state\" in ('missing', 'conflicting', 'withdrawn')\n        and \"field_resolutions\".\"selected_observation_id\" is null\n      )"
+        },
+        "field_resolutions_nonempty_ck": {
+          "name": "field_resolutions_nonempty_ck",
+          "value": "length(trim(\"field_resolutions\".\"reason\")) > 0\n        and length(trim(\"field_resolutions\".\"actor_ref\")) > 0\n        and length(trim(\"field_resolutions\".\"resolver_version\")) > 0"
+        }
+      }
+    },
+    "languages": {
+      "name": "languages",
+      "columns": {
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "languages_nonempty_ck": {
+          "name": "languages_nonempty_ck",
+          "value": "length(trim(\"languages\".\"tag\")) > 0 and length(trim(\"languages\".\"label\")) > 0"
+        }
+      }
+    },
+    "metadata_sources": {
+      "name": "metadata_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "terms_url": {
+          "name": "terms_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attribution_url": {
+          "name": "attribution_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approval_state": {
+          "name": "approval_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_policy": {
+          "name": "metadata_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "asset_policy": {
+          "name": "asset_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_policy": {
+          "name": "payload_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_interval_ms": {
+          "name": "refresh_interval_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "metadata_sources_key_uq": {
+          "name": "metadata_sources_key_uq",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "metadata_sources_nonempty_ck": {
+          "name": "metadata_sources_nonempty_ck",
+          "value": "length(trim(\"metadata_sources\".\"key\")) > 0 and length(trim(\"metadata_sources\".\"name\")) > 0"
+        },
+        "metadata_sources_approval_state_ck": {
+          "name": "metadata_sources_approval_state_ck",
+          "value": "\"metadata_sources\".\"approval_state\" in ('pending', 'approved', 'suspended', 'retired')"
+        },
+        "metadata_sources_payload_policy_ck": {
+          "name": "metadata_sources_payload_policy_ck",
+          "value": "\"metadata_sources\".\"payload_policy\" in ('none', 'selected_fields', 'full')"
+        },
+        "metadata_sources_policy_json_ck": {
+          "name": "metadata_sources_policy_json_ck",
+          "value": "json_valid(\"metadata_sources\".\"metadata_policy\") and json_valid(\"metadata_sources\".\"asset_policy\")"
+        },
+        "metadata_sources_approved_review_ck": {
+          "name": "metadata_sources_approved_review_ck",
+          "value": "\"metadata_sources\".\"approval_state\" <> 'approved' or \"metadata_sources\".\"reviewed_at\" is not null"
+        },
+        "metadata_sources_refresh_ck": {
+          "name": "metadata_sources_refresh_ck",
+          "value": "\"metadata_sources\".\"refresh_interval_ms\" is null or \"metadata_sources\".\"refresh_interval_ms\" > 0"
+        }
+      }
+    },
+    "publishers": {
+      "name": "publishers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "publishers_name_nonempty_ck": {
+          "name": "publishers_name_nonempty_ck",
+          "value": "length(trim(\"publishers\".\"display_name\")) > 0"
+        }
+      }
+    },
+    "source_record_links": {
+      "name": "source_record_links",
+      "columns": {
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "match_kind": {
+          "name": "match_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mapping_confidence": {
+          "name": "mapping_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "source_record_links_entity_idx": {
+          "name": "source_record_links_entity_idx",
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "state"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "source_record_links_source_record_id_source_records_id_fk": {
+          "name": "source_record_links_source_record_id_source_records_id_fk",
+          "tableFrom": "source_record_links",
+          "tableTo": "source_records",
+          "columnsFrom": [
+            "source_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "source_record_links_pk": {
+          "columns": [
+            "source_record_id",
+            "entity_type",
+            "entity_id"
+          ],
+          "name": "source_record_links_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "source_record_links_entity_type_ck": {
+          "name": "source_record_links_entity_type_ck",
+          "value": "\"source_record_links\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset')"
+        },
+        "source_record_links_match_kind_ck": {
+          "name": "source_record_links_match_kind_ck",
+          "value": "\"source_record_links\".\"match_kind\" in ('exact_identifier', 'source_relationship', 'curated', 'candidate')"
+        },
+        "source_record_links_state_ck": {
+          "name": "source_record_links_state_ck",
+          "value": "\"source_record_links\".\"state\" in ('active', 'candidate', 'rejected')"
+        },
+        "source_record_links_confidence_ck": {
+          "name": "source_record_links_confidence_ck",
+          "value": "\"source_record_links\".\"mapping_confidence\" between 0 and 1"
+        },
+        "source_record_links_actor_ck": {
+          "name": "source_record_links_actor_ck",
+          "value": "(\n        \"source_record_links\".\"match_kind\" <> 'curated' and \"source_record_links\".\"state\" <> 'rejected'\n      ) or (\n        length(trim(\"source_record_links\".\"actor_ref\")) > 0 and length(trim(\"source_record_links\".\"reason\")) > 0\n      )"
+        }
+      }
+    },
+    "source_records": {
+      "name": "source_records",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_modified_at": {
+          "name": "source_modified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retrieved_at": {
+          "name": "retrieved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "importer_version": {
+          "name": "importer_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_row_hash": {
+          "name": "source_row_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "source_records_source_key_uq": {
+          "name": "source_records_source_key_uq",
+          "columns": [
+            "source_id",
+            "record_key"
+          ],
+          "isUnique": true
+        },
+        "source_records_refresh_idx": {
+          "name": "source_records_refresh_idx",
+          "columns": [
+            "source_id",
+            "state",
+            "retrieved_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "source_records_source_id_metadata_sources_id_fk": {
+          "name": "source_records_source_id_metadata_sources_id_fk",
+          "tableFrom": "source_records",
+          "tableTo": "metadata_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "source_records_key_nonempty_ck": {
+          "name": "source_records_key_nonempty_ck",
+          "value": "length(trim(\"source_records\".\"record_key\")) > 0"
+        },
+        "source_records_state_ck": {
+          "name": "source_records_state_ck",
+          "value": "\"source_records\".\"state\" in ('active', 'withdrawn', 'deleted')"
+        },
+        "source_records_payload_json_ck": {
+          "name": "source_records_payload_json_ck",
+          "value": "\"source_records\".\"payload_json\" is null or json_valid(\"source_records\".\"payload_json\")"
+        },
+        "source_records_import_hash_ck": {
+          "name": "source_records_import_hash_ck",
+          "value": "(\"source_records\".\"importer_version\" is null and \"source_records\".\"source_row_hash\" is null)\n        or (length(trim(\"source_records\".\"importer_version\")) > 0 and length(\"source_records\".\"source_row_hash\") = 64)"
+        }
+      }
+    },
+    "work_authors": {
+      "name": "work_authors",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'author'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "work_authors_position_uq": {
+          "name": "work_authors_position_uq",
+          "columns": [
+            "work_id",
+            "position"
+          ],
+          "isUnique": true
+        },
+        "work_authors_owner_position_idx": {
+          "name": "work_authors_owner_position_idx",
+          "columns": [
+            "work_id",
+            "position"
+          ],
+          "isUnique": false
+        },
+        "work_authors_author_work_idx": {
+          "name": "work_authors_author_work_idx",
+          "columns": [
+            "author_id",
+            "work_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "work_authors_work_id_works_id_fk": {
+          "name": "work_authors_work_id_works_id_fk",
+          "tableFrom": "work_authors",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_authors_author_id_authors_id_fk": {
+          "name": "work_authors_author_id_authors_id_fk",
+          "tableFrom": "work_authors",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "work_authors_pk": {
+          "columns": [
+            "work_id",
+            "author_id",
+            "role"
+          ],
+          "name": "work_authors_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "work_authors_role_ck": {
+          "name": "work_authors_role_ck",
+          "value": "\"work_authors\".\"role\" in ('author', 'editor', 'translator', 'illustrator')"
+        },
+        "work_authors_position_ck": {
+          "name": "work_authors_position_ck",
+          "value": "\"work_authors\".\"position\" >= 0"
+        }
+      }
+    },
+    "work_categories": {
+      "name": "work_categories",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "work_categories_position_uq": {
+          "name": "work_categories_position_uq",
+          "columns": [
+            "work_id",
+            "position"
+          ],
+          "isUnique": true
+        },
+        "work_categories_primary_uq": {
+          "name": "work_categories_primary_uq",
+          "columns": [
+            "work_id"
+          ],
+          "isUnique": true,
+          "where": "\"work_categories\".\"is_primary\" = 1"
+        },
+        "work_categories_owner_position_idx": {
+          "name": "work_categories_owner_position_idx",
+          "columns": [
+            "work_id",
+            "position"
+          ],
+          "isUnique": false
+        },
+        "work_categories_category_work_idx": {
+          "name": "work_categories_category_work_idx",
+          "columns": [
+            "category_id",
+            "work_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "work_categories_work_id_works_id_fk": {
+          "name": "work_categories_work_id_works_id_fk",
+          "tableFrom": "work_categories",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_categories_category_id_categories_id_fk": {
+          "name": "work_categories_category_id_categories_id_fk",
+          "tableFrom": "work_categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "work_categories_pk": {
+          "columns": [
+            "work_id",
+            "category_id"
+          ],
+          "name": "work_categories_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "work_categories_position_ck": {
+          "name": "work_categories_position_ck",
+          "value": "\"work_categories\".\"position\" >= 0"
+        }
+      }
+    },
+    "works": {
+      "name": "works",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preferred_title": {
+          "name": "preferred_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_title": {
+          "name": "sort_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_publication_date": {
+          "name": "first_publication_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_publication_precision": {
+          "name": "first_publication_precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_publication_sort_date": {
+          "name": "first_publication_sort_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferred_edition_id": {
+          "name": "preferred_edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "works_sort_title_id_idx": {
+          "name": "works_sort_title_id_idx",
+          "columns": [
+            "sort_title",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "works_preferred_edition_idx": {
+          "name": "works_preferred_edition_idx",
+          "columns": [
+            "preferred_edition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "works_preferred_edition_id_editions_id_fk": {
+          "name": "works_preferred_edition_id_editions_id_fk",
+          "tableFrom": "works",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "preferred_edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "works_titles_nonempty_ck": {
+          "name": "works_titles_nonempty_ck",
+          "value": "length(trim(\"works\".\"preferred_title\")) > 0 and length(trim(\"works\".\"sort_title\")) > 0"
+        },
+        "works_first_publication_precision_ck": {
+          "name": "works_first_publication_precision_ck",
+          "value": "\"works\".\"first_publication_precision\" is null or \"works\".\"first_publication_precision\" in ('year', 'month', 'day')"
+        },
+        "works_first_publication_date_ck": {
+          "name": "works_first_publication_date_ck",
+          "value": "(\n        \"works\".\"first_publication_date\" is null\n        and \"works\".\"first_publication_precision\" is null\n        and \"works\".\"first_publication_sort_date\" is null\n      ) or (\n        \"works\".\"first_publication_date\" is not null\n        and \"works\".\"first_publication_precision\" is not null\n        and \"works\".\"first_publication_sort_date\" is not null\n        and (\n          (\n            \"works\".\"first_publication_precision\" = 'year'\n            and length(\"works\".\"first_publication_date\") = 4\n            and \"works\".\"first_publication_sort_date\" = \"works\".\"first_publication_date\" || '-01-01'\n          ) or (\n            \"works\".\"first_publication_precision\" = 'month'\n            and length(\"works\".\"first_publication_date\") = 7\n            and substr(\"works\".\"first_publication_date\", 5, 1) = '-'\n            and \"works\".\"first_publication_sort_date\" = \"works\".\"first_publication_date\" || '-01'\n          ) or (\n            \"works\".\"first_publication_precision\" = 'day'\n            and length(\"works\".\"first_publication_date\") = 10\n            and substr(\"works\".\"first_publication_date\", 5, 1) = '-'\n            and substr(\"works\".\"first_publication_date\", 8, 1) = '-'\n            and \"works\".\"first_publication_sort_date\" = \"works\".\"first_publication_date\"\n          )\n        )\n      )"
+        }
+      }
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1785159863046,
       "tag": "0004_loose_tyrannus",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1785258818562,
+      "tag": "0005_cuddly_bloodscream",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/pg/0007_third_blizzard.sql
+++ b/drizzle/pg/0007_third_blizzard.sql
@@ -1,0 +1,37 @@
+ALTER TABLE "field_observations" DROP CONSTRAINT "field_observations_target_ck";--> statement-breakpoint
+ALTER TABLE "field_resolution_heads" DROP CONSTRAINT "field_resolution_heads_target_ck";--> statement-breakpoint
+ALTER TABLE "field_resolutions" DROP CONSTRAINT "field_resolutions_target_ck";--> statement-breakpoint
+ALTER TABLE "works" ADD COLUMN "first_publication_date" text;--> statement-breakpoint
+ALTER TABLE "works" ADD COLUMN "first_publication_precision" text;--> statement-breakpoint
+ALTER TABLE "works" ADD COLUMN "first_publication_sort_date" text;--> statement-breakpoint
+ALTER TABLE "field_observations" ADD CONSTRAINT "field_observations_target_ck" CHECK ("field_observations"."entity_type" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and "field_observations"."field_key" in ('work.preferred_title', 'work.description', 'work.first_publication_date', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count'));--> statement-breakpoint
+ALTER TABLE "field_resolution_heads" ADD CONSTRAINT "field_resolution_heads_target_ck" CHECK ("field_resolution_heads"."entity_type" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and "field_resolution_heads"."field_key" in ('work.preferred_title', 'work.description', 'work.first_publication_date', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count'));--> statement-breakpoint
+ALTER TABLE "field_resolutions" ADD CONSTRAINT "field_resolutions_target_ck" CHECK ("field_resolutions"."entity_type" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and "field_resolutions"."field_key" in ('work.preferred_title', 'work.description', 'work.first_publication_date', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count'));--> statement-breakpoint
+ALTER TABLE "works" ADD CONSTRAINT "works_first_publication_precision_ck" CHECK ("works"."first_publication_precision" is null or "works"."first_publication_precision" in ('year', 'month', 'day'));--> statement-breakpoint
+ALTER TABLE "works" ADD CONSTRAINT "works_first_publication_date_ck" CHECK ((
+        "works"."first_publication_date" is null
+        and "works"."first_publication_precision" is null
+        and "works"."first_publication_sort_date" is null
+      ) or (
+        "works"."first_publication_date" is not null
+        and "works"."first_publication_precision" is not null
+        and "works"."first_publication_sort_date" is not null
+        and (
+          (
+            "works"."first_publication_precision" = 'year'
+            and length("works"."first_publication_date") = 4
+            and "works"."first_publication_sort_date" = "works"."first_publication_date" || '-01-01'
+          ) or (
+            "works"."first_publication_precision" = 'month'
+            and length("works"."first_publication_date") = 7
+            and substring("works"."first_publication_date" from 5 for 1) = '-'
+            and "works"."first_publication_sort_date" = "works"."first_publication_date" || '-01'
+          ) or (
+            "works"."first_publication_precision" = 'day'
+            and length("works"."first_publication_date") = 10
+            and substring("works"."first_publication_date" from 5 for 1) = '-'
+            and substring("works"."first_publication_date" from 8 for 1) = '-'
+            and "works"."first_publication_sort_date" = "works"."first_publication_date"
+          )
+        )
+      ));

--- a/drizzle/pg/meta/0007_snapshot.json
+++ b/drizzle/pg/meta/0007_snapshot.json
@@ -1,0 +1,2542 @@
+{
+  "id": "543da6a3-e3a7-47bb-988d-d6f1f72bbb49",
+  "prevId": "b1954e6a-a4d1-449a-92c7-9167ca16394c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.authors": {
+      "name": "authors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_name": {
+          "name": "sort_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "authors_sort_name_idx": {
+          "name": "authors_sort_name_idx",
+          "columns": [
+            {
+              "expression": "sort_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "authors_name_nonempty_ck": {
+          "name": "authors_name_nonempty_ck",
+          "value": "length(trim(\"authors\".\"display_name\")) > 0"
+        },
+        "authors_sort_name_ck": {
+          "name": "authors_sort_name_ck",
+          "value": "\"authors\".\"sort_name\" is null or length(trim(\"authors\".\"sort_name\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.catalog_change_events": {
+      "name": "catalog_change_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "catalog_change_events_type_created_idx": {
+          "name": "catalog_change_events_type_created_idx",
+          "columns": [
+            {
+              "expression": "change_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_change_events_type_ck": {
+          "name": "catalog_change_events_type_ck",
+          "value": "\"catalog_change_events\".\"change_type\" in ('work_merge', 'work_split', 'edition_reassignment')"
+        },
+        "catalog_change_events_nonempty_ck": {
+          "name": "catalog_change_events_nonempty_ck",
+          "value": "length(trim(\"catalog_change_events\".\"actor_ref\")) > 0 and length(trim(\"catalog_change_events\".\"reason\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "categories_slug_uq": {
+          "name": "categories_slug_uq",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "categories_nonempty_ck": {
+          "name": "categories_nonempty_ck",
+          "value": "length(trim(\"categories\".\"slug\")) > 0 and length(trim(\"categories\".\"label\")) > 0"
+        },
+        "categories_status_ck": {
+          "name": "categories_status_ck",
+          "value": "\"categories\".\"status\" in ('active', 'retired')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.cover_assets": {
+      "name": "cover_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_policy_id": {
+          "name": "source_policy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cover_assets_object_key_uq": {
+          "name": "cover_assets_object_key_uq",
+          "columns": [
+            {
+              "expression": "object_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cover_assets_source_policy_id_metadata_sources_id_fk": {
+          "name": "cover_assets_source_policy_id_metadata_sources_id_fk",
+          "tableFrom": "cover_assets",
+          "tableTo": "metadata_sources",
+          "columnsFrom": [
+            "source_policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cover_assets_object_key_ck": {
+          "name": "cover_assets_object_key_ck",
+          "value": "length(trim(\"cover_assets\".\"object_key\")) > 0 and substring(\"cover_assets\".\"object_key\" from 1 for 8) = '/covers/'"
+        },
+        "cover_assets_state_ck": {
+          "name": "cover_assets_state_ck",
+          "value": "\"cover_assets\".\"state\" in ('available', 'missing', 'withdrawn', 'failed')"
+        },
+        "cover_assets_dimensions_ck": {
+          "name": "cover_assets_dimensions_ck",
+          "value": "(\"cover_assets\".\"width\" is null or \"cover_assets\".\"width\" > 0)\n        and (\"cover_assets\".\"height\" is null or \"cover_assets\".\"height\" > 0)\n        and (\"cover_assets\".\"bytes\" is null or \"cover_assets\".\"bytes\" > 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.edition_covers": {
+      "name": "edition_covers",
+      "schema": "",
+      "columns": {
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_asset_id": {
+          "name": "cover_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "edition_covers_position_uq": {
+          "name": "edition_covers_position_uq",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_covers_primary_uq": {
+          "name": "edition_covers_primary_uq",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"edition_covers\".\"is_primary\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_covers_owner_position_idx": {
+          "name": "edition_covers_owner_position_idx",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_covers_primary_lookup_idx": {
+          "name": "edition_covers_primary_lookup_idx",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "edition_covers_edition_id_editions_id_fk": {
+          "name": "edition_covers_edition_id_editions_id_fk",
+          "tableFrom": "edition_covers",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edition_covers_cover_asset_id_cover_assets_id_fk": {
+          "name": "edition_covers_cover_asset_id_cover_assets_id_fk",
+          "tableFrom": "edition_covers",
+          "tableTo": "cover_assets",
+          "columnsFrom": [
+            "cover_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edition_covers_pk": {
+          "name": "edition_covers_pk",
+          "columns": [
+            "edition_id",
+            "cover_asset_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "edition_covers_position_ck": {
+          "name": "edition_covers_position_ck",
+          "value": "\"edition_covers\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.edition_identifiers": {
+      "name": "edition_identifiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheme": {
+          "name": "scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_normalized": {
+          "name": "value_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_display": {
+          "name": "value_display",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "edition_identifiers_value_uq": {
+          "name": "edition_identifiers_value_uq",
+          "columns": [
+            {
+              "expression": "scheme",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_identifiers_primary_uq": {
+          "name": "edition_identifiers_primary_uq",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"edition_identifiers\".\"is_primary\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_identifiers_owner_idx": {
+          "name": "edition_identifiers_owner_idx",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "edition_identifiers_edition_id_editions_id_fk": {
+          "name": "edition_identifiers_edition_id_editions_id_fk",
+          "tableFrom": "edition_identifiers",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "edition_identifiers_scheme_ck": {
+          "name": "edition_identifiers_scheme_ck",
+          "value": "\"edition_identifiers\".\"scheme\" in ('isbn10', 'isbn13')"
+        },
+        "edition_identifiers_value_ck": {
+          "name": "edition_identifiers_value_ck",
+          "value": "length(trim(\"edition_identifiers\".\"value_normalized\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.edition_languages": {
+      "name": "edition_languages",
+      "schema": "",
+      "columns": {
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_tag": {
+          "name": "language_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "edition_languages_position_uq": {
+          "name": "edition_languages_position_uq",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_languages_owner_position_idx": {
+          "name": "edition_languages_owner_position_idx",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_languages_language_edition_idx": {
+          "name": "edition_languages_language_edition_idx",
+          "columns": [
+            {
+              "expression": "language_tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "edition_languages_edition_id_editions_id_fk": {
+          "name": "edition_languages_edition_id_editions_id_fk",
+          "tableFrom": "edition_languages",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edition_languages_language_tag_languages_tag_fk": {
+          "name": "edition_languages_language_tag_languages_tag_fk",
+          "tableFrom": "edition_languages",
+          "tableTo": "languages",
+          "columnsFrom": [
+            "language_tag"
+          ],
+          "columnsTo": [
+            "tag"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edition_languages_pk": {
+          "name": "edition_languages_pk",
+          "columns": [
+            "edition_id",
+            "language_tag"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "edition_languages_position_ck": {
+          "name": "edition_languages_position_ck",
+          "value": "\"edition_languages\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.edition_publishers": {
+      "name": "edition_publishers",
+      "schema": "",
+      "columns": {
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publisher_id": {
+          "name": "publisher_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "edition_publishers_position_uq": {
+          "name": "edition_publishers_position_uq",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_publishers_owner_position_idx": {
+          "name": "edition_publishers_owner_position_idx",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "edition_publishers_edition_id_editions_id_fk": {
+          "name": "edition_publishers_edition_id_editions_id_fk",
+          "tableFrom": "edition_publishers",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edition_publishers_publisher_id_publishers_id_fk": {
+          "name": "edition_publishers_publisher_id_publishers_id_fk",
+          "tableFrom": "edition_publishers",
+          "tableTo": "publishers",
+          "columnsFrom": [
+            "publisher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edition_publishers_pk": {
+          "name": "edition_publishers_pk",
+          "columns": [
+            "edition_id",
+            "publisher_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "edition_publishers_position_ck": {
+          "name": "edition_publishers_position_ck",
+          "value": "\"edition_publishers\".\"position\" >= 0"
+        },
+        "edition_publishers_role_ck": {
+          "name": "edition_publishers_role_ck",
+          "value": "\"edition_publishers\".\"role\" is null or \"edition_publishers\".\"role\" in ('publisher', 'co_publisher', 'imprint', 'distributor')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.editions": {
+      "name": "editions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_date": {
+          "name": "publication_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_precision": {
+          "name": "publication_precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_sort_date": {
+          "name": "publication_sort_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pages": {
+          "name": "pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cataloged_at": {
+          "name": "cataloged_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "editions_work_id_idx": {
+          "name": "editions_work_id_idx",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "editions_publication_sort_work_idx": {
+          "name": "editions_publication_sort_work_idx",
+          "columns": [
+            {
+              "expression": "publication_sort_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "editions_cataloged_work_idx": {
+          "name": "editions_cataloged_work_idx",
+          "columns": [
+            {
+              "expression": "cataloged_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "editions_work_id_works_id_fk": {
+          "name": "editions_work_id_works_id_fk",
+          "tableFrom": "editions",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "editions_title_ck": {
+          "name": "editions_title_ck",
+          "value": "\"editions\".\"title\" is null or length(trim(\"editions\".\"title\")) > 0"
+        },
+        "editions_subtitle_ck": {
+          "name": "editions_subtitle_ck",
+          "value": "\"editions\".\"subtitle\" is null or length(trim(\"editions\".\"subtitle\")) > 0"
+        },
+        "editions_format_ck": {
+          "name": "editions_format_ck",
+          "value": "\"editions\".\"format\" is null or \"editions\".\"format\" in ('hardcover', 'paperback', 'ebook', 'audiobook', 'other')"
+        },
+        "editions_pages_ck": {
+          "name": "editions_pages_ck",
+          "value": "\"editions\".\"pages\" is null or \"editions\".\"pages\" > 0"
+        },
+        "editions_publication_precision_ck": {
+          "name": "editions_publication_precision_ck",
+          "value": "\"editions\".\"publication_precision\" is null or \"editions\".\"publication_precision\" in ('year', 'month', 'day')"
+        },
+        "editions_publication_date_ck": {
+          "name": "editions_publication_date_ck",
+          "value": "(\n        \"editions\".\"publication_date\" is null\n        and \"editions\".\"publication_precision\" is null\n        and \"editions\".\"publication_sort_date\" is null\n      ) or (\n        \"editions\".\"publication_precision\" = 'year'\n        and length(\"editions\".\"publication_date\") = 4\n        and \"editions\".\"publication_sort_date\" = \"editions\".\"publication_date\" || '-01-01'\n      ) or (\n        \"editions\".\"publication_precision\" = 'month'\n        and length(\"editions\".\"publication_date\") = 7\n        and substring(\"editions\".\"publication_date\" from 5 for 1) = '-'\n        and \"editions\".\"publication_sort_date\" = \"editions\".\"publication_date\" || '-01'\n      ) or (\n        \"editions\".\"publication_precision\" = 'day'\n        and length(\"editions\".\"publication_date\") = 10\n        and substring(\"editions\".\"publication_date\" from 5 for 1) = '-'\n        and substring(\"editions\".\"publication_date\" from 8 for 1) = '-'\n        and \"editions\".\"publication_sort_date\" = \"editions\".\"publication_date\"\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.entity_aliases": {
+      "name": "entity_aliases",
+      "schema": "",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_id": {
+          "name": "from_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_id": {
+          "name": "to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "entity_aliases_target_idx": {
+          "name": "entity_aliases_target_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "entity_aliases_pk": {
+          "name": "entity_aliases_pk",
+          "columns": [
+            "entity_type",
+            "from_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "entity_aliases_ck": {
+          "name": "entity_aliases_ck",
+          "value": "\"entity_aliases\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset')\n        and \"entity_aliases\".\"from_id\" <> \"entity_aliases\".\"to_id\"\n        and length(trim(\"entity_aliases\".\"reason\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.field_observations": {
+      "name": "field_observations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_json": {
+          "name": "value_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comparison_hash": {
+          "name": "comparison_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provenance_kind": {
+          "name": "provenance_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_modified_at": {
+          "name": "source_modified_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retrieved_at": {
+          "name": "retrieved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mapping_confidence": {
+          "name": "mapping_confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "derivation_name": {
+          "name": "derivation_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "derivation_version": {
+          "name": "derivation_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_ids_json": {
+          "name": "parent_ids_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "field_observations_identity_uq": {
+          "name": "field_observations_identity_uq",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "field_observations_source_field_state_idx": {
+          "name": "field_observations_source_field_state_idx",
+          "columns": [
+            {
+              "expression": "source_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "field_observations_target_field_idx": {
+          "name": "field_observations_target_field_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "field_observations_source_record_id_source_records_id_fk": {
+          "name": "field_observations_source_record_id_source_records_id_fk",
+          "tableFrom": "field_observations",
+          "tableTo": "source_records",
+          "columnsFrom": [
+            "source_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "field_observations_target_ck": {
+          "name": "field_observations_target_ck",
+          "value": "\"field_observations\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and \"field_observations\".\"field_key\" in ('work.preferred_title', 'work.description', 'work.first_publication_date', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')"
+        },
+        "field_observations_hash_ck": {
+          "name": "field_observations_hash_ck",
+          "value": "length(\"field_observations\".\"comparison_hash\") = 64"
+        },
+        "field_observations_provenance_ck": {
+          "name": "field_observations_provenance_ck",
+          "value": "\"field_observations\".\"provenance_kind\" in ('curated', 'imported', 'derived', 'synthetic')"
+        },
+        "field_observations_state_ck": {
+          "name": "field_observations_state_ck",
+          "value": "\"field_observations\".\"state\" in ('active', 'stale', 'withdrawn', 'invalid')"
+        },
+        "field_observations_confidence_ck": {
+          "name": "field_observations_confidence_ck",
+          "value": "\"field_observations\".\"mapping_confidence\" between 0 and 1"
+        },
+        "field_observations_curated_ck": {
+          "name": "field_observations_curated_ck",
+          "value": "\"field_observations\".\"provenance_kind\" <> 'curated'\n        or (length(trim(\"field_observations\".\"actor_ref\")) > 0 and length(trim(\"field_observations\".\"reason\")) > 0)"
+        },
+        "field_observations_derived_ck": {
+          "name": "field_observations_derived_ck",
+          "value": "\"field_observations\".\"provenance_kind\" <> 'derived'\n        or (\n          length(trim(\"field_observations\".\"derivation_name\")) > 0\n          and length(trim(\"field_observations\".\"derivation_version\")) > 0\n          and \"field_observations\".\"parent_ids_json\" is not null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.field_resolution_heads": {
+      "name": "field_resolution_heads",
+      "schema": "",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution_id": {
+          "name": "resolution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "field_resolution_heads_resolution_uq": {
+          "name": "field_resolution_heads_resolution_uq",
+          "columns": [
+            {
+              "expression": "resolution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "field_resolution_heads_lookup_idx": {
+          "name": "field_resolution_heads_lookup_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "field_resolution_heads_resolution_id_field_resolutions_id_fk": {
+          "name": "field_resolution_heads_resolution_id_field_resolutions_id_fk",
+          "tableFrom": "field_resolution_heads",
+          "tableTo": "field_resolutions",
+          "columnsFrom": [
+            "resolution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "field_resolution_heads_pk": {
+          "name": "field_resolution_heads_pk",
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "field_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "field_resolution_heads_target_ck": {
+          "name": "field_resolution_heads_target_ck",
+          "value": "\"field_resolution_heads\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and \"field_resolution_heads\".\"field_key\" in ('work.preferred_title', 'work.description', 'work.first_publication_date', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.field_resolutions": {
+      "name": "field_resolutions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_observation_id": {
+          "name": "selected_observation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_resolution_id": {
+          "name": "previous_resolution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolver_version": {
+          "name": "resolver_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "field_resolutions_target_history_idx": {
+          "name": "field_resolutions_target_history_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "field_resolutions_selected_observation_id_field_observations_id_fk": {
+          "name": "field_resolutions_selected_observation_id_field_observations_id_fk",
+          "tableFrom": "field_resolutions",
+          "tableTo": "field_observations",
+          "columnsFrom": [
+            "selected_observation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "field_resolutions_previous_resolution_id_field_resolutions_id_fk": {
+          "name": "field_resolutions_previous_resolution_id_field_resolutions_id_fk",
+          "tableFrom": "field_resolutions",
+          "tableTo": "field_resolutions",
+          "columnsFrom": [
+            "previous_resolution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "field_resolutions_target_ck": {
+          "name": "field_resolutions_target_ck",
+          "value": "\"field_resolutions\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and \"field_resolutions\".\"field_key\" in ('work.preferred_title', 'work.description', 'work.first_publication_date', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')"
+        },
+        "field_resolutions_state_ck": {
+          "name": "field_resolutions_state_ck",
+          "value": "\"field_resolutions\".\"state\" in ('present', 'missing', 'conflicting', 'stale', 'withdrawn')"
+        },
+        "field_resolutions_selection_ck": {
+          "name": "field_resolutions_selection_ck",
+          "value": "(\n        \"field_resolutions\".\"state\" in ('present', 'stale')\n        and \"field_resolutions\".\"selected_observation_id\" is not null\n      ) or (\n        \"field_resolutions\".\"state\" in ('missing', 'conflicting', 'withdrawn')\n        and \"field_resolutions\".\"selected_observation_id\" is null\n      )"
+        },
+        "field_resolutions_nonempty_ck": {
+          "name": "field_resolutions_nonempty_ck",
+          "value": "length(trim(\"field_resolutions\".\"reason\")) > 0\n        and length(trim(\"field_resolutions\".\"actor_ref\")) > 0\n        and length(trim(\"field_resolutions\".\"resolver_version\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.languages": {
+      "name": "languages",
+      "schema": "",
+      "columns": {
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "languages_nonempty_ck": {
+          "name": "languages_nonempty_ck",
+          "value": "length(trim(\"languages\".\"tag\")) > 0 and length(trim(\"languages\".\"label\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.metadata_sources": {
+      "name": "metadata_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terms_url": {
+          "name": "terms_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution_url": {
+          "name": "attribution_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_state": {
+          "name": "approval_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata_policy": {
+          "name": "metadata_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_policy": {
+          "name": "asset_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_policy": {
+          "name": "payload_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_interval_ms": {
+          "name": "refresh_interval_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "metadata_sources_key_uq": {
+          "name": "metadata_sources_key_uq",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "metadata_sources_nonempty_ck": {
+          "name": "metadata_sources_nonempty_ck",
+          "value": "length(trim(\"metadata_sources\".\"key\")) > 0 and length(trim(\"metadata_sources\".\"name\")) > 0"
+        },
+        "metadata_sources_approval_state_ck": {
+          "name": "metadata_sources_approval_state_ck",
+          "value": "\"metadata_sources\".\"approval_state\" in ('pending', 'approved', 'suspended', 'retired')"
+        },
+        "metadata_sources_payload_policy_ck": {
+          "name": "metadata_sources_payload_policy_ck",
+          "value": "\"metadata_sources\".\"payload_policy\" in ('none', 'selected_fields', 'full')"
+        },
+        "metadata_sources_approved_review_ck": {
+          "name": "metadata_sources_approved_review_ck",
+          "value": "\"metadata_sources\".\"approval_state\" <> 'approved' or \"metadata_sources\".\"reviewed_at\" is not null"
+        },
+        "metadata_sources_refresh_ck": {
+          "name": "metadata_sources_refresh_ck",
+          "value": "\"metadata_sources\".\"refresh_interval_ms\" is null or \"metadata_sources\".\"refresh_interval_ms\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.publishers": {
+      "name": "publishers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "publishers_name_nonempty_ck": {
+          "name": "publishers_name_nonempty_ck",
+          "value": "length(trim(\"publishers\".\"display_name\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.source_record_links": {
+      "name": "source_record_links",
+      "schema": "",
+      "columns": {
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_kind": {
+          "name": "match_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mapping_confidence": {
+          "name": "mapping_confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "source_record_links_entity_idx": {
+          "name": "source_record_links_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_record_links_source_record_id_source_records_id_fk": {
+          "name": "source_record_links_source_record_id_source_records_id_fk",
+          "tableFrom": "source_record_links",
+          "tableTo": "source_records",
+          "columnsFrom": [
+            "source_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "source_record_links_pk": {
+          "name": "source_record_links_pk",
+          "columns": [
+            "source_record_id",
+            "entity_type",
+            "entity_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "source_record_links_entity_type_ck": {
+          "name": "source_record_links_entity_type_ck",
+          "value": "\"source_record_links\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset')"
+        },
+        "source_record_links_match_kind_ck": {
+          "name": "source_record_links_match_kind_ck",
+          "value": "\"source_record_links\".\"match_kind\" in ('exact_identifier', 'source_relationship', 'curated', 'candidate')"
+        },
+        "source_record_links_state_ck": {
+          "name": "source_record_links_state_ck",
+          "value": "\"source_record_links\".\"state\" in ('active', 'candidate', 'rejected')"
+        },
+        "source_record_links_confidence_ck": {
+          "name": "source_record_links_confidence_ck",
+          "value": "\"source_record_links\".\"mapping_confidence\" between 0 and 1"
+        },
+        "source_record_links_actor_ck": {
+          "name": "source_record_links_actor_ck",
+          "value": "(\n        \"source_record_links\".\"match_kind\" <> 'curated' and \"source_record_links\".\"state\" <> 'rejected'\n      ) or (\n        length(trim(\"source_record_links\".\"actor_ref\")) > 0 and length(trim(\"source_record_links\".\"reason\")) > 0\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.source_records": {
+      "name": "source_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_modified_at": {
+          "name": "source_modified_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retrieved_at": {
+          "name": "retrieved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "importer_version": {
+          "name": "importer_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_row_hash": {
+          "name": "source_row_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "source_records_source_key_uq": {
+          "name": "source_records_source_key_uq",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "record_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_records_refresh_idx": {
+          "name": "source_records_refresh_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "retrieved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_records_source_id_metadata_sources_id_fk": {
+          "name": "source_records_source_id_metadata_sources_id_fk",
+          "tableFrom": "source_records",
+          "tableTo": "metadata_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "source_records_key_nonempty_ck": {
+          "name": "source_records_key_nonempty_ck",
+          "value": "length(trim(\"source_records\".\"record_key\")) > 0"
+        },
+        "source_records_state_ck": {
+          "name": "source_records_state_ck",
+          "value": "\"source_records\".\"state\" in ('active', 'withdrawn', 'deleted')"
+        },
+        "source_records_import_hash_ck": {
+          "name": "source_records_import_hash_ck",
+          "value": "(\"source_records\".\"importer_version\" is null and \"source_records\".\"source_row_hash\" is null)\n        or (length(trim(\"source_records\".\"importer_version\")) > 0 and length(\"source_records\".\"source_row_hash\") = 64)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.work_authors": {
+      "name": "work_authors",
+      "schema": "",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'author'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "work_authors_position_uq": {
+          "name": "work_authors_position_uq",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_authors_owner_position_idx": {
+          "name": "work_authors_owner_position_idx",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_authors_author_work_idx": {
+          "name": "work_authors_author_work_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "work_authors_work_id_works_id_fk": {
+          "name": "work_authors_work_id_works_id_fk",
+          "tableFrom": "work_authors",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_authors_author_id_authors_id_fk": {
+          "name": "work_authors_author_id_authors_id_fk",
+          "tableFrom": "work_authors",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "work_authors_pk": {
+          "name": "work_authors_pk",
+          "columns": [
+            "work_id",
+            "author_id",
+            "role"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "work_authors_role_ck": {
+          "name": "work_authors_role_ck",
+          "value": "\"work_authors\".\"role\" in ('author', 'editor', 'translator', 'illustrator')"
+        },
+        "work_authors_position_ck": {
+          "name": "work_authors_position_ck",
+          "value": "\"work_authors\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.work_categories": {
+      "name": "work_categories",
+      "schema": "",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "work_categories_position_uq": {
+          "name": "work_categories_position_uq",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_categories_primary_uq": {
+          "name": "work_categories_primary_uq",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"work_categories\".\"is_primary\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_categories_owner_position_idx": {
+          "name": "work_categories_owner_position_idx",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_categories_category_work_idx": {
+          "name": "work_categories_category_work_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "work_categories_work_id_works_id_fk": {
+          "name": "work_categories_work_id_works_id_fk",
+          "tableFrom": "work_categories",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_categories_category_id_categories_id_fk": {
+          "name": "work_categories_category_id_categories_id_fk",
+          "tableFrom": "work_categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "work_categories_pk": {
+          "name": "work_categories_pk",
+          "columns": [
+            "work_id",
+            "category_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "work_categories_position_ck": {
+          "name": "work_categories_position_ck",
+          "value": "\"work_categories\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.works": {
+      "name": "works",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "preferred_title": {
+          "name": "preferred_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_title": {
+          "name": "sort_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_publication_date": {
+          "name": "first_publication_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_publication_precision": {
+          "name": "first_publication_precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_publication_sort_date": {
+          "name": "first_publication_sort_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_edition_id": {
+          "name": "preferred_edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "works_sort_title_id_idx": {
+          "name": "works_sort_title_id_idx",
+          "columns": [
+            {
+              "expression": "sort_title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "works_preferred_edition_idx": {
+          "name": "works_preferred_edition_idx",
+          "columns": [
+            {
+              "expression": "preferred_edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "works_preferred_edition_id_editions_id_fk": {
+          "name": "works_preferred_edition_id_editions_id_fk",
+          "tableFrom": "works",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "preferred_edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "works_titles_nonempty_ck": {
+          "name": "works_titles_nonempty_ck",
+          "value": "length(trim(\"works\".\"preferred_title\")) > 0 and length(trim(\"works\".\"sort_title\")) > 0"
+        },
+        "works_first_publication_precision_ck": {
+          "name": "works_first_publication_precision_ck",
+          "value": "\"works\".\"first_publication_precision\" is null or \"works\".\"first_publication_precision\" in ('year', 'month', 'day')"
+        },
+        "works_first_publication_date_ck": {
+          "name": "works_first_publication_date_ck",
+          "value": "(\n        \"works\".\"first_publication_date\" is null\n        and \"works\".\"first_publication_precision\" is null\n        and \"works\".\"first_publication_sort_date\" is null\n      ) or (\n        \"works\".\"first_publication_date\" is not null\n        and \"works\".\"first_publication_precision\" is not null\n        and \"works\".\"first_publication_sort_date\" is not null\n        and (\n          (\n            \"works\".\"first_publication_precision\" = 'year'\n            and length(\"works\".\"first_publication_date\") = 4\n            and \"works\".\"first_publication_sort_date\" = \"works\".\"first_publication_date\" || '-01-01'\n          ) or (\n            \"works\".\"first_publication_precision\" = 'month'\n            and length(\"works\".\"first_publication_date\") = 7\n            and substring(\"works\".\"first_publication_date\" from 5 for 1) = '-'\n            and \"works\".\"first_publication_sort_date\" = \"works\".\"first_publication_date\" || '-01'\n          ) or (\n            \"works\".\"first_publication_precision\" = 'day'\n            and length(\"works\".\"first_publication_date\") = 10\n            and substring(\"works\".\"first_publication_date\" from 5 for 1) = '-'\n            and substring(\"works\".\"first_publication_date\" from 8 for 1) = '-'\n            and \"works\".\"first_publication_sort_date\" = \"works\".\"first_publication_date\"\n          )\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/pg/meta/_journal.json
+++ b/drizzle/pg/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1785159867531,
       "tag": "0006_luxuriant_albert_cleary",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1785258819351,
+      "tag": "0007_third_blizzard",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/books/[id]/route.test.ts
+++ b/src/app/api/books/[id]/route.test.ts
@@ -36,6 +36,22 @@ describe("GET /api/books/[id]", () => {
     expect(response.status).toBe(404);
   });
 
+  it("omits an ineligible work date without suppressing the edition date", async () => {
+    vi.spyOn(repo, "findWorkById").mockResolvedValue({
+      ...workDetailFixture,
+      firstPublication: undefined,
+    });
+    const response = await GET(new Request("https://test"), {
+      params: Promise.resolve({ id: workDetailFixture.id }),
+    });
+    const body = await response.json();
+    expect(body).not.toHaveProperty("firstPublication");
+    expect(body.preferredEdition.publication).toEqual({
+      date: "2020",
+      precision: "year",
+    });
+  });
+
   it("advertises read-only methods", async () => {
     const response = await OPTIONS();
     expect(response.headers.get("Access-Control-Allow-Methods")).toBe(

--- a/src/app/api/books/[id]/route.test.ts
+++ b/src/app/api/books/[id]/route.test.ts
@@ -16,6 +16,14 @@ describe("GET /api/books/[id]", () => {
     const { provenance: _provenance, ...expected } = workDetailFixture;
     const body = await response.json();
     expect(body).toEqual(expected);
+    expect(body.firstPublication).toEqual({
+      date: "1965-06",
+      precision: "month",
+    });
+    expect(body.preferredEdition.publication).toEqual({
+      date: "2020",
+      precision: "year",
+    });
     expect(body).not.toHaveProperty("provenance");
     expect(find).toHaveBeenCalledWith(workDetailFixture.id);
   });

--- a/src/app/books/[id]/page.test.tsx
+++ b/src/app/books/[id]/page.test.tsx
@@ -57,6 +57,28 @@ describe("work detail page", () => {
     );
   });
 
+  it("omits an ineligible work date while retaining edition structured data", async () => {
+    vi.spyOn(repo, "findWorkById").mockResolvedValue({
+      ...workDetailFixture,
+      firstPublication: undefined,
+    });
+    const { container } = render(
+      await BookPage({
+        params: Promise.resolve({ id: workDetailFixture.id }),
+      }),
+    );
+    const script = container.querySelector(
+      'script[type="application/ld+json"]',
+    );
+    const structuredData = JSON.parse(script?.textContent ?? "");
+    expect(structuredData).not.toHaveProperty("datePublished");
+    expect(structuredData).toMatchObject({
+      workExample: [{ datePublished: "2020" }],
+    });
+    expect(screen.queryByText(/first published/i)).not.toBeInTheDocument();
+    expect(screen.getByText("Published")).toBeInTheDocument();
+  });
+
   it("keeps partial metadata factual without inventing a description", () => {
     const metadata = buildWorkMetadata(partialWorkDetailFixture);
     expect(metadata.title).toBe("Partial Work");

--- a/src/app/books/[id]/page.test.tsx
+++ b/src/app/books/[id]/page.test.tsx
@@ -38,7 +38,9 @@ describe("work detail page", () => {
       "@context": "https://schema.org",
       "@type": "Book",
       name: "Example Work",
+      datePublished: "1965-06",
       author: ["First Author", "Second Author"],
+      workExample: [{ datePublished: "2020" }],
     });
   });
 

--- a/src/db/catalog/enrichment/policies.ts
+++ b/src/db/catalog/enrichment/policies.ts
@@ -147,8 +147,8 @@ export const WIKIDATA_WORK_FACTS_ADAPTER = {
   sourceKey: "wikidata",
   sourceName: "Wikidata structured work facts",
   adapterId: "wikidata.work-facts",
-  adapterVersion: "1.0.0",
-  sourcePolicyVersion: "wikidata-cc0-2026-07-28",
+  adapterVersion: "1.1.0",
+  sourcePolicyVersion: "wikidata-cc0-first-publication-2026-07-28",
   policyReviewDate: POLICY_REVIEW_DATE,
   policySources: [
     "https://www.wikidata.org/wiki/Wikidata:Licensing",
@@ -159,12 +159,12 @@ export const WIKIDATA_WORK_FACTS_ADAPTER = {
   nextReviewDate: NEXT_POLICY_REVIEW_DATE,
   permissions: {
     metadata: {
-      allowedFields: ["work.preferred_title"],
+      allowedFields: ["work.preferred_title", "work.first_publication_date"],
       fetch: true,
       cache: true,
       retain: "full",
       transform: true,
-      display: false,
+      display: true,
     },
     text: denied(),
     asset: denied(),

--- a/src/db/catalog/enrichment/workflow.test.ts
+++ b/src/db/catalog/enrichment/workflow.test.ts
@@ -109,7 +109,8 @@ describe("isolated five-work enrichment workflow", () => {
       ]),
     );
     expect(policyBySource.get("bukie_editorial")?.display).toBe(true);
-    expect(policyBySource.get("wikidata")?.display).toBe(false);
+    expect(policyBySource.get("wikidata")?.display).toBe(true);
+    expect(policyBySource.get("wikidata")?.proposedEvidenceOnly).toBe(true);
     expect(
       run.metadataSources.every(
         (source) => JSON.parse(String(source.assetPolicy)).display === false,

--- a/src/db/catalog/importer.test.ts
+++ b/src/db/catalog/importer.test.ts
@@ -56,6 +56,22 @@ describe("normalized catalog importer", () => {
     ).toBe(true);
   });
 
+  it("never infers work first publication from imported edition dates", () => {
+    expect(
+      graph.works.every(
+        (work) =>
+          work.firstPublicationDate === null &&
+          work.firstPublicationPrecision === null &&
+          work.firstPublicationSortDate === null,
+      ),
+    ).toBe(true);
+    expect(
+      graph.fieldObservations.some(
+        (observation) => observation.fieldKey === "work.first_publication_date",
+      ),
+    ).toBe(false);
+  });
+
   it("preserves cover object keys independently of target IDs", () => {
     expect(new Set(graph.coverAssets.map((row) => row.objectKey))).toEqual(
       new Set(baseCatalog.map((book) => book.cover)),

--- a/src/db/catalog/importer.ts
+++ b/src/db/catalog/importer.ts
@@ -447,6 +447,9 @@ export function buildCatalogImportGraph(
         record.description && !record.generatedDescription
           ? record.description
           : null,
+      firstPublicationDate: null,
+      firstPublicationPrecision: null,
+      firstPublicationSortDate: null,
       preferredEditionId: null,
       createdAt: CATALOG_ARTIFACT_TIMESTAMP,
       updatedAt: CATALOG_ARTIFACT_TIMESTAMP,

--- a/src/db/catalog/policy-eligibility.test.ts
+++ b/src/db/catalog/policy-eligibility.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { sourcePolicyAllowsFieldDisplay } from "./policy-eligibility";
+
+describe("source field display policy", () => {
+  it("allows display when an optional allowlist includes the field", () => {
+    expect(
+      sourcePolicyAllowsFieldDisplay(
+        JSON.stringify({
+          display: true,
+          fieldPermission: {
+            allowedFields: ["work.first_publication_date"],
+          },
+          proposedEvidenceOnly: false,
+        }),
+        "work.first_publication_date",
+      ),
+    ).toBe(true);
+  });
+
+  it("preserves broad internal policies without a field allowlist", () => {
+    expect(
+      sourcePolicyAllowsFieldDisplay(
+        { display: true },
+        "edition.publication_date",
+      ),
+    ).toBe(true);
+  });
+
+  it("allows fields declared by the separate text permission", () => {
+    expect(
+      sourcePolicyAllowsFieldDisplay(
+        {
+          display: true,
+          fieldPermission: { allowedFields: ["work.preferred_title"] },
+          textPermission: { allowedFields: ["work.description"] },
+        },
+        "work.description",
+      ),
+    ).toBe(true);
+  });
+
+  it.each([
+    ["proposed-only", { display: true, proposedEvidenceOnly: true }],
+    [
+      "field denied",
+      {
+        display: true,
+        fieldPermission: { allowedFields: ["work.description"] },
+      },
+    ],
+    ["display denied", { display: false }],
+    [
+      "malformed field scope",
+      { display: true, fieldPermission: { allowedFields: "work.description" } },
+    ],
+    ["malformed", "{not-json"],
+  ])("rejects %s policy", (_case, policy) => {
+    expect(
+      sourcePolicyAllowsFieldDisplay(
+        policy as string | Record<string, unknown>,
+        "work.first_publication_date",
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/db/catalog/policy-eligibility.ts
+++ b/src/db/catalog/policy-eligibility.ts
@@ -1,0 +1,53 @@
+type DisplayPolicy = {
+  display?: unknown;
+  proposedEvidenceOnly?: unknown;
+  fieldPermission?: {
+    allowedFields?: unknown;
+  };
+  textPermission?: {
+    allowedFields?: unknown;
+  };
+};
+
+export function sourcePolicyAllowsFieldDisplay(
+  policy: string | Record<string, unknown> | null,
+  fieldKey: string,
+): boolean {
+  if (!policy) return false;
+  try {
+    const value: unknown =
+      typeof policy === "string" ? JSON.parse(policy) : policy;
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return false;
+    }
+    const parsed = value as DisplayPolicy;
+    if (parsed.display !== true || parsed.proposedEvidenceOnly === true) {
+      return false;
+    }
+    const permissionKeys = [
+      "fieldPermission",
+      "textPermission",
+    ] as const satisfies ReadonlyArray<keyof DisplayPolicy>;
+    const declaredPermissions = permissionKeys
+      .filter((key) => Object.hasOwn(parsed, key))
+      .map((key) => parsed[key]);
+    if (declaredPermissions.length === 0) return true;
+    const allowedFieldLists: string[][] = [];
+    for (const permission of declaredPermissions) {
+      if (!permission || typeof permission !== "object") return false;
+      const allowedFields = permission.allowedFields;
+      if (
+        !Array.isArray(allowedFields) ||
+        !allowedFields.every((allowedField) => typeof allowedField === "string")
+      ) {
+        return false;
+      }
+      allowedFieldLists.push(allowedFields);
+    }
+    return allowedFieldLists.some((allowedFields) =>
+      allowedFields.includes(fieldKey),
+    );
+  } catch {
+    return false;
+  }
+}

--- a/src/db/catalog/repository.test.ts
+++ b/src/db/catalog/repository.test.ts
@@ -417,4 +417,45 @@ describe("normalized catalog repository", () => {
       false,
     );
   });
+
+  it("keeps publication sorting and period filters edition-based", async () => {
+    const beforeSort = await repository.listWorkSummaries(
+      query({ sort: "publication" }),
+    );
+    const beforePeriod = await repository.listWorkSummaries(
+      query({ period: "1950-1999", sort: "publication" }),
+    );
+    raw.exec("begin");
+    try {
+      for (const [index, work] of beforeSort.entries()) {
+        const year = String(1900 + (beforeSort.length - index)).padStart(
+          4,
+          "0",
+        );
+        raw
+          .prepare(
+            `update works
+             set first_publication_date = ?,
+                 first_publication_precision = 'year',
+                 first_publication_sort_date = ?
+             where id = ?`,
+          )
+          .run(year, `${year}-01-01`, work.id);
+      }
+      const afterSort = await repository.listWorkSummaries(
+        query({ sort: "publication" }),
+      );
+      const afterPeriod = await repository.listWorkSummaries(
+        query({ period: "1950-1999", sort: "publication" }),
+      );
+      expect(afterSort.map((work) => work.id)).toEqual(
+        beforeSort.map((work) => work.id),
+      );
+      expect(afterPeriod.map((work) => work.id)).toEqual(
+        beforePeriod.map((work) => work.id),
+      );
+    } finally {
+      raw.exec("rollback");
+    }
+  });
 });

--- a/src/db/catalog/repository.ts
+++ b/src/db/catalog/repository.ts
@@ -35,6 +35,10 @@ type WorkRow = {
   title: string;
   sortTitle: string;
   description: string | null;
+  firstPublicationDate: string | null;
+  firstPublicationPrecision:
+    | NonNullable<WorkDetail["firstPublication"]>["precision"]
+    | null;
   preferredEditionId: string | null;
   publicationSortDate: string | null;
   catalogedAt: number | string | Date | null;
@@ -145,6 +149,8 @@ const WORK_COLUMNS = `
     w.preferred_title as "title",
     w.sort_title as "sortTitle",
     w.description as "description",
+    w.first_publication_date as "firstPublicationDate",
+    w.first_publication_precision as "firstPublicationPrecision",
     w.preferred_edition_id as "preferredEditionId",
     preferred.publication_sort_date as "publicationSortDate",
     preferred.cataloged_at as "catalogedAt"
@@ -570,6 +576,13 @@ export function createCatalogRepository(
       description: eligible("work", detail.id, "work.description")
         ? detail.description
         : undefined,
+      firstPublication: eligible(
+        "work",
+        detail.id,
+        "work.first_publication_date",
+      )
+        ? detail.firstPublication
+        : undefined,
       categories,
       editions,
       provenance,
@@ -804,6 +817,13 @@ export function createCatalogRepository(
       return {
         ...summary,
         description: optional(row.description),
+        firstPublication:
+          row.firstPublicationDate && row.firstPublicationPrecision
+            ? {
+                date: row.firstPublicationDate,
+                precision: row.firstPublicationPrecision,
+              }
+            : undefined,
         categories,
         editions: allEditions,
       } satisfies Omit<WorkDetail, "provenance">;

--- a/src/db/catalog/repository.ts
+++ b/src/db/catalog/repository.ts
@@ -21,6 +21,7 @@ import type {
   WorkDetail,
   WorkSummary,
 } from "@/features/books/types";
+import { sourcePolicyAllowsFieldDisplay } from "./policy-eligibility";
 
 export type CatalogQueryExecutor = {
   dialect: "sqlite" | "postgres";
@@ -179,18 +180,6 @@ function epochMilliseconds(value: number | string | Date): number {
   const numeric = Number(value);
   if (Number.isFinite(numeric)) return numeric;
   return new Date(value).getTime();
-}
-
-function sourcePolicyAllowsDisplay(
-  policy: string | Record<string, unknown> | null,
-): boolean {
-  if (!policy) return false;
-  try {
-    const parsed = typeof policy === "string" ? JSON.parse(policy) : policy;
-    return parsed.display === true;
-  } catch {
-    return false;
-  }
 }
 
 export function isDetailFieldDisplayEligible(
@@ -496,10 +485,11 @@ export function createCatalogRepository(
                 row.sourceRecordState === "active" &&
                 row.sourceLinkState === "active" &&
                 row.provenanceKind !== "synthetic" &&
-                sourcePolicyAllowsDisplay(
+                sourcePolicyAllowsFieldDisplay(
                   row.field === "edition.covers"
                     ? row.assetPolicy
                     : row.metadataPolicy,
+                  row.field,
                 ),
             }
           : undefined,

--- a/src/db/catalog/resolver.test.ts
+++ b/src/db/catalog/resolver.test.ts
@@ -41,6 +41,59 @@ describe("catalog field resolver", () => {
     });
   });
 
+  it("resolves work first-publication objects without inventing precision", () => {
+    expect(
+      resolveField("work.first_publication_date", [
+        candidate({
+          id: "year",
+          value: { date: "1965", precision: "year" },
+        }),
+        candidate({
+          id: "month",
+          value: { date: "1965-06", precision: "month" },
+        }),
+      ]),
+    ).toMatchObject({
+      state: "present",
+      selectedObservationId: "month",
+    });
+  });
+
+  it("rejects invalid or mismatched publication precision", () => {
+    expect(
+      resolveField("work.first_publication_date", [
+        candidate({ value: { date: "1965", precision: "day" } }),
+        candidate({
+          id: "invalid-month",
+          value: { date: "1965-13", precision: "month" },
+        }),
+      ]),
+    ).toMatchObject({
+      state: "missing",
+      selectedObservationId: null,
+    });
+  });
+
+  it("keeps conflicting stale work dates out of resolution", () => {
+    expect(
+      resolveField("work.first_publication_date", [
+        candidate({
+          id: "stale-a",
+          value: { date: "1965", precision: "year" },
+          state: "stale",
+        }),
+        candidate({
+          id: "stale-b",
+          value: { date: "1966", precision: "year" },
+          state: "stale",
+        }),
+      ]),
+    ).toMatchObject({
+      state: "conflicting",
+      selectedObservationId: null,
+    });
+  });
+
   it("uses an attributable curated correction without deleting evidence", () => {
     expect(
       resolveField("work.preferred_title", [

--- a/src/db/catalog/resolver.ts
+++ b/src/db/catalog/resolver.ts
@@ -1,5 +1,5 @@
 import { canonicalJson, hashCanonicalJson } from "./identity";
-import { parsePartialDate } from "./normalize";
+import { type PartialDate, parsePartialDate } from "./normalize";
 import type {
   CatalogFieldKey,
   ObservationState,
@@ -47,19 +47,45 @@ function compareCandidate(
   return left.id.localeCompare(right.id);
 }
 
+export function parsePublicationObservationValue(
+  value: unknown,
+): PartialDate | null {
+  if (typeof value === "string" || typeof value === "number") {
+    return parsePartialDate(value);
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const candidate = value as { date?: unknown; precision?: unknown };
+  if (
+    typeof candidate.date !== "string" ||
+    typeof candidate.precision !== "string"
+  ) {
+    return null;
+  }
+  const parsed = parsePartialDate(candidate.date);
+  return parsed?.precision === candidate.precision ? parsed : null;
+}
+
+function isPublicationDateField(fieldKey: CatalogFieldKey): boolean {
+  return (
+    fieldKey === "edition.publication_date" ||
+    fieldKey === "work.first_publication_date"
+  );
+}
+
 function compatiblePublicationDate(
   candidates: ResolutionCandidate[],
 ): ResolutionCandidate | "conflicting" | null {
   const parsed = candidates.map((candidate) => ({
     candidate,
-    date: parsePartialDate(String(candidate.value)),
+    date: parsePublicationObservationValue(candidate.value),
   }));
   if (parsed.some((entry) => entry.date === null)) return null;
   const ordered = parsed.sort((left, right) => {
     const precision = { year: 1, month: 2, day: 3 } as const;
     return (
       precision[right.date?.precision ?? "year"] -
-      precision[left.date?.precision ?? "year"]
+        precision[left.date?.precision ?? "year"] ||
+      compareCandidate(left.candidate, right.candidate)
     );
   });
   const mostPrecise = ordered[0];
@@ -75,7 +101,13 @@ export function resolveField(
   fieldKey: CatalogFieldKey,
   candidates: ResolutionCandidate[],
 ): ResolutionDecision {
-  const approved = candidates.filter((candidate) => candidate.sourceApproved);
+  const approved = candidates
+    .filter((candidate) => candidate.sourceApproved)
+    .filter(
+      (candidate) =>
+        !isPublicationDateField(fieldKey) ||
+        parsePublicationObservationValue(candidate.value) !== null,
+    );
   const eligible = approved.filter(
     (candidate) =>
       candidate.state === "active" &&
@@ -118,7 +150,29 @@ export function resolveField(
         ),
     );
     if (stale.length) {
-      const selected = [...stale].sort(compareCandidate)[0];
+      const bestPriority = Math.min(
+        ...stale.map((candidate) => candidate.sourcePriority),
+      );
+      const preferred = stale.filter(
+        (candidate) => candidate.sourcePriority === bestPriority,
+      );
+      let selected = [...preferred].sort(compareCandidate)[0];
+      if (isPublicationDateField(fieldKey)) {
+        const compatible = compatiblePublicationDate(preferred);
+        if (compatible === "conflicting" || compatible === null) {
+          return {
+            state: "conflicting",
+            selectedObservationId: null,
+            comparisonHash: hashCanonicalJson(
+              preferred
+                .map((candidate) => canonicalJson(candidate.value))
+                .sort(),
+            ),
+            reason: "Equally eligible stale observations conflict",
+          };
+        }
+        selected = compatible;
+      }
       return {
         state: "stale",
         selectedObservationId: selected.id,
@@ -153,7 +207,7 @@ export function resolveField(
     };
   }
 
-  if (fieldKey === "edition.publication_date") {
+  if (isPublicationDateField(fieldKey)) {
     const compatible = compatiblePublicationDate(preferred);
     if (compatible && compatible !== "conflicting") {
       return {

--- a/src/db/catalog/schema-parity.test.ts
+++ b/src/db/catalog/schema-parity.test.ts
@@ -156,4 +156,25 @@ describe("SQLite/Postgres normalized catalog schema parity", () => {
       );
     }
   });
+
+  it("adds nullable work first-publication fields and vocabulary in both providers", () => {
+    const sqliteMigration = readFileSync(
+      path.resolve("drizzle/0005_cuddly_bloodscream.sql"),
+      "utf8",
+    );
+    const postgresMigration = readFileSync(
+      path.resolve("drizzle/pg/0007_third_blizzard.sql"),
+      "utf8",
+    );
+    for (const migration of [sqliteMigration, postgresMigration]) {
+      expect(migration).toContain("work.first_publication_date");
+      expect(migration).toContain("first_publication_date");
+      expect(migration).toContain("first_publication_precision");
+      expect(migration).toContain("first_publication_sort_date");
+      expect(migration).toContain("works_first_publication_date_ck");
+      expect(migration).not.toMatch(
+        /update\s+works[\s\S]*editions|from\s+editions[\s\S]*first_publication/i,
+      );
+    }
+  });
 });

--- a/src/db/catalog/schema.pg.ts
+++ b/src/db/catalog/schema.pg.ts
@@ -86,6 +86,9 @@ export const worksPg = pgTable(
     preferredTitle: text("preferred_title").notNull(),
     sortTitle: text("sort_title").notNull(),
     description: text("description"),
+    firstPublicationDate: text("first_publication_date"),
+    firstPublicationPrecision: text("first_publication_precision"),
+    firstPublicationSortDate: text("first_publication_sort_date"),
     preferredEditionId: text("preferred_edition_id").references(
       (): AnyPgColumn => editionsPg.id,
       { onDelete: "set null" },
@@ -97,6 +100,40 @@ export const worksPg = pgTable(
     check(
       "works_titles_nonempty_ck",
       sql`length(trim(${table.preferredTitle})) > 0 and length(trim(${table.sortTitle})) > 0`,
+    ),
+    check(
+      "works_first_publication_precision_ck",
+      sql`${table.firstPublicationPrecision} is null or ${table.firstPublicationPrecision} in (${sql.raw(sqlList(PUBLICATION_PRECISIONS))})`,
+    ),
+    check(
+      "works_first_publication_date_ck",
+      sql`(
+        ${table.firstPublicationDate} is null
+        and ${table.firstPublicationPrecision} is null
+        and ${table.firstPublicationSortDate} is null
+      ) or (
+        ${table.firstPublicationDate} is not null
+        and ${table.firstPublicationPrecision} is not null
+        and ${table.firstPublicationSortDate} is not null
+        and (
+          (
+            ${table.firstPublicationPrecision} = 'year'
+            and length(${table.firstPublicationDate}) = 4
+            and ${table.firstPublicationSortDate} = ${table.firstPublicationDate} || '-01-01'
+          ) or (
+            ${table.firstPublicationPrecision} = 'month'
+            and length(${table.firstPublicationDate}) = 7
+            and substring(${table.firstPublicationDate} from 5 for 1) = '-'
+            and ${table.firstPublicationSortDate} = ${table.firstPublicationDate} || '-01'
+          ) or (
+            ${table.firstPublicationPrecision} = 'day'
+            and length(${table.firstPublicationDate}) = 10
+            and substring(${table.firstPublicationDate} from 5 for 1) = '-'
+            and substring(${table.firstPublicationDate} from 8 for 1) = '-'
+            and ${table.firstPublicationSortDate} = ${table.firstPublicationDate}
+          )
+        )
+      )`,
     ),
     index("works_sort_title_id_idx").on(table.sortTitle, table.id),
     index("works_preferred_edition_idx").on(table.preferredEditionId),

--- a/src/db/catalog/schema.ts
+++ b/src/db/catalog/schema.ts
@@ -86,6 +86,9 @@ export const works = sqliteTable(
     preferredTitle: text("preferred_title").notNull(),
     sortTitle: text("sort_title").notNull(),
     description: text("description"),
+    firstPublicationDate: text("first_publication_date"),
+    firstPublicationPrecision: text("first_publication_precision"),
+    firstPublicationSortDate: text("first_publication_sort_date"),
     preferredEditionId: text("preferred_edition_id").references(
       (): AnySQLiteColumn => editions.id,
       { onDelete: "set null" },
@@ -97,6 +100,40 @@ export const works = sqliteTable(
     check(
       "works_titles_nonempty_ck",
       sql`length(trim(${table.preferredTitle})) > 0 and length(trim(${table.sortTitle})) > 0`,
+    ),
+    check(
+      "works_first_publication_precision_ck",
+      sql`${table.firstPublicationPrecision} is null or ${table.firstPublicationPrecision} in (${sql.raw(sqlList(PUBLICATION_PRECISIONS))})`,
+    ),
+    check(
+      "works_first_publication_date_ck",
+      sql`(
+        ${table.firstPublicationDate} is null
+        and ${table.firstPublicationPrecision} is null
+        and ${table.firstPublicationSortDate} is null
+      ) or (
+        ${table.firstPublicationDate} is not null
+        and ${table.firstPublicationPrecision} is not null
+        and ${table.firstPublicationSortDate} is not null
+        and (
+          (
+            ${table.firstPublicationPrecision} = 'year'
+            and length(${table.firstPublicationDate}) = 4
+            and ${table.firstPublicationSortDate} = ${table.firstPublicationDate} || '-01-01'
+          ) or (
+            ${table.firstPublicationPrecision} = 'month'
+            and length(${table.firstPublicationDate}) = 7
+            and substr(${table.firstPublicationDate}, 5, 1) = '-'
+            and ${table.firstPublicationSortDate} = ${table.firstPublicationDate} || '-01'
+          ) or (
+            ${table.firstPublicationPrecision} = 'day'
+            and length(${table.firstPublicationDate}) = 10
+            and substr(${table.firstPublicationDate}, 5, 1) = '-'
+            and substr(${table.firstPublicationDate}, 8, 1) = '-'
+            and ${table.firstPublicationSortDate} = ${table.firstPublicationDate}
+          )
+        )
+      )`,
     ),
     index("works_sort_title_id_idx").on(table.sortTitle, table.id),
     index("works_preferred_edition_idx").on(table.preferredEditionId),

--- a/src/db/catalog/values.ts
+++ b/src/db/catalog/values.ts
@@ -10,6 +10,7 @@ export const CATALOG_ENTITY_TYPES = [
 export const CATALOG_FIELD_KEYS = [
   "work.preferred_title",
   "work.description",
+  "work.first_publication_date",
   "work.preferred_edition",
   "work.authors",
   "work.categories",

--- a/src/db/catalog/work-first-publication-migration.test.ts
+++ b/src/db/catalog/work-first-publication-migration.test.ts
@@ -1,0 +1,116 @@
+import {
+  cpSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { describe, expect, it } from "vitest";
+
+describe("work first-publication SQLite migration", () => {
+  it("adds nullable fields without inferring from an edition and preserves rollback safety", () => {
+    const directory = mkdtempSync(
+      path.join(tmpdir(), "bukie-work-date-migration-"),
+    );
+    const sqlitePath = path.join(directory, "catalog.sqlite");
+    const oldMigrations = path.join(directory, "old-migrations");
+    const raw = new Database(sqlitePath);
+    try {
+      cpSync(path.resolve("drizzle"), oldMigrations, { recursive: true });
+      rmSync(path.join(oldMigrations, "0005_cuddly_bloodscream.sql"));
+      rmSync(path.join(oldMigrations, "meta", "0005_snapshot.json"));
+      const journalPath = path.join(oldMigrations, "meta", "_journal.json");
+      const journal = JSON.parse(readFileSync(journalPath, "utf8")) as {
+        entries: Array<{ idx: number }>;
+      };
+      journal.entries = journal.entries.filter((entry) => entry.idx < 5);
+      writeFileSync(journalPath, JSON.stringify(journal, null, 2));
+
+      migrate(drizzle(raw), { migrationsFolder: oldMigrations });
+      raw
+        .prepare(
+          `insert into works (
+             id, preferred_title, sort_title, description,
+             preferred_edition_id, created_at, updated_at
+           ) values ('work-migration', 'Migration Work', 'migration work',
+                     null, null, 100, 100)`,
+        )
+        .run();
+      raw
+        .prepare(
+          `insert into editions (
+             id, work_id, title, subtitle, format, publication_date,
+             publication_precision, publication_sort_date, pages,
+             cataloged_at, created_at, updated_at
+           ) values (
+             'edition-migration', 'work-migration', null, null, null, '2020-07',
+             'month', '2020-07-01', null, 100, 100, 100
+           )`,
+        )
+        .run();
+      raw
+        .prepare(
+          "update works set preferred_edition_id = 'edition-migration' where id = 'work-migration'",
+        )
+        .run();
+
+      migrate(drizzle(raw), { migrationsFolder: path.resolve("drizzle") });
+      expect(
+        raw
+          .prepare(
+            `select first_publication_date as date,
+                    first_publication_precision as precision,
+                    first_publication_sort_date as sortDate
+             from works where id = 'work-migration'`,
+          )
+          .get(),
+      ).toEqual({ date: null, precision: null, sortDate: null });
+      expect(
+        raw
+          .prepare(
+            `select publication_date as date,
+                    publication_precision as precision,
+                    publication_sort_date as sortDate
+             from editions where id = 'edition-migration'`,
+          )
+          .get(),
+      ).toEqual({
+        date: "2020-07",
+        precision: "month",
+        sortDate: "2020-07-01",
+      });
+      expect(raw.pragma("foreign_key_check")).toEqual([]);
+      expect(() =>
+        raw
+          .prepare(
+            `update works
+             set first_publication_date = '1965',
+                 first_publication_precision = null,
+                 first_publication_sort_date = null
+             where id = 'work-migration'`,
+          )
+          .run(),
+      ).toThrow();
+    } finally {
+      raw.close();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("uses nullable additions rather than an edition-data backfill", () => {
+    const migration = readFileSync(
+      path.resolve("drizzle/0005_cuddly_bloodscream.sql"),
+      "utf8",
+    );
+    expect(migration).toContain(
+      "ALTER TABLE `works` ADD `first_publication_date` text",
+    );
+    expect(migration).not.toContain("FROM `editions`");
+    expect(migration).not.toMatch(/UPDATE `?works`?[\s\S]*first_publication/i);
+  });
+});

--- a/src/db/catalog/work-first-publication.pg.test.ts
+++ b/src/db/catalog/work-first-publication.pg.test.ts
@@ -1,0 +1,183 @@
+import postgres from "postgres";
+import { describe, expect, it } from "vitest";
+import { hashCanonicalJson } from "./identity";
+import { buildCatalogImportGraph } from "./importer";
+import { rebuildCatalogPostgres } from "./postgres-rebuild";
+import { resolveRebuildTarget } from "./rebuild-safety";
+import { resolveWorkFirstPublicationPostgres } from "./work-first-publication";
+
+const isolatedUrl = process.env.CATALOG_TEST_POSTGRES_URL;
+
+describe.skipIf(!isolatedUrl)(
+  "Postgres work first-publication resolution",
+  () => {
+    it("matches SQLite semantics, preserves edition dates, and rolls back atomically", async () => {
+      const target = resolveRebuildTarget({
+        rawTarget: `postgres:${isolatedUrl}`,
+        confirmDisposable: true,
+        env: { NODE_ENV: "test" },
+      });
+      if (target.driver !== "postgres") {
+        throw new Error("Expected an isolated Postgres target");
+      }
+      const graph = buildCatalogImportGraph([
+        {
+          sourceKey: "legacy_catalog",
+          recordKey: "postgres-work-date",
+          title: "Postgres Independent Dates",
+          authors: [{ name: "Example Author" }],
+          categories: [],
+          publicationDate: "2020-07",
+        },
+      ]);
+      const workId = String(graph.works[0].id);
+      const editionId = String(graph.editions[0].id);
+      await rebuildCatalogPostgres({ url: target.url, graph });
+      const client = postgres(target.url, { max: 1 });
+      const addEvidence = async (
+        key: string,
+        value: { date: string; precision: "year" | "month" | "day" },
+      ) => {
+        const sourceId = `pg-source-${key}`;
+        const recordId = `pg-record-${key}`;
+        const observationId = `pg-observation-${key}`;
+        await client`
+          insert into metadata_sources (
+            id, key, name, terms_url, attribution_url, reviewed_at,
+            approval_state, metadata_policy, asset_policy, payload_policy,
+            refresh_interval_ms
+          ) values (
+            ${sourceId}, ${`pg-${key}`}, ${`PG source ${key}`}, null, null,
+            ${new Date(Date.UTC(2026, 6, 28))}, 'approved',
+            ${client.json({
+              display: true,
+              fieldPermission: {
+                allowedFields: ["work.first_publication_date"],
+              },
+              proposedEvidenceOnly: false,
+            })},
+            ${client.json({ display: false })}, 'selected_fields', null
+          )
+        `;
+        await client`
+          insert into source_records (
+            id, source_id, record_key, source_revision, source_modified_at,
+            retrieved_at, payload_json, payload_hash, importer_version,
+            source_row_hash, state
+          ) values (
+            ${recordId}, ${sourceId}, ${key}, 'v1', null,
+            ${new Date(Date.UTC(2026, 6, 28))}, null, null, 'test',
+            ${hashCanonicalJson({ key })}, 'active'
+          )
+        `;
+        await client`
+          insert into source_record_links (
+            source_record_id, entity_type, entity_id, match_kind,
+            mapping_confidence, state, actor_ref, reason, created_at
+          ) values (
+            ${recordId}, 'work', ${workId}, 'source_relationship', 1,
+            'active', null, null, ${new Date(Date.UTC(2026, 6, 28))}
+          )
+        `;
+        await client`
+          insert into field_observations (
+            id, source_record_id, entity_type, entity_id, field_key,
+            value_json, comparison_hash, provenance_kind, source_path,
+            source_modified_at, retrieved_at, mapping_confidence, state,
+            actor_ref, reason, derivation_name, derivation_version,
+            parent_ids_json
+          ) values (
+            ${observationId}, ${recordId}, 'work', ${workId},
+            'work.first_publication_date', ${client.json(value)},
+            ${hashCanonicalJson(value)}, 'imported', 'publication', null,
+            ${new Date(Date.UTC(2026, 6, 28))}, 1, 'active', null, null,
+            null, null, null
+          )
+        `;
+        return observationId;
+      };
+      try {
+        await addEvidence("year", { date: "1965", precision: "year" });
+        await addEvidence("day", { date: "1965-06-18", precision: "day" });
+        const first = await resolveWorkFirstPublicationPostgres(target.url, {
+          workId,
+          resolvedAt: 200,
+        });
+        const retry = await resolveWorkFirstPublicationPostgres(target.url, {
+          workId,
+          resolvedAt: 300,
+        });
+        expect(first).toMatchObject({
+          changed: true,
+          decision: { state: "present" },
+          projection: {
+            firstPublicationDate: "1965-06-18",
+            firstPublicationPrecision: "day",
+            firstPublicationSortDate: "1965-06-18",
+          },
+        });
+        expect(retry).toMatchObject({
+          changed: false,
+          resolutionId: first.resolutionId,
+        });
+        expect(
+          await client`
+            select first_publication_date as date,
+                   first_publication_precision as precision,
+                   first_publication_sort_date as "sortDate"
+            from works where id = ${workId}
+          `,
+        ).toMatchObject([
+          { date: "1965-06-18", precision: "day", sortDate: "1965-06-18" },
+        ]);
+        expect(
+          await client`
+            select publication_date as date, publication_precision as precision
+            from editions where id = ${editionId}
+          `,
+        ).toMatchObject([{ date: "2020-07", precision: "month" }]);
+
+        const conflictId = await addEvidence("conflict", {
+          date: "1966",
+          precision: "year",
+        });
+        const conflict = await resolveWorkFirstPublicationPostgres(target.url, {
+          workId,
+          resolvedAt: 400,
+        });
+        expect(conflict.decision.state).toBe("conflicting");
+        expect(
+          await client`
+            select first_publication_date as date from works where id = ${workId}
+          `,
+        ).toMatchObject([{ date: null }]);
+
+        await client`
+          update field_observations set state = 'invalid'
+          where id = ${conflictId}
+        `;
+        await expect(
+          resolveWorkFirstPublicationPostgres(target.url, {
+            workId,
+            resolvedAt: 500,
+            failAfter: "head",
+          }),
+        ).rejects.toThrow("Forced work first-publication failure after head");
+        expect(
+          await client`
+            select h.resolution_id as id,
+                   w.first_publication_date as date
+            from works w
+            join field_resolution_heads h
+              on h.entity_type = 'work'
+             and h.entity_id = w.id
+             and h.field_key = 'work.first_publication_date'
+            where w.id = ${workId}
+          `,
+        ).toMatchObject([{ id: conflict.resolutionId, date: null }]);
+      } finally {
+        await client.end({ timeout: 5_000 });
+      }
+    }, 120_000);
+  },
+);

--- a/src/db/catalog/work-first-publication.pg.test.ts
+++ b/src/db/catalog/work-first-publication.pg.test.ts
@@ -34,6 +34,7 @@ describe.skipIf(!isolatedUrl)(
       const editionId = String(graph.editions[0].id);
       await rebuildCatalogPostgres({ url: target.url, graph });
       const client = postgres(target.url, { max: 1 });
+      const evidenceTimestamp = Date.UTC(2026, 6, 28);
       const addEvidence = async (
         key: string,
         value: { date: string; precision: "year" | "month" | "day" },
@@ -48,7 +49,7 @@ describe.skipIf(!isolatedUrl)(
             refresh_interval_ms
           ) values (
             ${sourceId}, ${`pg-${key}`}, ${`PG source ${key}`}, null, null,
-            ${new Date(Date.UTC(2026, 6, 28))}, 'approved',
+            ${evidenceTimestamp}, 'approved',
             ${client.json({
               display: true,
               fieldPermission: {
@@ -66,7 +67,7 @@ describe.skipIf(!isolatedUrl)(
             source_row_hash, state
           ) values (
             ${recordId}, ${sourceId}, ${key}, 'v1', null,
-            ${new Date(Date.UTC(2026, 6, 28))}, null, null, 'test',
+            ${evidenceTimestamp}, null, null, 'test',
             ${hashCanonicalJson({ key })}, 'active'
           )
         `;
@@ -76,7 +77,7 @@ describe.skipIf(!isolatedUrl)(
             mapping_confidence, state, actor_ref, reason, created_at
           ) values (
             ${recordId}, 'work', ${workId}, 'source_relationship', 1,
-            'active', null, null, ${new Date(Date.UTC(2026, 6, 28))}
+            'active', null, null, ${evidenceTimestamp}
           )
         `;
         await client`
@@ -90,7 +91,7 @@ describe.skipIf(!isolatedUrl)(
             ${observationId}, ${recordId}, 'work', ${workId},
             'work.first_publication_date', ${client.json(value)},
             ${hashCanonicalJson(value)}, 'imported', 'publication', null,
-            ${new Date(Date.UTC(2026, 6, 28))}, 1, 'active', null, null,
+            ${evidenceTimestamp}, 1, 'active', null, null,
             null, null, null
           )
         `;

--- a/src/db/catalog/work-first-publication.test.ts
+++ b/src/db/catalog/work-first-publication.test.ts
@@ -349,6 +349,61 @@ describe("provenance-resolved work first publication", () => {
     }
   });
 
+  it("immediately hides a prior projection when field policy is revoked", async () => {
+    const database = setup();
+    try {
+      addEvidence(database, {
+        key: "policy-revocation",
+        value: { date: "1965", precision: "year" },
+      });
+      resolveWorkFirstPublicationSqlite(database.raw, {
+        workId: database.workId,
+        resolvedAt: 200,
+      });
+      const repository = await repositoryFor(database);
+      await expect(
+        repository.getWorkDetail(database.workId),
+      ).resolves.toMatchObject({
+        firstPublication: { date: "1965", precision: "year" },
+      });
+
+      for (const metadataPolicy of [
+        {
+          display: true,
+          fieldPermission: {
+            allowedFields: ["work.first_publication_date"],
+          },
+          proposedEvidenceOnly: true,
+        },
+        {
+          display: true,
+          fieldPermission: { allowedFields: ["work.description"] },
+          proposedEvidenceOnly: false,
+        },
+      ]) {
+        database.raw
+          .prepare(
+            "update metadata_sources set metadata_policy = ? where key = 'policy-revocation'",
+          )
+          .run(canonicalJson(metadataPolicy));
+        await expect(
+          repository.getWorkDetail(database.workId),
+        ).resolves.toMatchObject({ firstPublication: undefined });
+      }
+
+      expect(
+        database.raw
+          .prepare(
+            `select count(*) as count from field_resolutions
+             where entity_id = ? and field_key = 'work.first_publication_date'`,
+          )
+          .get(database.workId),
+      ).toEqual({ count: 1 });
+    } finally {
+      cleanup(database);
+    }
+  });
+
   it("rolls back the resolution head and projection on a forced failure", () => {
     const database = setup();
     try {

--- a/src/db/catalog/work-first-publication.test.ts
+++ b/src/db/catalog/work-first-publication.test.ts
@@ -1,0 +1,409 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+import { canonicalJson, hashCanonicalJson } from "./identity";
+import { buildCatalogImportGraph } from "./importer";
+import {
+  type CatalogQueryExecutor,
+  createCatalogRepository,
+} from "./repository";
+import { openCatalogSqlite, rebuildCatalogSqlite } from "./sqlite-rebuild";
+import {
+  resolveWorkFirstPublicationSqlite,
+  WORK_FIRST_PUBLICATION_RESOLVER_VERSION,
+} from "./work-first-publication";
+
+type TestDatabase = {
+  directory: string;
+  raw: InstanceType<typeof Database>;
+  workId: string;
+  editionId: string;
+};
+
+function setup(): TestDatabase {
+  const directory = mkdtempSync(path.join(tmpdir(), "bukie-work-date-"));
+  const sqlitePath = path.join(directory, "catalog.sqlite");
+  const graph = buildCatalogImportGraph([
+    {
+      sourceKey: "legacy_catalog",
+      recordKey: "work-date-fixture",
+      title: "Independent Dates",
+      authors: [{ name: "Example Author" }],
+      categories: [],
+      publicationDate: "2020-07",
+    },
+  ]);
+  rebuildCatalogSqlite({ sqlitePath, graph });
+  const { raw } = openCatalogSqlite(sqlitePath);
+  return {
+    directory,
+    raw,
+    workId: String(graph.works[0].id),
+    editionId: String(graph.editions[0].id),
+  };
+}
+
+function cleanup(database: TestDatabase): void {
+  database.raw.close();
+  rmSync(database.directory, { recursive: true, force: true });
+}
+
+function addEvidence(
+  database: TestDatabase,
+  input: {
+    key: string;
+    value: unknown;
+    observationState?: "active" | "stale" | "withdrawn" | "invalid";
+    sourceApproval?: "approved" | "suspended";
+    sourceRecordState?: "active" | "withdrawn" | "deleted";
+    linkState?: "active" | "candidate" | "rejected";
+    provenanceKind?: "curated" | "imported";
+    proposedEvidenceOnly?: boolean;
+    retrievedAt?: number;
+  },
+): string {
+  const sourceId = `source-${input.key}`;
+  const sourceRecordId = `record-${input.key}`;
+  const observationId = `observation-${input.key}`;
+  const provenanceKind = input.provenanceKind ?? "imported";
+  const metadataPolicy = canonicalJson({
+    display: true,
+    fieldPermission: {
+      allowedFields: ["work.first_publication_date"],
+    },
+    proposedEvidenceOnly: input.proposedEvidenceOnly ?? false,
+  });
+  database.raw
+    .prepare(
+      `insert into metadata_sources (
+         id, key, name, terms_url, attribution_url, reviewed_at,
+         approval_state, metadata_policy, asset_policy, payload_policy,
+         refresh_interval_ms
+       ) values (?, ?, ?, null, null, ?, ?, ?, ?, 'selected_fields', null)`,
+    )
+    .run(
+      sourceId,
+      input.key,
+      `Source ${input.key}`,
+      Date.UTC(2026, 6, 28),
+      input.sourceApproval ?? "approved",
+      metadataPolicy,
+      canonicalJson({ display: false }),
+    );
+  database.raw
+    .prepare(
+      `insert into source_records (
+         id, source_id, record_key, source_revision, source_modified_at,
+         retrieved_at, payload_json, payload_hash, importer_version,
+         source_row_hash, state
+       ) values (?, ?, ?, 'v1', null, ?, null, null, 'test', ?, ?)`,
+    )
+    .run(
+      sourceRecordId,
+      sourceId,
+      input.key,
+      input.retrievedAt ?? 100,
+      hashCanonicalJson({ key: input.key }),
+      input.sourceRecordState ?? "active",
+    );
+  database.raw
+    .prepare(
+      `insert into source_record_links (
+         source_record_id, entity_type, entity_id, match_kind,
+         mapping_confidence, state, actor_ref, reason, created_at
+       ) values (?, 'work', ?, ?, 1, ?, null, null, 100)`,
+    )
+    .run(
+      sourceRecordId,
+      database.workId,
+      input.linkState === "candidate" ? "candidate" : "source_relationship",
+      input.linkState ?? "active",
+    );
+  database.raw
+    .prepare(
+      `insert into field_observations (
+         id, source_record_id, entity_type, entity_id, field_key, value_json,
+         comparison_hash, provenance_kind, source_path, source_modified_at,
+         retrieved_at, mapping_confidence, state, actor_ref, reason,
+         derivation_name, derivation_version, parent_ids_json
+       ) values (
+         ?, ?, 'work', ?, 'work.first_publication_date', ?, ?, ?,
+         'publication', null, ?, 1, ?, ?, ?, null, null, null
+       )`,
+    )
+    .run(
+      observationId,
+      sourceRecordId,
+      database.workId,
+      canonicalJson(input.value),
+      hashCanonicalJson(input.value),
+      provenanceKind,
+      input.retrievedAt ?? 100,
+      input.observationState ?? "active",
+      provenanceKind === "curated" ? "user:test-editor" : null,
+      provenanceKind === "curated" ? "Verified from work evidence" : null,
+    );
+  return observationId;
+}
+
+async function repositoryFor(database: TestDatabase) {
+  const executor: CatalogQueryExecutor = {
+    dialect: "sqlite",
+    async query<T extends Record<string, unknown>>(
+      statement: string,
+      parameters: unknown[] = [],
+    ) {
+      return database.raw.prepare(statement).all(...parameters) as T[];
+    },
+  };
+  return createCatalogRepository(executor);
+}
+
+describe("provenance-resolved work first publication", () => {
+  it.each([
+    ["1965", "year", "1965-01-01"],
+    ["1965-06", "month", "1965-06-01"],
+    ["1965-06-18", "day", "1965-06-18"],
+  ] as const)("round-trips %s precision without changing the edition date", async (date, precision, sortDate) => {
+    const database = setup();
+    try {
+      addEvidence(database, {
+        key: `precision-${precision}`,
+        value: { date, precision },
+      });
+      const result = resolveWorkFirstPublicationSqlite(database.raw, {
+        workId: database.workId,
+        resolvedAt: 200,
+      });
+      expect(result).toMatchObject({
+        changed: true,
+        decision: { state: "present" },
+        projection: {
+          firstPublicationDate: date,
+          firstPublicationPrecision: precision,
+          firstPublicationSortDate: sortDate,
+        },
+      });
+      const repository = await repositoryFor(database);
+      const detail = await repository.getWorkDetail(database.workId);
+      expect(detail?.firstPublication).toEqual({ date, precision });
+      expect(detail?.preferredEdition?.publication).toEqual({
+        date: "2020-07",
+        precision: "month",
+      });
+    } finally {
+      cleanup(database);
+    }
+  });
+
+  it("selects compatible greater precision deterministically and is idempotent", () => {
+    const database = setup();
+    try {
+      addEvidence(database, {
+        key: "year",
+        value: { date: "1965", precision: "year" },
+      });
+      const selected = addEvidence(database, {
+        key: "day",
+        value: { date: "1965-06-18", precision: "day" },
+      });
+      const first = resolveWorkFirstPublicationSqlite(database.raw, {
+        workId: database.workId,
+        resolvedAt: 200,
+      });
+      const second = resolveWorkFirstPublicationSqlite(database.raw, {
+        workId: database.workId,
+        resolvedAt: 300,
+      });
+      expect(first.decision.selectedObservationId).toBe(selected);
+      expect(second).toMatchObject({
+        changed: false,
+        resolutionId: first.resolutionId,
+      });
+      expect(
+        database.raw
+          .prepare(
+            `select count(*) as count from field_resolutions
+             where entity_id = ? and field_key = 'work.first_publication_date'`,
+          )
+          .get(database.workId),
+      ).toEqual({ count: 1 });
+    } finally {
+      cleanup(database);
+    }
+  });
+
+  it("keeps incompatible years conflicting and out of projections", async () => {
+    const database = setup();
+    try {
+      addEvidence(database, {
+        key: "conflict-a",
+        value: { date: "1965", precision: "year" },
+      });
+      addEvidence(database, {
+        key: "conflict-b",
+        value: { date: "1966", precision: "year" },
+      });
+      const result = resolveWorkFirstPublicationSqlite(database.raw, {
+        workId: database.workId,
+        resolvedAt: 200,
+      });
+      expect(result.decision).toMatchObject({
+        state: "conflicting",
+        selectedObservationId: null,
+      });
+      await expect(
+        (await repositoryFor(database)).getWorkDetail(database.workId),
+      ).resolves.toMatchObject({ firstPublication: undefined });
+    } finally {
+      cleanup(database);
+    }
+  });
+
+  it.each([
+    ["missing", undefined, undefined, "missing"],
+    ["invalid", "invalid", undefined, "missing"],
+    ["suspended", "active", "suspended", "missing"],
+    ["stale", "stale", undefined, "stale"],
+    ["withdrawn", "withdrawn", undefined, "withdrawn"],
+  ] as const)("applies %s evidence eligibility", (key, observationState, sourceApproval, expectedState) => {
+    const database = setup();
+    try {
+      if (observationState) {
+        addEvidence(database, {
+          key,
+          value:
+            observationState === "invalid"
+              ? { date: "1965-13", precision: "month" }
+              : { date: "1965", precision: "year" },
+          observationState,
+          sourceApproval,
+        });
+      }
+      const result = resolveWorkFirstPublicationSqlite(database.raw, {
+        workId: database.workId,
+        resolvedAt: 200,
+      });
+      expect(result.decision.state).toBe(expectedState);
+      expect(result.projection.firstPublicationDate).toBe(
+        expectedState === "stale" ? "1965" : null,
+      );
+    } finally {
+      cleanup(database);
+    }
+  });
+
+  it("withdraws a prior projection and retains immutable resolution history", () => {
+    const database = setup();
+    try {
+      const observationId = addEvidence(database, {
+        key: "withdrawal",
+        value: { date: "1965", precision: "year" },
+      });
+      const first = resolveWorkFirstPublicationSqlite(database.raw, {
+        workId: database.workId,
+        resolvedAt: 200,
+      });
+      database.raw
+        .prepare(
+          "update field_observations set state = 'withdrawn' where id = ?",
+        )
+        .run(observationId);
+      const withdrawn = resolveWorkFirstPublicationSqlite(database.raw, {
+        workId: database.workId,
+        resolvedAt: 300,
+      });
+      expect(withdrawn.decision.state).toBe("withdrawn");
+      expect(withdrawn.projection.firstPublicationDate).toBeNull();
+      expect(
+        database.raw
+          .prepare(
+            `select previous_resolution_id as previous
+             from field_resolutions where id = ?`,
+          )
+          .get(withdrawn.resolutionId),
+      ).toEqual({ previous: first.resolutionId });
+    } finally {
+      cleanup(database);
+    }
+  });
+
+  it("excludes unpromoted proposed evidence from resolution", () => {
+    const database = setup();
+    try {
+      addEvidence(database, {
+        key: "proposed",
+        value: { date: "1965", precision: "year" },
+        proposedEvidenceOnly: true,
+      });
+      expect(
+        resolveWorkFirstPublicationSqlite(database.raw, {
+          workId: database.workId,
+          resolvedAt: 200,
+        }).decision.state,
+      ).toBe("missing");
+    } finally {
+      cleanup(database);
+    }
+  });
+
+  it("rolls back the resolution head and projection on a forced failure", () => {
+    const database = setup();
+    try {
+      addEvidence(database, {
+        key: "rollback",
+        value: { date: "1965", precision: "year" },
+      });
+      expect(() =>
+        resolveWorkFirstPublicationSqlite(database.raw, {
+          workId: database.workId,
+          resolvedAt: 200,
+          failAfter: "head",
+        }),
+      ).toThrow("Forced work first-publication failure after head");
+      expect(
+        database.raw
+          .prepare(
+            `select count(*) as count from field_resolutions
+             where entity_id = ? and field_key = 'work.first_publication_date'`,
+          )
+          .get(database.workId),
+      ).toEqual({ count: 0 });
+      expect(
+        database.raw
+          .prepare(
+            `select first_publication_date as date from works where id = ?`,
+          )
+          .get(database.workId),
+      ).toEqual({ date: null });
+    } finally {
+      cleanup(database);
+    }
+  });
+
+  it("records the dedicated resolver version", () => {
+    const database = setup();
+    try {
+      addEvidence(database, {
+        key: "version",
+        value: { date: "1965", precision: "year" },
+      });
+      const result = resolveWorkFirstPublicationSqlite(database.raw, {
+        workId: database.workId,
+        resolvedAt: 200,
+      });
+      expect(
+        database.raw
+          .prepare(
+            `select resolver_version as version
+             from field_resolutions where id = ?`,
+          )
+          .get(result.resolutionId),
+      ).toEqual({ version: WORK_FIRST_PUBLICATION_RESOLVER_VERSION });
+    } finally {
+      cleanup(database);
+    }
+  });
+});

--- a/src/db/catalog/work-first-publication.ts
+++ b/src/db/catalog/work-first-publication.ts
@@ -358,7 +358,7 @@ export async function resolveWorkFirstPublicationPostgres(
           current?.id ?? null,
           options.actorRef ?? "system:work-first-publication-resolver",
           WORK_FIRST_PUBLICATION_RESOLVER_VERSION,
-          new Date(resolvedAt),
+          resolvedAt,
         ],
       );
       if (options.failAfter === "resolution") {
@@ -388,7 +388,7 @@ export async function resolveWorkFirstPublicationPostgres(
           projection.firstPublicationDate,
           projection.firstPublicationPrecision,
           projection.firstPublicationSortDate,
-          new Date(resolvedAt),
+          resolvedAt,
           options.workId,
         ],
       );

--- a/src/db/catalog/work-first-publication.ts
+++ b/src/db/catalog/work-first-publication.ts
@@ -2,6 +2,7 @@ import type Database from "better-sqlite3";
 import postgres from "postgres";
 import { deterministicCatalogId, hashCanonicalJson } from "./identity";
 import type { PartialDate } from "./normalize";
+import { sourcePolicyAllowsFieldDisplay } from "./policy-eligibility";
 import {
   parsePublicationObservationValue,
   type ResolutionCandidate,
@@ -66,33 +67,11 @@ function parseJson(value: string | unknown): unknown {
   return typeof value === "string" ? JSON.parse(value) : value;
 }
 
-function policyAllowsWorkFirstPublication(
-  value: string | Record<string, unknown>,
-): boolean {
-  try {
-    const policy = parseJson(value) as {
-      display?: unknown;
-      proposedEvidenceOnly?: unknown;
-      fieldPermission?: { allowedFields?: unknown };
-    };
-    if (policy.display !== true || policy.proposedEvidenceOnly === true) {
-      return false;
-    }
-    const allowedFields = policy.fieldPermission?.allowedFields;
-    return (
-      allowedFields === undefined ||
-      (Array.isArray(allowedFields) && allowedFields.includes(FIELD_KEY))
-    );
-  } catch {
-    return false;
-  }
-}
-
 function candidateFromRow(row: CandidateRow): ResolutionCandidate {
   const sourceUsable =
     row.sourceApproval === "approved" &&
     row.sourceLinkState === "active" &&
-    policyAllowsWorkFirstPublication(row.metadataPolicy);
+    sourcePolicyAllowsFieldDisplay(row.metadataPolicy, FIELD_KEY);
   return {
     id: row.id,
     sourceKey: row.sourceKey,

--- a/src/db/catalog/work-first-publication.ts
+++ b/src/db/catalog/work-first-publication.ts
@@ -1,0 +1,405 @@
+import type Database from "better-sqlite3";
+import postgres from "postgres";
+import { deterministicCatalogId, hashCanonicalJson } from "./identity";
+import type { PartialDate } from "./normalize";
+import {
+  parsePublicationObservationValue,
+  type ResolutionCandidate,
+  type ResolutionDecision,
+  resolveField,
+} from "./resolver";
+
+export const WORK_FIRST_PUBLICATION_RESOLVER_VERSION =
+  "work-first-publication-v1";
+const FIELD_KEY = "work.first_publication_date";
+
+type CandidateRow = {
+  id: string;
+  sourceKey: string;
+  sourceApproval: "pending" | "approved" | "suspended" | "retired";
+  metadataPolicy: string | Record<string, unknown>;
+  valueJson: string | unknown;
+  provenanceKind: ResolutionCandidate["provenanceKind"];
+  observationState: ResolutionCandidate["state"];
+  retrievedAt: number | string | Date;
+  actorRef: string | null;
+  reason: string | null;
+  sourceRecordState: "active" | "withdrawn" | "deleted";
+  sourceLinkState: "active" | "candidate" | "rejected";
+};
+
+type CurrentResolutionRow = {
+  id: string;
+  state: ResolutionDecision["state"];
+  selectedObservationId: string | null;
+  resolverVersion: string;
+};
+
+type WorkProjectionRow = {
+  firstPublicationDate: string | null;
+  firstPublicationPrecision: PartialDate["precision"] | null;
+  firstPublicationSortDate: string | null;
+};
+
+export type WorkFirstPublicationResult = {
+  changed: boolean;
+  resolutionId: string;
+  decision: ResolutionDecision;
+  projection: WorkProjectionRow;
+};
+
+export type WorkFirstPublicationOptions = {
+  workId: string;
+  resolvedAt?: number;
+  actorRef?: string;
+  failAfter?: "resolution" | "head";
+};
+
+function epochMilliseconds(value: number | string | Date): number {
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === "number") return value;
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : new Date(value).getTime();
+}
+
+function parseJson(value: string | unknown): unknown {
+  return typeof value === "string" ? JSON.parse(value) : value;
+}
+
+function policyAllowsWorkFirstPublication(
+  value: string | Record<string, unknown>,
+): boolean {
+  try {
+    const policy = parseJson(value) as {
+      display?: unknown;
+      proposedEvidenceOnly?: unknown;
+      fieldPermission?: { allowedFields?: unknown };
+    };
+    if (policy.display !== true || policy.proposedEvidenceOnly === true) {
+      return false;
+    }
+    const allowedFields = policy.fieldPermission?.allowedFields;
+    return (
+      allowedFields === undefined ||
+      (Array.isArray(allowedFields) && allowedFields.includes(FIELD_KEY))
+    );
+  } catch {
+    return false;
+  }
+}
+
+function candidateFromRow(row: CandidateRow): ResolutionCandidate {
+  const sourceUsable =
+    row.sourceApproval === "approved" &&
+    row.sourceLinkState === "active" &&
+    policyAllowsWorkFirstPublication(row.metadataPolicy);
+  return {
+    id: row.id,
+    sourceKey: row.sourceKey,
+    sourceApproved: sourceUsable,
+    sourcePriority: 0,
+    value: parseJson(row.valueJson),
+    provenanceKind: row.provenanceKind,
+    state:
+      sourceUsable && row.sourceRecordState !== "active"
+        ? "withdrawn"
+        : row.observationState,
+    retrievedAt: epochMilliseconds(row.retrievedAt),
+    actorRef: row.actorRef ?? undefined,
+    reason: row.reason ?? undefined,
+  };
+}
+
+export function resolveWorkFirstPublicationRows(rows: CandidateRow[]): {
+  decision: ResolutionDecision;
+  projection: WorkProjectionRow;
+} {
+  const candidates = rows.map(candidateFromRow);
+  const decision = resolveField(FIELD_KEY, candidates);
+  const selected = candidates.find(
+    (candidate) => candidate.id === decision.selectedObservationId,
+  );
+  const parsed = selected
+    ? parsePublicationObservationValue(selected.value)
+    : null;
+  return {
+    decision,
+    projection: parsed
+      ? {
+          firstPublicationDate: parsed.value,
+          firstPublicationPrecision: parsed.precision,
+          firstPublicationSortDate: parsed.sortDate,
+        }
+      : {
+          firstPublicationDate: null,
+          firstPublicationPrecision: null,
+          firstPublicationSortDate: null,
+        },
+  };
+}
+
+const CANDIDATE_SQL = `
+  select
+    o.id as "id",
+    s.key as "sourceKey",
+    s.approval_state as "sourceApproval",
+    s.metadata_policy as "metadataPolicy",
+    o.value_json as "valueJson",
+    o.provenance_kind as "provenanceKind",
+    o.state as "observationState",
+    o.retrieved_at as "retrievedAt",
+    o.actor_ref as "actorRef",
+    o.reason as "reason",
+    sr.state as "sourceRecordState",
+    sl.state as "sourceLinkState"
+  from field_observations o
+  join source_records sr on sr.id = o.source_record_id
+  join metadata_sources s on s.id = sr.source_id
+  join source_record_links sl
+    on sl.source_record_id = sr.id
+   and sl.entity_type = o.entity_type
+   and sl.entity_id = o.entity_id
+  where o.entity_type = 'work'
+    and o.entity_id = PLACEHOLDER
+    and o.field_key = 'work.first_publication_date'
+  order by s.key asc, o.retrieved_at desc, o.id asc
+`;
+
+function resolutionId(
+  workId: string,
+  previousResolutionId: string | null,
+  decision: ResolutionDecision,
+): string {
+  return deterministicCatalogId(
+    "field_resolution",
+    WORK_FIRST_PUBLICATION_RESOLVER_VERSION,
+    hashCanonicalJson({
+      decision,
+      fieldKey: FIELD_KEY,
+      previousResolutionId,
+      workId,
+    }),
+  );
+}
+
+function isEquivalentCurrent(
+  current: CurrentResolutionRow | undefined,
+  decision: ResolutionDecision,
+): boolean {
+  return Boolean(
+    current &&
+      current.state === decision.state &&
+      current.selectedObservationId === decision.selectedObservationId &&
+      current.resolverVersion === WORK_FIRST_PUBLICATION_RESOLVER_VERSION,
+  );
+}
+
+export function resolveWorkFirstPublicationSqlite(
+  raw: InstanceType<typeof Database>,
+  options: WorkFirstPublicationOptions,
+): WorkFirstPublicationResult {
+  const resolvedAt = options.resolvedAt ?? Date.now();
+  const apply = raw.transaction(() => {
+    const work = raw
+      .prepare("select id from works where id = ?")
+      .get(options.workId);
+    if (!work) throw new Error(`Work ${options.workId} does not exist`);
+    const rows = raw
+      .prepare(CANDIDATE_SQL.replace("PLACEHOLDER", "?"))
+      .all(options.workId) as CandidateRow[];
+    const { decision, projection } = resolveWorkFirstPublicationRows(rows);
+    const current = raw
+      .prepare(
+        `select r.id as "id",
+                r.state as "state",
+                r.selected_observation_id as "selectedObservationId",
+                r.resolver_version as "resolverVersion"
+         from field_resolution_heads h
+         join field_resolutions r on r.id = h.resolution_id
+         where h.entity_type = 'work'
+           and h.entity_id = ?
+           and h.field_key = 'work.first_publication_date'`,
+      )
+      .get(options.workId) as CurrentResolutionRow | undefined;
+    if (isEquivalentCurrent(current, decision)) {
+      return {
+        changed: false,
+        resolutionId: current?.id ?? "",
+        decision,
+        projection,
+      };
+    }
+    const nextResolutionId = resolutionId(
+      options.workId,
+      current?.id ?? null,
+      decision,
+    );
+    raw
+      .prepare(
+        `insert into field_resolutions (
+           id, entity_type, entity_id, field_key, selected_observation_id,
+           state, reason, previous_resolution_id, actor_ref, resolver_version,
+           resolved_at
+         ) values (?, 'work', ?, 'work.first_publication_date', ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        nextResolutionId,
+        options.workId,
+        decision.selectedObservationId,
+        decision.state,
+        decision.reason,
+        current?.id ?? null,
+        options.actorRef ?? "system:work-first-publication-resolver",
+        WORK_FIRST_PUBLICATION_RESOLVER_VERSION,
+        resolvedAt,
+      );
+    if (options.failAfter === "resolution") {
+      throw new Error("Forced work first-publication failure after resolution");
+    }
+    raw
+      .prepare(
+        `insert into field_resolution_heads (
+           entity_type, entity_id, field_key, resolution_id
+         ) values ('work', ?, 'work.first_publication_date', ?)
+         on conflict(entity_type, entity_id, field_key)
+         do update set resolution_id = excluded.resolution_id`,
+      )
+      .run(options.workId, nextResolutionId);
+    if (options.failAfter === "head") {
+      throw new Error("Forced work first-publication failure after head");
+    }
+    raw
+      .prepare(
+        `update works
+         set first_publication_date = ?,
+             first_publication_precision = ?,
+             first_publication_sort_date = ?,
+             updated_at = ?
+         where id = ?`,
+      )
+      .run(
+        projection.firstPublicationDate,
+        projection.firstPublicationPrecision,
+        projection.firstPublicationSortDate,
+        resolvedAt,
+        options.workId,
+      );
+    return {
+      changed: true,
+      resolutionId: nextResolutionId,
+      decision,
+      projection,
+    };
+  });
+  return apply.immediate();
+}
+
+export async function resolveWorkFirstPublicationPostgres(
+  url: string,
+  options: WorkFirstPublicationOptions,
+): Promise<WorkFirstPublicationResult> {
+  const client = postgres(url, { max: 1 });
+  const resolvedAt = options.resolvedAt ?? Date.now();
+  try {
+    return await client.begin(async (sql) => {
+      const works = (await sql.unsafe(
+        "select id from works where id = $1 for update",
+        [options.workId],
+      )) as unknown as Array<{ id: string }>;
+      if (!works[0]) throw new Error(`Work ${options.workId} does not exist`);
+      const rows = await sql.unsafe<CandidateRow[]>(
+        CANDIDATE_SQL.replace("PLACEHOLDER", "$1"),
+        [options.workId],
+      );
+      const { decision, projection } = resolveWorkFirstPublicationRows([
+        ...rows,
+      ]);
+      const currentRows = (await sql.unsafe(
+        `select r.id as "id",
+                r.state as "state",
+                r.selected_observation_id as "selectedObservationId",
+                r.resolver_version as "resolverVersion"
+         from field_resolution_heads h
+         join field_resolutions r on r.id = h.resolution_id
+         where h.entity_type = 'work'
+           and h.entity_id = $1
+           and h.field_key = 'work.first_publication_date'`,
+        [options.workId],
+      )) as unknown as CurrentResolutionRow[];
+      const current = currentRows[0];
+      if (isEquivalentCurrent(current, decision)) {
+        return {
+          changed: false,
+          resolutionId: current.id,
+          decision,
+          projection,
+        };
+      }
+      const nextResolutionId = resolutionId(
+        options.workId,
+        current?.id ?? null,
+        decision,
+      );
+      await sql.unsafe(
+        `insert into field_resolutions (
+           id, entity_type, entity_id, field_key, selected_observation_id,
+           state, reason, previous_resolution_id, actor_ref, resolver_version,
+           resolved_at
+         ) values (
+           $1, 'work', $2, 'work.first_publication_date', $3, $4, $5, $6,
+           $7, $8, $9
+         )`,
+        [
+          nextResolutionId,
+          options.workId,
+          decision.selectedObservationId,
+          decision.state,
+          decision.reason,
+          current?.id ?? null,
+          options.actorRef ?? "system:work-first-publication-resolver",
+          WORK_FIRST_PUBLICATION_RESOLVER_VERSION,
+          new Date(resolvedAt),
+        ],
+      );
+      if (options.failAfter === "resolution") {
+        throw new Error(
+          "Forced work first-publication failure after resolution",
+        );
+      }
+      await sql.unsafe(
+        `insert into field_resolution_heads (
+           entity_type, entity_id, field_key, resolution_id
+         ) values ('work', $1, 'work.first_publication_date', $2)
+         on conflict(entity_type, entity_id, field_key)
+         do update set resolution_id = excluded.resolution_id`,
+        [options.workId, nextResolutionId],
+      );
+      if (options.failAfter === "head") {
+        throw new Error("Forced work first-publication failure after head");
+      }
+      await sql.unsafe(
+        `update works
+         set first_publication_date = $1,
+             first_publication_precision = $2,
+             first_publication_sort_date = $3,
+             updated_at = $4
+         where id = $5`,
+        [
+          projection.firstPublicationDate,
+          projection.firstPublicationPrecision,
+          projection.firstPublicationSortDate,
+          new Date(resolvedAt),
+          options.workId,
+        ],
+      );
+      return {
+        changed: true,
+        resolutionId: nextResolutionId,
+        decision,
+        projection,
+      };
+    });
+  } finally {
+    await client.end({ timeout: 5_000 });
+  }
+}

--- a/src/features/books/BookDetails.test.tsx
+++ b/src/features/books/BookDetails.test.tsx
@@ -28,6 +28,9 @@ describe("BookDetails", () => {
     ]);
     expect(screen.getByText("First Author, Second Author")).toBeInTheDocument();
     expect(screen.getByText("Stored catalog description.")).toBeInTheDocument();
+    expect(screen.getByText("First published 1965-06")).toBeInTheDocument();
+    expect(screen.getByText("2020")).toBeInTheDocument();
+    expect(screen.getByText("Published")).toBeInTheDocument();
     expect(screen.getByText("Example Press")).toBeInTheDocument();
     expect(screen.getByText("978-0-441-17271-9")).toBeInTheDocument();
     expect(

--- a/src/features/books/BookDetails.tsx
+++ b/src/features/books/BookDetails.tsx
@@ -206,6 +206,12 @@ export function BookDetails({ work }: BookDetailsProps) {
                   ))}
                 </ul>
               ) : null}
+              {work.firstPublication ? (
+                <p className="m-0 inline-flex items-center gap-[var(--spacing-1)] text-[var(--type-sm)] text-[var(--color-on-surface)] opacity-80">
+                  <Calendar className="h-4 w-4" aria-hidden="true" />
+                  <span>First published {work.firstPublication.date}</span>
+                </p>
+              ) : null}
             </header>
 
             {work.description ? (

--- a/src/features/books/detailPresentation.test.ts
+++ b/src/features/books/detailPresentation.test.ts
@@ -44,6 +44,7 @@ describe("detail presentation", () => {
       "@context": "https://schema.org",
       "@type": "Book",
       name: "Example Work",
+      datePublished: "1965-06",
       description: "Stored catalog description.",
       author: ["First Author", "Second Author"],
       genre: ["Fiction", "Classics"],
@@ -61,6 +62,14 @@ describe("detail presentation", () => {
     expect(JSON.stringify(data)).not.toMatch(
       /rating|popularity|catalogedAt|objectKey|provenance/i,
     );
+    expect(data.datePublished).not.toBe(
+      (
+        (data.workExample as Array<Record<string, unknown>>)[0] as Record<
+          string,
+          unknown
+        >
+      ).datePublished,
+    );
   });
 
   it("keeps partial structured data valid and escapes script-breaking text", () => {
@@ -77,5 +86,16 @@ describe("detail presentation", () => {
     const serialized = serializeStructuredData(data);
     expect(serialized).not.toContain("<");
     expect(JSON.parse(serialized)).toEqual(data);
+  });
+
+  it("omits an ineligible work date without suppressing the edition date", () => {
+    const data = buildBookStructuredData({
+      ...workDetailFixture,
+      firstPublication: undefined,
+    });
+    expect(data).not.toHaveProperty("datePublished");
+    expect(data).toMatchObject({
+      workExample: [{ datePublished: "2020" }],
+    });
   });
 });

--- a/src/features/books/detailPresentation.ts
+++ b/src/features/books/detailPresentation.ts
@@ -76,6 +76,9 @@ export function buildBookStructuredData(
     "@context": "https://schema.org",
     "@type": "Book",
     name: work.title,
+    ...(work.firstPublication
+      ? { datePublished: work.firstPublication.date }
+      : {}),
     ...(work.description ? { description: work.description } : {}),
     ...(work.categories.length > 0
       ? { genre: work.categories.map((category) => category.label) }

--- a/src/features/books/types.ts
+++ b/src/features/books/types.ts
@@ -62,6 +62,7 @@ export type EditionSummary = {
 export type DetailProvenanceField =
   | "work.preferred_title"
   | "work.description"
+  | "work.first_publication_date"
   | "work.preferred_edition"
   | "work.authors"
   | "work.categories"
@@ -102,6 +103,10 @@ export type WorkSummary = {
 
 export type WorkDetail = WorkSummary & {
   description?: string;
+  firstPublication?: {
+    date: string;
+    precision: "year" | "month" | "day";
+  };
   categories: WorkCategory[];
   editions: EditionSummary[];
   provenance: DetailProvenance[];

--- a/src/test/catalog-fixtures.ts
+++ b/src/test/catalog-fixtures.ts
@@ -93,6 +93,7 @@ export const workSummaryFixture: WorkSummary = {
 export const workDetailFixture: WorkDetail = {
   ...workSummaryFixture,
   description: "Stored catalog description.",
+  firstPublication: { date: "1965-06", precision: "month" },
   categories: [
     {
       id: "70000000-0000-4000-8000-000000000001",
@@ -113,6 +114,11 @@ export const workDetailFixture: WorkDetail = {
   provenance: [
     provenanceFixture("work", workSummaryFixture.id, "work.preferred_title"),
     provenanceFixture("work", workSummaryFixture.id, "work.description"),
+    provenanceFixture(
+      "work",
+      workSummaryFixture.id,
+      "work.first_publication_date",
+    ),
     provenanceFixture("work", workSummaryFixture.id, "work.authors"),
     provenanceFixture("work", workSummaryFixture.id, "work.categories"),
     provenanceFixture("work", workSummaryFixture.id, "work.preferred_edition", {
@@ -168,6 +174,7 @@ export const partialWorkDetailFixture: WorkDetail = {
     ...(
       [
         "work.description",
+        "work.first_publication_date",
         "work.authors",
         "work.categories",
         "work.preferred_edition",


### PR DESCRIPTION
## Summary

- Add a nullable, provenance-resolved work first-publication fact with exact year, month, or day precision while preserving independent edition publication dates.
- Expose only eligible work dates through detail/API/page projections and map work and edition dates to separate Schema.org locations.

## Linked Issue

- Closes #132
- Labels aligned with linked issue: `enhancement`, `backend`, `database`, `seo`, `data-curation`, `area: catalog`

## Changes

- Add SQLite/Postgres work columns, constraints, migrations, snapshots, and the `work.first_publication_date` field vocabulary.
- Add deterministic per-work resolution and transactional projection for compatible, conflicting, missing, stale, invalid, suspended, withdrawn, proposed-only, and curated evidence.
- Keep migrations and the legacy importer from deriving a work date from any edition date.
- Extend `WorkDetail`, the public detail API, page presentation, and JSON-LD while keeping `WorkSummary`, catalog period filters, and publication sorting edition-based.
- Add migration, schema parity, resolver, repository, page, API, structured-data, SQLite/Postgres, withdrawal, idempotency, conflict, stale, and rollback coverage.

## Validation

- [x] `bun run lint`
- [x] `bun run test` — 231 passed, 3 environment-gated Postgres tests skipped locally
- [x] `bun run test:playwright` — 28 passed
- [x] `bun run test:storybook -- --run` — 39 passed
- [x] `bun run build:ci`
- [x] `bunx tsc --noEmit`
- [x] `bun run db:generate` and `bun run db:generate:pg` — no schema changes after committed snapshots
- [x] `git diff --check`
- [x] disposable SQLite rebuild twice with identical snapshot hash, 500 works, 500 editions, 0 inferred work dates, 100 retained edition dates, and 0 foreign-key violations

The isolated PostgreSQL 16 CI job now runs both the enrichment persistence test and the new first-publication migration/resolution parity and rollback test.

## UX Notes

- [ ] no visual changes
- [ ] responsive behavior verified at affected breakpoints
- [x] accessibility impact reviewed

Notes:

- Eligible work context is labeled `First published`; selected-edition context remains labeled `Published`.
- Missing, conflicting, or ineligible work dates render no placeholder or fallback.
- A manual browser comparison was not needed because the change is a small conditional text fact covered by component, page, Storybook, build, and Playwright tests.

## Architecture Notes

- [ ] no architectural impact
- [x] follows existing architecture and framework defaults
- [x] introduces or updates a documented decision in `docs/decisions`

ADR / decision links:

- `docs/decisions/0016-catalog-metadata-provenance.md`
- `docs/database-architecture.md`

## Data / API / Infra Impact

- [ ] no data, API, or infra impact
- [x] database schema changed
- [ ] seed/import/catalog data changed
- [x] API contract changed
- [ ] environment variables changed
- [x] CI/CD or deployment behavior changed

Operational notes:

- Existing works migrate to null work-date columns; no edition data is copied.
- Promotion remains explicit and per-work. The #131 diagnostic workflow stays proposed-only and cannot advance public heads.
- Existing catalog period filters and publication ordering continue to use preferred-edition `publication_sort_date`.

## Risks

- [ ] low risk
- [x] medium risk
- [ ] high risk

Main risks and mitigations:

- risk: SQLite table rebuilds are needed to extend the constrained provenance vocabulary.
- mitigation: the migration rebuilds parent/child ledger tables in dependency order and is covered by a populated pre-#132 upgrade plus foreign-key checks.
- risk: a resolution failure could desynchronize the immutable head and work projection.
- mitigation: SQLite and Postgres update history, head, and projection in one transaction with forced-failure rollback tests.

## Checklist

- [x] scope matches the linked issue
- [x] PR labels match the linked issue labels where applicable
- [x] touched code is cleaner than before
- [x] tests cover the changed behavior
- [x] docs were updated where needed
- [x] local-only/generated artifacts are excluded from git
