### PR TITLE
feat(catalog): add evidence-gated description enrichment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,7 @@ jobs:
         run: >-
           bun run test --
           src/db/catalog/enrichment/persistence.pg.test.ts
+          src/db/catalog/enrichment/descriptions/repository.pg.test.ts
           src/db/catalog/work-first-publication.pg.test.ts
           --no-file-parallelism
         env:

--- a/docs/catalog-enrichment.md
+++ b/docs/catalog-enrichment.md
@@ -178,3 +178,59 @@ SQLite/Postgres persistence adapters serialize the recorded fixture to
 equivalent logical rows. Live Postgres rebuild coverage remains gated by the
 existing explicitly isolated `CATALOG_TEST_POSTGRES_URL`; no application or
 preview database is used by this workflow.
+
+## Evidence-gated descriptions
+
+Issue #133 implements the three description classes approved by the research:
+
+| Class | Required immutable provenance | Eligibility path |
+|---|---|---|
+| `licensed_verbatim` | exact source revision, license URL/name, attribution decision, derivative permission, source policy version | automated gates may pass exact licensed text; any warning requires review |
+| `bukie_editorial` | approved parent observations, editor, editorial reason and revision | independent reviewer approval is required |
+| `model_assisted_candidate` | every parent and claim mapping, provider-neutral model/version, prompt version, input hash, generation time/duration, tokens, cost, and policy version | every initial candidate requires human approval |
+
+No model provider is selected or called. Tests and the diagnostic command use
+deterministic recorded fixtures under the same provider-neutral contract.
+Wikidata structured facts may be parent evidence only when their source/link
+and field policy are currently eligible; they are never treated as prose.
+Wikipedia, publisher, retailer, competitor, and search-result prose remain
+disabled by the source-policy matrix above.
+
+Automated gates use stable reason codes for parent support, identity,
+unresolved evidence conflicts, length, readability, specificity, neutral tone,
+spoilers, copying similarity, licensing, source revision, and source policy.
+An exact eight-word source match is only
+`copying_exact_eight_word_match`, a review warning. It is not a legal
+determination and cannot approve or reject text on its own. A distinct high
+similarity rule can reject a candidate as `copying_similarity_high`.
+Ambiguous and sensitive cases also enter human review. The advisory quality
+score is stored and reported but is never read by an eligibility decision.
+
+The review queue has a transactionally enforced capacity and one operational
+row per candidate. SQLite uses an immediate transaction; Postgres combines a
+row lock with an advisory transaction lock around the active-count check.
+Retries deduplicate deterministically. At capacity, a candidate becomes
+`paused` and no queue row or eligibility is created. It can be queued only
+after capacity becomes available.
+
+Description decision and internal projection histories are immutable linked
+events. Human decisions, withdrawal, source-policy revocation, policy/model/
+prompt invalidation, re-review, selection, and rollback advance their heads in
+one transaction. Read-time checks still apply current source, record, identity
+link, parent evidence, conflict, model, prompt, and policy state. These
+description heads are diagnostic only: they do not update `works.description`
+or public field-resolution heads.
+
+Run the reproducible five-work SQLite proof only against an explicitly
+disposable target:
+
+```powershell
+bun run db:catalog:description-sample --target=sqlite:.data/catalog-targets/issue-133-description-test.sqlite --confirm-disposable
+```
+
+The recorded proof creates five model candidates, exercises approved, rejected,
+withdrawn, and queued states, retries every candidate, and reports exact
+coverage, queue, token, cost, and linearly scaled 500-work estimates. It also
+hashes public resolution heads and work description values before and after
+the run and refuses to finish if either changes. Rebuilding and rerunning the
+same manifest produces the same candidate IDs, snapshot hash, and metrics.

--- a/docs/catalog-enrichment.md
+++ b/docs/catalog-enrichment.md
@@ -199,6 +199,11 @@ disabled by the source-policy matrix above.
 Automated gates use stable reason codes for parent support, identity,
 unresolved evidence conflicts, length, readability, specificity, neutral tone,
 spoilers, copying similarity, licensing, source revision, and source policy.
+For editorial and model-assisted text, every normalized candidate sentence must
+have an exact claim row with at least one parent observation; omitted or
+out-of-text claims reject with stable coverage codes. Human review judges
+whether those explicit mappings support the prose, while the deterministic
+gate prevents unmapped prose from reaching approval.
 An exact eight-word source match is only
 `copying_exact_eight_word_match`, a review warning. It is not a legal
 determination and cannot approve or reject text on its own. A distinct high
@@ -216,10 +221,17 @@ after capacity becomes available.
 Description decision and internal projection histories are immutable linked
 events. Human decisions, withdrawal, source-policy revocation, policy/model/
 prompt invalidation, re-review, selection, and rollback advance their heads in
-one transaction. Read-time checks still apply current source, record, identity
+one transaction in both SQLite and Postgres. Hard automated rejections cannot
+enter re-review. Approval and rollback reapply current source, record, identity
 link, parent evidence, conflict, model, prompt, and policy state. These
 description heads are diagnostic only: they do not update `works.description`
-or public field-resolution heads.
+or public field-resolution heads, and catalog reads fail closed for every
+description-candidate observation until the separate promotion approval.
+
+Licensed candidates retain a hash of the exact recorded source text and an
+explicit transformed flag. A changed text is accepted only when both the
+license record and current source policy permit derivatives; otherwise it
+receives `licensed_derivative_not_permitted`.
 
 Run the reproducible five-work SQLite proof only against an explicitly
 disposable target:

--- a/docs/database-architecture.md
+++ b/docs/database-architecture.md
@@ -5,7 +5,7 @@ by [ADR 0016](./decisions/0016-catalog-metadata-provenance.md).
 
 - SQLite is the local-development provider.
 - Postgres is the preview and production provider.
-- `src/db/catalog/schema.ts` and `schema.pg.ts` define the same 21 logical
+- `src/db/catalog/schema.ts` and `schema.pg.ts` define the same 29 logical
   tables and constraints.
 - `src/db/catalog/repository.ts` implements provider-neutral work-first reads.
 - `src/features/books/types.ts` defines the public `WorkSummary`,
@@ -96,6 +96,23 @@ All other enrichment continues through source records, immutable observations,
 resolution heads, and the existing display-eligibility checks. Dry runs write
 to an isolated disposable target and cannot update current heads, projections,
 or cover pointers.
+
+Issue #133 adds a description-specific evidence and review layer without
+changing that public boundary. Immutable description candidates identify one
+of `licensed_verbatim`, `bukie_editorial`, or `model_assisted_candidate` and
+retain the class-specific rights, revision, editor, model, prompt, token, cost,
+and policy metadata. Relational claim rows map every asserted generated fact to
+eligible parent observations. Immutable decision history, a bounded
+deduplicated queue, and internal projection history support review,
+withdrawal, invalidation, re-review, rollback, and dry-run metrics.
+
+The description projection tables are internal dry-run selections. They are
+not `field_resolution_heads`, are not read by the catalog repository, and
+never update `works.description`. A selected internal candidate therefore
+remains non-public while its source policy is `proposedEvidenceOnly`. The
+internal proposal reader also reapplies source, link, observation, parent,
+policy, model, and prompt eligibility at read time so a revocation fails closed
+before reconciliation runs.
 
 The issue #131
 [policy-gated adapter foundation](./catalog-enrichment.md) implements that

--- a/docs/decisions/0016-catalog-metadata-provenance.md
+++ b/docs/decisions/0016-catalog-metadata-provenance.md
@@ -285,9 +285,10 @@ text requires additional immutable provenance and review state before it can
 be considered for a resolution.
 
 - Licensed verbatim text retains its license, attribution decision, source
-  revision, policy version, and derivative permission. It is not summarized,
-  translated, or otherwise transformed unless both the rights record and
-  source policy explicitly permit derivatives.
+  revision, source-text hash, transformed flag, policy version, and derivative
+  permission. It is not summarized, translated, or otherwise transformed
+  unless both the rights record and source policy explicitly permit
+  derivatives.
 - Bukie editorial text retains every approved parent observation, its editor,
   an independent reviewer before eligibility, reason, and editorial revision.
 - A model-assisted candidate retains every claim-to-parent mapping, a
@@ -300,6 +301,9 @@ unresolved conflicts, length, readability, specificity, tone, spoilers,
 copying similarity, ambiguity, and sensitivity. Exact eight-word overlap is a
 review warning, not a legal conclusion or an automatic eligibility decision.
 Quality scores are advisory and never select a candidate.
+Every editorial or model-assisted candidate sentence has an exact claim row
+and eligible parent mapping. Re-review preserves hard rejection codes and is
+unavailable to rejected or withdrawn candidates.
 
 Description candidates, claims, claim evidence, decisions, decision heads,
 review queue rows, internal projection events, and projection heads are
@@ -313,7 +317,8 @@ does not advance `field_resolution_heads` or update `works.description`.
 `proposedEvidenceOnly`, field text permission, source approval, active identity
 links, observation/source lifecycle, current parent eligibility, and current
 policy/model/prompt versions are reapplied at read time. Public promotion
-remains subject to the separate dry-run approval.
+remains subject to the separate dry-run approval, so existing catalog reads
+exclude all description-candidate observations even after internal approval.
 
 ### Field resolution
 

--- a/docs/decisions/0016-catalog-metadata-provenance.md
+++ b/docs/decisions/0016-catalog-metadata-provenance.md
@@ -277,6 +277,44 @@ claim correctly. It is not a probability that the underlying fact is true.
 Synthetic observations must always carry `synthetic` provenance and may never
 win resolution for bibliographic facts outside explicit development fixtures.
 
+#### 2026-07-29 amendment: description evidence and review
+
+Descriptions have one explicit class: licensed verbatim, Bukie editorial, or
+model-assisted candidate. Each is still a `work.description` observation, but
+text requires additional immutable provenance and review state before it can
+be considered for a resolution.
+
+- Licensed verbatim text retains its license, attribution decision, source
+  revision, policy version, and derivative permission. It is not summarized,
+  translated, or otherwise transformed unless both the rights record and
+  source policy explicitly permit derivatives.
+- Bukie editorial text retains every approved parent observation, its editor,
+  an independent reviewer before eligibility, reason, and editorial revision.
+- A model-assisted candidate retains every claim-to-parent mapping, a
+  provider-neutral model identifier and version, prompt version, generation
+  input hash and time, token/cost telemetry, and policy version. It remains a
+  candidate until deterministic gates and required human review pass.
+
+The deterministic gates cover parent eligibility, claim support, identity,
+unresolved conflicts, length, readability, specificity, tone, spoilers,
+copying similarity, ambiguity, and sensitivity. Exact eight-word overlap is a
+review warning, not a legal conclusion or an automatic eligibility decision.
+Quality scores are advisory and never select a candidate.
+
+Description candidates, claims, claim evidence, decisions, decision heads,
+review queue rows, internal projection events, and projection heads are
+separate normalized tables with SQLite/Postgres parity. The queue is bounded
+and deduplicated; overflow pauses or omits work. Decisions and internal
+projections advance transactionally and retain withdrawal, invalidation,
+re-review, and rollback history.
+
+This internal projection is for the diagnostic proof and planned dry run. It
+does not advance `field_resolution_heads` or update `works.description`.
+`proposedEvidenceOnly`, field text permission, source approval, active identity
+links, observation/source lifecycle, current parent eligibility, and current
+policy/model/prompt versions are reapplied at read time. Public promotion
+remains subject to the separate dry-run approval.
+
 ### Field resolution
 
 A resolution is an immutable event storing the selected observation for a

--- a/drizzle/0006_legal_trish_tilby.sql
+++ b/drizzle/0006_legal_trish_tilby.sql
@@ -1,0 +1,190 @@
+CREATE TABLE `description_candidates` (
+	`id` text PRIMARY KEY NOT NULL,
+	`work_id` text NOT NULL,
+	`observation_id` text NOT NULL,
+	`description_class` text NOT NULL,
+	`text_content` text NOT NULL,
+	`text_hash` text NOT NULL,
+	`source_revision` text NOT NULL,
+	`source_policy_version` text NOT NULL,
+	`description_policy_version` text NOT NULL,
+	`license_name` text,
+	`license_url` text,
+	`attribution_text` text,
+	`derivatives_permitted` integer,
+	`editor_ref` text,
+	`editorial_reason` text,
+	`editorial_revision` text,
+	`model_id` text,
+	`model_version` text,
+	`prompt_version` text,
+	`generation_input_hash` text,
+	`generated_at` integer,
+	`generation_duration_ms` integer,
+	`input_tokens` integer,
+	`output_tokens` integer,
+	`cost_microusd` integer,
+	`quality_score` real,
+	`ambiguous_identity` integer DEFAULT false NOT NULL,
+	`sensitive_content` integer DEFAULT false NOT NULL,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`work_id`) REFERENCES `works`(`id`) ON UPDATE no action ON DELETE restrict,
+	FOREIGN KEY (`observation_id`) REFERENCES `field_observations`(`id`) ON UPDATE no action ON DELETE restrict,
+	CONSTRAINT "description_candidates_class_ck" CHECK("description_candidates"."description_class" in ('licensed_verbatim', 'bukie_editorial', 'model_assisted_candidate')),
+	CONSTRAINT "description_candidates_text_ck" CHECK(length(trim("description_candidates"."text_content")) > 0 and length("description_candidates"."text_hash") = 64),
+	CONSTRAINT "description_candidates_versions_ck" CHECK(length(trim("description_candidates"."source_revision")) > 0
+        and length(trim("description_candidates"."source_policy_version")) > 0
+        and length(trim("description_candidates"."description_policy_version")) > 0),
+	CONSTRAINT "description_candidates_license_ck" CHECK((
+        "description_candidates"."description_class" = 'licensed_verbatim'
+        and length(trim("description_candidates"."license_name")) > 0
+        and length(trim("description_candidates"."license_url")) > 0
+        and "description_candidates"."derivatives_permitted" is not null
+      ) or (
+        "description_candidates"."description_class" <> 'licensed_verbatim'
+        and "description_candidates"."license_name" is null
+        and "description_candidates"."license_url" is null
+        and "description_candidates"."attribution_text" is null
+        and "description_candidates"."derivatives_permitted" is null
+      )),
+	CONSTRAINT "description_candidates_editorial_ck" CHECK((
+        "description_candidates"."description_class" = 'bukie_editorial'
+        and length(trim("description_candidates"."editor_ref")) > 0
+        and length(trim("description_candidates"."editorial_reason")) > 0
+        and length(trim("description_candidates"."editorial_revision")) > 0
+      ) or (
+        "description_candidates"."description_class" <> 'bukie_editorial'
+        and "description_candidates"."editor_ref" is null
+        and "description_candidates"."editorial_reason" is null
+        and "description_candidates"."editorial_revision" is null
+      )),
+	CONSTRAINT "description_candidates_model_ck" CHECK((
+        "description_candidates"."description_class" = 'model_assisted_candidate'
+        and length(trim("description_candidates"."model_id")) > 0
+        and length(trim("description_candidates"."model_version")) > 0
+        and length(trim("description_candidates"."prompt_version")) > 0
+        and length("description_candidates"."generation_input_hash") = 64
+        and "description_candidates"."generated_at" is not null
+        and "description_candidates"."generation_duration_ms" >= 0
+        and "description_candidates"."input_tokens" >= 0
+        and "description_candidates"."output_tokens" >= 0
+        and "description_candidates"."cost_microusd" >= 0
+      ) or (
+        "description_candidates"."description_class" <> 'model_assisted_candidate'
+        and "description_candidates"."model_id" is null
+        and "description_candidates"."model_version" is null
+        and "description_candidates"."prompt_version" is null
+        and "description_candidates"."generation_input_hash" is null
+        and "description_candidates"."generated_at" is null
+        and "description_candidates"."generation_duration_ms" is null
+        and "description_candidates"."input_tokens" is null
+        and "description_candidates"."output_tokens" is null
+        and "description_candidates"."cost_microusd" is null
+      )),
+	CONSTRAINT "description_candidates_quality_ck" CHECK("description_candidates"."quality_score" is null or "description_candidates"."quality_score" between 0 and 100)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `description_candidates_observation_uq` ON `description_candidates` (`observation_id`);--> statement-breakpoint
+CREATE INDEX `description_candidates_work_created_idx` ON `description_candidates` (`work_id`,`created_at`);--> statement-breakpoint
+CREATE TABLE `description_claim_evidence` (
+	`claim_id` text NOT NULL,
+	`observation_id` text NOT NULL,
+	PRIMARY KEY(`claim_id`, `observation_id`),
+	FOREIGN KEY (`claim_id`) REFERENCES `description_claims`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`observation_id`) REFERENCES `field_observations`(`id`) ON UPDATE no action ON DELETE restrict
+);
+--> statement-breakpoint
+CREATE INDEX `description_claim_evidence_observation_idx` ON `description_claim_evidence` (`observation_id`);--> statement-breakpoint
+CREATE TABLE `description_claims` (
+	`id` text PRIMARY KEY NOT NULL,
+	`candidate_id` text NOT NULL,
+	`position` integer NOT NULL,
+	`claim_text` text NOT NULL,
+	`claim_hash` text NOT NULL,
+	FOREIGN KEY (`candidate_id`) REFERENCES `description_candidates`(`id`) ON UPDATE no action ON DELETE cascade,
+	CONSTRAINT "description_claims_content_ck" CHECK("description_claims"."position" >= 0
+        and length(trim("description_claims"."claim_text")) > 0
+        and length("description_claims"."claim_hash") = 64)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `description_claims_position_uq` ON `description_claims` (`candidate_id`,`position`);--> statement-breakpoint
+CREATE INDEX `description_claims_candidate_idx` ON `description_claims` (`candidate_id`);--> statement-breakpoint
+CREATE TABLE `description_decision_heads` (
+	`candidate_id` text PRIMARY KEY NOT NULL,
+	`decision_id` text NOT NULL,
+	FOREIGN KEY (`candidate_id`) REFERENCES `description_candidates`(`id`) ON UPDATE no action ON DELETE restrict,
+	FOREIGN KEY (`decision_id`) REFERENCES `description_decisions`(`id`) ON UPDATE no action ON DELETE restrict
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `description_decision_heads_decision_uq` ON `description_decision_heads` (`decision_id`);--> statement-breakpoint
+CREATE TABLE `description_decisions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`candidate_id` text NOT NULL,
+	`state` text NOT NULL,
+	`rejection_codes_json` text NOT NULL,
+	`warning_codes_json` text NOT NULL,
+	`reviewer_ref` text,
+	`review_reason` text,
+	`previous_decision_id` text,
+	`policy_version` text NOT NULL,
+	`decided_at` integer NOT NULL,
+	FOREIGN KEY (`candidate_id`) REFERENCES `description_candidates`(`id`) ON UPDATE no action ON DELETE restrict,
+	FOREIGN KEY (`previous_decision_id`) REFERENCES `description_decisions`(`id`) ON UPDATE no action ON DELETE restrict,
+	CONSTRAINT "description_decisions_state_ck" CHECK("description_decisions"."state" in ('candidate', 'review_required', 'paused', 'rejected', 'eligible', 'withdrawn', 'invalidated')),
+	CONSTRAINT "description_decisions_json_ck" CHECK(json_valid("description_decisions"."rejection_codes_json")
+        and json_valid("description_decisions"."warning_codes_json")),
+	CONSTRAINT "description_decisions_review_ck" CHECK(("description_decisions"."reviewer_ref" is null and "description_decisions"."review_reason" is null)
+        or (
+          length(trim("description_decisions"."reviewer_ref")) > 0
+          and length(trim("description_decisions"."review_reason")) > 0
+        )),
+	CONSTRAINT "description_decisions_policy_ck" CHECK(length(trim("description_decisions"."policy_version")) > 0)
+);
+--> statement-breakpoint
+CREATE INDEX `description_decisions_candidate_history_idx` ON `description_decisions` (`candidate_id`,`decided_at`);--> statement-breakpoint
+CREATE TABLE `description_projection_heads` (
+	`work_id` text PRIMARY KEY NOT NULL,
+	`projection_id` text NOT NULL,
+	FOREIGN KEY (`work_id`) REFERENCES `works`(`id`) ON UPDATE no action ON DELETE restrict,
+	FOREIGN KEY (`projection_id`) REFERENCES `description_projections`(`id`) ON UPDATE no action ON DELETE restrict
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `description_projection_heads_projection_uq` ON `description_projection_heads` (`projection_id`);--> statement-breakpoint
+CREATE TABLE `description_projections` (
+	`id` text PRIMARY KEY NOT NULL,
+	`work_id` text NOT NULL,
+	`candidate_id` text,
+	`state` text NOT NULL,
+	`previous_projection_id` text,
+	`reason_code` text NOT NULL,
+	`actor_ref` text NOT NULL,
+	`policy_version` text NOT NULL,
+	`projected_at` integer NOT NULL,
+	FOREIGN KEY (`work_id`) REFERENCES `works`(`id`) ON UPDATE no action ON DELETE restrict,
+	FOREIGN KEY (`candidate_id`) REFERENCES `description_candidates`(`id`) ON UPDATE no action ON DELETE restrict,
+	FOREIGN KEY (`previous_projection_id`) REFERENCES `description_projections`(`id`) ON UPDATE no action ON DELETE restrict,
+	CONSTRAINT "description_projections_state_ck" CHECK("description_projections"."state" in ('selected', 'withdrawn', 'invalidated', 'rolled_back')),
+	CONSTRAINT "description_projections_selection_ck" CHECK(("description_projections"."state" in ('selected', 'rolled_back') and "description_projections"."candidate_id" is not null)
+        or ("description_projections"."state" in ('withdrawn', 'invalidated') and "description_projections"."candidate_id" is null)),
+	CONSTRAINT "description_projections_nonempty_ck" CHECK(length(trim("description_projections"."reason_code")) > 0
+        and length(trim("description_projections"."actor_ref")) > 0
+        and length(trim("description_projections"."policy_version")) > 0)
+);
+--> statement-breakpoint
+CREATE INDEX `description_projections_work_history_idx` ON `description_projections` (`work_id`,`projected_at`);--> statement-breakpoint
+CREATE TABLE `description_review_queue` (
+	`candidate_id` text PRIMARY KEY NOT NULL,
+	`state` text NOT NULL,
+	`priority` integer NOT NULL,
+	`reason_codes_json` text NOT NULL,
+	`queued_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	`reviewer_ref` text,
+	FOREIGN KEY (`candidate_id`) REFERENCES `description_candidates`(`id`) ON UPDATE no action ON DELETE restrict,
+	CONSTRAINT "description_review_queue_state_ck" CHECK("description_review_queue"."state" in ('queued', 'claimed', 'completed', 'cancelled')),
+	CONSTRAINT "description_review_queue_values_ck" CHECK("description_review_queue"."priority" >= 0
+        and json_valid("description_review_queue"."reason_codes_json")
+        and ("description_review_queue"."reviewer_ref" is null or length(trim("description_review_queue"."reviewer_ref")) > 0))
+);
+--> statement-breakpoint
+CREATE INDEX `description_review_queue_active_idx` ON `description_review_queue` (`state`,`priority`,`queued_at`);

--- a/drizzle/0007_milky_omega_red.sql
+++ b/drizzle/0007_milky_omega_red.sql
@@ -1,0 +1,99 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_description_candidates` (
+	`id` text PRIMARY KEY NOT NULL,
+	`work_id` text NOT NULL,
+	`observation_id` text NOT NULL,
+	`description_class` text NOT NULL,
+	`text_content` text NOT NULL,
+	`text_hash` text NOT NULL,
+	`source_revision` text NOT NULL,
+	`source_policy_version` text NOT NULL,
+	`description_policy_version` text NOT NULL,
+	`license_name` text,
+	`license_url` text,
+	`attribution_text` text,
+	`derivatives_permitted` integer,
+	`licensed_source_text_hash` text,
+	`licensed_text_transformed` integer,
+	`editor_ref` text,
+	`editorial_reason` text,
+	`editorial_revision` text,
+	`model_id` text,
+	`model_version` text,
+	`prompt_version` text,
+	`generation_input_hash` text,
+	`generated_at` integer,
+	`generation_duration_ms` integer,
+	`input_tokens` integer,
+	`output_tokens` integer,
+	`cost_microusd` integer,
+	`quality_score` real,
+	`ambiguous_identity` integer DEFAULT false NOT NULL,
+	`sensitive_content` integer DEFAULT false NOT NULL,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`work_id`) REFERENCES `works`(`id`) ON UPDATE no action ON DELETE restrict,
+	FOREIGN KEY (`observation_id`) REFERENCES `field_observations`(`id`) ON UPDATE no action ON DELETE restrict,
+	CONSTRAINT "description_candidates_class_ck" CHECK("__new_description_candidates"."description_class" in ('licensed_verbatim', 'bukie_editorial', 'model_assisted_candidate')),
+	CONSTRAINT "description_candidates_text_ck" CHECK(length(trim("__new_description_candidates"."text_content")) > 0 and length("__new_description_candidates"."text_hash") = 64),
+	CONSTRAINT "description_candidates_versions_ck" CHECK(length(trim("__new_description_candidates"."source_revision")) > 0
+        and length(trim("__new_description_candidates"."source_policy_version")) > 0
+        and length(trim("__new_description_candidates"."description_policy_version")) > 0),
+	CONSTRAINT "description_candidates_license_ck" CHECK((
+        "__new_description_candidates"."description_class" = 'licensed_verbatim'
+        and length(trim("__new_description_candidates"."license_name")) > 0
+        and length(trim("__new_description_candidates"."license_url")) > 0
+        and "__new_description_candidates"."derivatives_permitted" is not null
+        and length("__new_description_candidates"."licensed_source_text_hash") = 64
+        and "__new_description_candidates"."licensed_text_transformed" is not null
+      ) or (
+        "__new_description_candidates"."description_class" <> 'licensed_verbatim'
+        and "__new_description_candidates"."license_name" is null
+        and "__new_description_candidates"."license_url" is null
+        and "__new_description_candidates"."attribution_text" is null
+        and "__new_description_candidates"."derivatives_permitted" is null
+        and "__new_description_candidates"."licensed_source_text_hash" is null
+        and "__new_description_candidates"."licensed_text_transformed" is null
+      )),
+	CONSTRAINT "description_candidates_editorial_ck" CHECK((
+        "__new_description_candidates"."description_class" = 'bukie_editorial'
+        and length(trim("__new_description_candidates"."editor_ref")) > 0
+        and length(trim("__new_description_candidates"."editorial_reason")) > 0
+        and length(trim("__new_description_candidates"."editorial_revision")) > 0
+      ) or (
+        "__new_description_candidates"."description_class" <> 'bukie_editorial'
+        and "__new_description_candidates"."editor_ref" is null
+        and "__new_description_candidates"."editorial_reason" is null
+        and "__new_description_candidates"."editorial_revision" is null
+      )),
+	CONSTRAINT "description_candidates_model_ck" CHECK((
+        "__new_description_candidates"."description_class" = 'model_assisted_candidate'
+        and length(trim("__new_description_candidates"."model_id")) > 0
+        and length(trim("__new_description_candidates"."model_version")) > 0
+        and length(trim("__new_description_candidates"."prompt_version")) > 0
+        and length("__new_description_candidates"."generation_input_hash") = 64
+        and "__new_description_candidates"."generated_at" is not null
+        and "__new_description_candidates"."generation_duration_ms" >= 0
+        and "__new_description_candidates"."input_tokens" >= 0
+        and "__new_description_candidates"."output_tokens" >= 0
+        and "__new_description_candidates"."cost_microusd" >= 0
+      ) or (
+        "__new_description_candidates"."description_class" <> 'model_assisted_candidate'
+        and "__new_description_candidates"."model_id" is null
+        and "__new_description_candidates"."model_version" is null
+        and "__new_description_candidates"."prompt_version" is null
+        and "__new_description_candidates"."generation_input_hash" is null
+        and "__new_description_candidates"."generated_at" is null
+        and "__new_description_candidates"."generation_duration_ms" is null
+        and "__new_description_candidates"."input_tokens" is null
+        and "__new_description_candidates"."output_tokens" is null
+        and "__new_description_candidates"."cost_microusd" is null
+      )),
+	CONSTRAINT "description_candidates_quality_ck" CHECK("__new_description_candidates"."quality_score" is null or "__new_description_candidates"."quality_score" between 0 and 100)
+);
+--> statement-breakpoint
+INSERT INTO `__new_description_candidates`("id", "work_id", "observation_id", "description_class", "text_content", "text_hash", "source_revision", "source_policy_version", "description_policy_version", "license_name", "license_url", "attribution_text", "derivatives_permitted", "licensed_source_text_hash", "licensed_text_transformed", "editor_ref", "editorial_reason", "editorial_revision", "model_id", "model_version", "prompt_version", "generation_input_hash", "generated_at", "generation_duration_ms", "input_tokens", "output_tokens", "cost_microusd", "quality_score", "ambiguous_identity", "sensitive_content", "created_at") SELECT "id", "work_id", "observation_id", "description_class", "text_content", "text_hash", "source_revision", "source_policy_version", "description_policy_version", "license_name", "license_url", "attribution_text", "derivatives_permitted", case when "description_class" = 'licensed_verbatim' then "text_hash" else null end, case when "description_class" = 'licensed_verbatim' then 0 else null end, "editor_ref", "editorial_reason", "editorial_revision", "model_id", "model_version", "prompt_version", "generation_input_hash", "generated_at", "generation_duration_ms", "input_tokens", "output_tokens", "cost_microusd", "quality_score", "ambiguous_identity", "sensitive_content", "created_at" FROM `description_candidates`;--> statement-breakpoint
+DROP TABLE `description_candidates`;--> statement-breakpoint
+ALTER TABLE `__new_description_candidates` RENAME TO `description_candidates`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE UNIQUE INDEX `description_candidates_observation_uq` ON `description_candidates` (`observation_id`);--> statement-breakpoint
+CREATE INDEX `description_candidates_work_created_idx` ON `description_candidates` (`work_id`,`created_at`);

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,3066 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "82e3a4bf-40f2-4028-b21d-036e8df800f6",
+  "prevId": "531095e7-2607-47f1-9c41-88dcc646840a",
+  "tables": {
+    "authors": {
+      "name": "authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_name": {
+          "name": "sort_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authors_sort_name_idx": {
+          "name": "authors_sort_name_idx",
+          "columns": [
+            "sort_name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "authors_name_nonempty_ck": {
+          "name": "authors_name_nonempty_ck",
+          "value": "length(trim(\"authors\".\"display_name\")) > 0"
+        },
+        "authors_sort_name_ck": {
+          "name": "authors_sort_name_ck",
+          "value": "\"authors\".\"sort_name\" is null or length(trim(\"authors\".\"sort_name\")) > 0"
+        }
+      }
+    },
+    "catalog_change_events": {
+      "name": "catalog_change_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "catalog_change_events_type_created_idx": {
+          "name": "catalog_change_events_type_created_idx",
+          "columns": [
+            "change_type",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "catalog_change_events_type_ck": {
+          "name": "catalog_change_events_type_ck",
+          "value": "\"catalog_change_events\".\"change_type\" in ('work_merge', 'work_split', 'edition_reassignment')"
+        },
+        "catalog_change_events_json_ck": {
+          "name": "catalog_change_events_json_ck",
+          "value": "json_valid(\"catalog_change_events\".\"payload_json\")"
+        },
+        "catalog_change_events_nonempty_ck": {
+          "name": "catalog_change_events_nonempty_ck",
+          "value": "length(trim(\"catalog_change_events\".\"actor_ref\")) > 0 and length(trim(\"catalog_change_events\".\"reason\")) > 0"
+        }
+      }
+    },
+    "categories": {
+      "name": "categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "categories_slug_uq": {
+          "name": "categories_slug_uq",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "categories_nonempty_ck": {
+          "name": "categories_nonempty_ck",
+          "value": "length(trim(\"categories\".\"slug\")) > 0 and length(trim(\"categories\".\"label\")) > 0"
+        },
+        "categories_status_ck": {
+          "name": "categories_status_ck",
+          "value": "\"categories\".\"status\" in ('active', 'retired')"
+        }
+      }
+    },
+    "cover_assets": {
+      "name": "cover_assets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_policy_id": {
+          "name": "source_policy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cover_assets_object_key_uq": {
+          "name": "cover_assets_object_key_uq",
+          "columns": [
+            "object_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "cover_assets_source_policy_id_metadata_sources_id_fk": {
+          "name": "cover_assets_source_policy_id_metadata_sources_id_fk",
+          "tableFrom": "cover_assets",
+          "tableTo": "metadata_sources",
+          "columnsFrom": [
+            "source_policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "cover_assets_object_key_ck": {
+          "name": "cover_assets_object_key_ck",
+          "value": "length(trim(\"cover_assets\".\"object_key\")) > 0 and substr(\"cover_assets\".\"object_key\", 1, 8) = '/covers/'"
+        },
+        "cover_assets_state_ck": {
+          "name": "cover_assets_state_ck",
+          "value": "\"cover_assets\".\"state\" in ('available', 'missing', 'withdrawn', 'failed')"
+        },
+        "cover_assets_dimensions_ck": {
+          "name": "cover_assets_dimensions_ck",
+          "value": "(\"cover_assets\".\"width\" is null or \"cover_assets\".\"width\" > 0)\n        and (\"cover_assets\".\"height\" is null or \"cover_assets\".\"height\" > 0)\n        and (\"cover_assets\".\"bytes\" is null or \"cover_assets\".\"bytes\" > 0)"
+        }
+      }
+    },
+    "description_candidates": {
+      "name": "description_candidates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "observation_id": {
+          "name": "observation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description_class": {
+          "name": "description_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_hash": {
+          "name": "text_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_policy_version": {
+          "name": "source_policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description_policy_version": {
+          "name": "description_policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "license_name": {
+          "name": "license_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "license_url": {
+          "name": "license_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attribution_text": {
+          "name": "attribution_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "derivatives_permitted": {
+          "name": "derivatives_permitted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_ref": {
+          "name": "editor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editorial_reason": {
+          "name": "editorial_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editorial_revision": {
+          "name": "editorial_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generation_input_hash": {
+          "name": "generation_input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generation_duration_ms": {
+          "name": "generation_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_microusd": {
+          "name": "cost_microusd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ambiguous_identity": {
+          "name": "ambiguous_identity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sensitive_content": {
+          "name": "sensitive_content",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "description_candidates_observation_uq": {
+          "name": "description_candidates_observation_uq",
+          "columns": [
+            "observation_id"
+          ],
+          "isUnique": true
+        },
+        "description_candidates_work_created_idx": {
+          "name": "description_candidates_work_created_idx",
+          "columns": [
+            "work_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "description_candidates_work_id_works_id_fk": {
+          "name": "description_candidates_work_id_works_id_fk",
+          "tableFrom": "description_candidates",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_candidates_observation_id_field_observations_id_fk": {
+          "name": "description_candidates_observation_id_field_observations_id_fk",
+          "tableFrom": "description_candidates",
+          "tableTo": "field_observations",
+          "columnsFrom": [
+            "observation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "description_candidates_class_ck": {
+          "name": "description_candidates_class_ck",
+          "value": "\"description_candidates\".\"description_class\" in ('licensed_verbatim', 'bukie_editorial', 'model_assisted_candidate')"
+        },
+        "description_candidates_text_ck": {
+          "name": "description_candidates_text_ck",
+          "value": "length(trim(\"description_candidates\".\"text_content\")) > 0 and length(\"description_candidates\".\"text_hash\") = 64"
+        },
+        "description_candidates_versions_ck": {
+          "name": "description_candidates_versions_ck",
+          "value": "length(trim(\"description_candidates\".\"source_revision\")) > 0\n        and length(trim(\"description_candidates\".\"source_policy_version\")) > 0\n        and length(trim(\"description_candidates\".\"description_policy_version\")) > 0"
+        },
+        "description_candidates_license_ck": {
+          "name": "description_candidates_license_ck",
+          "value": "(\n        \"description_candidates\".\"description_class\" = 'licensed_verbatim'\n        and length(trim(\"description_candidates\".\"license_name\")) > 0\n        and length(trim(\"description_candidates\".\"license_url\")) > 0\n        and \"description_candidates\".\"derivatives_permitted\" is not null\n      ) or (\n        \"description_candidates\".\"description_class\" <> 'licensed_verbatim'\n        and \"description_candidates\".\"license_name\" is null\n        and \"description_candidates\".\"license_url\" is null\n        and \"description_candidates\".\"attribution_text\" is null\n        and \"description_candidates\".\"derivatives_permitted\" is null\n      )"
+        },
+        "description_candidates_editorial_ck": {
+          "name": "description_candidates_editorial_ck",
+          "value": "(\n        \"description_candidates\".\"description_class\" = 'bukie_editorial'\n        and length(trim(\"description_candidates\".\"editor_ref\")) > 0\n        and length(trim(\"description_candidates\".\"editorial_reason\")) > 0\n        and length(trim(\"description_candidates\".\"editorial_revision\")) > 0\n      ) or (\n        \"description_candidates\".\"description_class\" <> 'bukie_editorial'\n        and \"description_candidates\".\"editor_ref\" is null\n        and \"description_candidates\".\"editorial_reason\" is null\n        and \"description_candidates\".\"editorial_revision\" is null\n      )"
+        },
+        "description_candidates_model_ck": {
+          "name": "description_candidates_model_ck",
+          "value": "(\n        \"description_candidates\".\"description_class\" = 'model_assisted_candidate'\n        and length(trim(\"description_candidates\".\"model_id\")) > 0\n        and length(trim(\"description_candidates\".\"model_version\")) > 0\n        and length(trim(\"description_candidates\".\"prompt_version\")) > 0\n        and length(\"description_candidates\".\"generation_input_hash\") = 64\n        and \"description_candidates\".\"generated_at\" is not null\n        and \"description_candidates\".\"generation_duration_ms\" >= 0\n        and \"description_candidates\".\"input_tokens\" >= 0\n        and \"description_candidates\".\"output_tokens\" >= 0\n        and \"description_candidates\".\"cost_microusd\" >= 0\n      ) or (\n        \"description_candidates\".\"description_class\" <> 'model_assisted_candidate'\n        and \"description_candidates\".\"model_id\" is null\n        and \"description_candidates\".\"model_version\" is null\n        and \"description_candidates\".\"prompt_version\" is null\n        and \"description_candidates\".\"generation_input_hash\" is null\n        and \"description_candidates\".\"generated_at\" is null\n        and \"description_candidates\".\"generation_duration_ms\" is null\n        and \"description_candidates\".\"input_tokens\" is null\n        and \"description_candidates\".\"output_tokens\" is null\n        and \"description_candidates\".\"cost_microusd\" is null\n      )"
+        },
+        "description_candidates_quality_ck": {
+          "name": "description_candidates_quality_ck",
+          "value": "\"description_candidates\".\"quality_score\" is null or \"description_candidates\".\"quality_score\" between 0 and 100"
+        }
+      }
+    },
+    "description_claim_evidence": {
+      "name": "description_claim_evidence",
+      "columns": {
+        "claim_id": {
+          "name": "claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "observation_id": {
+          "name": "observation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "description_claim_evidence_observation_idx": {
+          "name": "description_claim_evidence_observation_idx",
+          "columns": [
+            "observation_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "description_claim_evidence_claim_id_description_claims_id_fk": {
+          "name": "description_claim_evidence_claim_id_description_claims_id_fk",
+          "tableFrom": "description_claim_evidence",
+          "tableTo": "description_claims",
+          "columnsFrom": [
+            "claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "description_claim_evidence_observation_id_field_observations_id_fk": {
+          "name": "description_claim_evidence_observation_id_field_observations_id_fk",
+          "tableFrom": "description_claim_evidence",
+          "tableTo": "field_observations",
+          "columnsFrom": [
+            "observation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "description_claim_evidence_pk": {
+          "columns": [
+            "claim_id",
+            "observation_id"
+          ],
+          "name": "description_claim_evidence_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "description_claims": {
+      "name": "description_claims",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claim_text": {
+          "name": "claim_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claim_hash": {
+          "name": "claim_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "description_claims_position_uq": {
+          "name": "description_claims_position_uq",
+          "columns": [
+            "candidate_id",
+            "position"
+          ],
+          "isUnique": true
+        },
+        "description_claims_candidate_idx": {
+          "name": "description_claims_candidate_idx",
+          "columns": [
+            "candidate_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "description_claims_candidate_id_description_candidates_id_fk": {
+          "name": "description_claims_candidate_id_description_candidates_id_fk",
+          "tableFrom": "description_claims",
+          "tableTo": "description_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "description_claims_content_ck": {
+          "name": "description_claims_content_ck",
+          "value": "\"description_claims\".\"position\" >= 0\n        and length(trim(\"description_claims\".\"claim_text\")) > 0\n        and length(\"description_claims\".\"claim_hash\") = 64"
+        }
+      }
+    },
+    "description_decision_heads": {
+      "name": "description_decision_heads",
+      "columns": {
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision_id": {
+          "name": "decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "description_decision_heads_decision_uq": {
+          "name": "description_decision_heads_decision_uq",
+          "columns": [
+            "decision_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "description_decision_heads_candidate_id_description_candidates_id_fk": {
+          "name": "description_decision_heads_candidate_id_description_candidates_id_fk",
+          "tableFrom": "description_decision_heads",
+          "tableTo": "description_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_decision_heads_decision_id_description_decisions_id_fk": {
+          "name": "description_decision_heads_decision_id_description_decisions_id_fk",
+          "tableFrom": "description_decision_heads",
+          "tableTo": "description_decisions",
+          "columnsFrom": [
+            "decision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "description_decisions": {
+      "name": "description_decisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rejection_codes_json": {
+          "name": "rejection_codes_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "warning_codes_json": {
+          "name": "warning_codes_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reviewer_ref": {
+          "name": "reviewer_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_reason": {
+          "name": "review_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_decision_id": {
+          "name": "previous_decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "description_decisions_candidate_history_idx": {
+          "name": "description_decisions_candidate_history_idx",
+          "columns": [
+            "candidate_id",
+            "decided_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "description_decisions_candidate_id_description_candidates_id_fk": {
+          "name": "description_decisions_candidate_id_description_candidates_id_fk",
+          "tableFrom": "description_decisions",
+          "tableTo": "description_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_decisions_previous_decision_id_description_decisions_id_fk": {
+          "name": "description_decisions_previous_decision_id_description_decisions_id_fk",
+          "tableFrom": "description_decisions",
+          "tableTo": "description_decisions",
+          "columnsFrom": [
+            "previous_decision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "description_decisions_state_ck": {
+          "name": "description_decisions_state_ck",
+          "value": "\"description_decisions\".\"state\" in ('candidate', 'review_required', 'paused', 'rejected', 'eligible', 'withdrawn', 'invalidated')"
+        },
+        "description_decisions_json_ck": {
+          "name": "description_decisions_json_ck",
+          "value": "json_valid(\"description_decisions\".\"rejection_codes_json\")\n        and json_valid(\"description_decisions\".\"warning_codes_json\")"
+        },
+        "description_decisions_review_ck": {
+          "name": "description_decisions_review_ck",
+          "value": "(\"description_decisions\".\"reviewer_ref\" is null and \"description_decisions\".\"review_reason\" is null)\n        or (\n          length(trim(\"description_decisions\".\"reviewer_ref\")) > 0\n          and length(trim(\"description_decisions\".\"review_reason\")) > 0\n        )"
+        },
+        "description_decisions_policy_ck": {
+          "name": "description_decisions_policy_ck",
+          "value": "length(trim(\"description_decisions\".\"policy_version\")) > 0"
+        }
+      }
+    },
+    "description_projection_heads": {
+      "name": "description_projection_heads",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projection_id": {
+          "name": "projection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "description_projection_heads_projection_uq": {
+          "name": "description_projection_heads_projection_uq",
+          "columns": [
+            "projection_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "description_projection_heads_work_id_works_id_fk": {
+          "name": "description_projection_heads_work_id_works_id_fk",
+          "tableFrom": "description_projection_heads",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_projection_heads_projection_id_description_projections_id_fk": {
+          "name": "description_projection_heads_projection_id_description_projections_id_fk",
+          "tableFrom": "description_projection_heads",
+          "tableTo": "description_projections",
+          "columnsFrom": [
+            "projection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "description_projections": {
+      "name": "description_projections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "previous_projection_id": {
+          "name": "previous_projection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projected_at": {
+          "name": "projected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "description_projections_work_history_idx": {
+          "name": "description_projections_work_history_idx",
+          "columns": [
+            "work_id",
+            "projected_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "description_projections_work_id_works_id_fk": {
+          "name": "description_projections_work_id_works_id_fk",
+          "tableFrom": "description_projections",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_projections_candidate_id_description_candidates_id_fk": {
+          "name": "description_projections_candidate_id_description_candidates_id_fk",
+          "tableFrom": "description_projections",
+          "tableTo": "description_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_projections_previous_projection_id_description_projections_id_fk": {
+          "name": "description_projections_previous_projection_id_description_projections_id_fk",
+          "tableFrom": "description_projections",
+          "tableTo": "description_projections",
+          "columnsFrom": [
+            "previous_projection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "description_projections_state_ck": {
+          "name": "description_projections_state_ck",
+          "value": "\"description_projections\".\"state\" in ('selected', 'withdrawn', 'invalidated', 'rolled_back')"
+        },
+        "description_projections_selection_ck": {
+          "name": "description_projections_selection_ck",
+          "value": "(\"description_projections\".\"state\" in ('selected', 'rolled_back') and \"description_projections\".\"candidate_id\" is not null)\n        or (\"description_projections\".\"state\" in ('withdrawn', 'invalidated') and \"description_projections\".\"candidate_id\" is null)"
+        },
+        "description_projections_nonempty_ck": {
+          "name": "description_projections_nonempty_ck",
+          "value": "length(trim(\"description_projections\".\"reason_code\")) > 0\n        and length(trim(\"description_projections\".\"actor_ref\")) > 0\n        and length(trim(\"description_projections\".\"policy_version\")) > 0"
+        }
+      }
+    },
+    "description_review_queue": {
+      "name": "description_review_queue",
+      "columns": {
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason_codes_json": {
+          "name": "reason_codes_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reviewer_ref": {
+          "name": "reviewer_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "description_review_queue_active_idx": {
+          "name": "description_review_queue_active_idx",
+          "columns": [
+            "state",
+            "priority",
+            "queued_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "description_review_queue_candidate_id_description_candidates_id_fk": {
+          "name": "description_review_queue_candidate_id_description_candidates_id_fk",
+          "tableFrom": "description_review_queue",
+          "tableTo": "description_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "description_review_queue_state_ck": {
+          "name": "description_review_queue_state_ck",
+          "value": "\"description_review_queue\".\"state\" in ('queued', 'claimed', 'completed', 'cancelled')"
+        },
+        "description_review_queue_values_ck": {
+          "name": "description_review_queue_values_ck",
+          "value": "\"description_review_queue\".\"priority\" >= 0\n        and json_valid(\"description_review_queue\".\"reason_codes_json\")\n        and (\"description_review_queue\".\"reviewer_ref\" is null or length(trim(\"description_review_queue\".\"reviewer_ref\")) > 0)"
+        }
+      }
+    },
+    "edition_covers": {
+      "name": "edition_covers",
+      "columns": {
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cover_asset_id": {
+          "name": "cover_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "edition_covers_position_uq": {
+          "name": "edition_covers_position_uq",
+          "columns": [
+            "edition_id",
+            "position"
+          ],
+          "isUnique": true
+        },
+        "edition_covers_primary_uq": {
+          "name": "edition_covers_primary_uq",
+          "columns": [
+            "edition_id"
+          ],
+          "isUnique": true,
+          "where": "\"edition_covers\".\"is_primary\" = 1"
+        },
+        "edition_covers_owner_position_idx": {
+          "name": "edition_covers_owner_position_idx",
+          "columns": [
+            "edition_id",
+            "position"
+          ],
+          "isUnique": false
+        },
+        "edition_covers_primary_lookup_idx": {
+          "name": "edition_covers_primary_lookup_idx",
+          "columns": [
+            "edition_id",
+            "is_primary"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "edition_covers_edition_id_editions_id_fk": {
+          "name": "edition_covers_edition_id_editions_id_fk",
+          "tableFrom": "edition_covers",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edition_covers_cover_asset_id_cover_assets_id_fk": {
+          "name": "edition_covers_cover_asset_id_cover_assets_id_fk",
+          "tableFrom": "edition_covers",
+          "tableTo": "cover_assets",
+          "columnsFrom": [
+            "cover_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edition_covers_pk": {
+          "columns": [
+            "edition_id",
+            "cover_asset_id"
+          ],
+          "name": "edition_covers_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "edition_covers_position_ck": {
+          "name": "edition_covers_position_ck",
+          "value": "\"edition_covers\".\"position\" >= 0"
+        }
+      }
+    },
+    "edition_identifiers": {
+      "name": "edition_identifiers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheme": {
+          "name": "scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_normalized": {
+          "name": "value_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_display": {
+          "name": "value_display",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "edition_identifiers_value_uq": {
+          "name": "edition_identifiers_value_uq",
+          "columns": [
+            "scheme",
+            "value_normalized"
+          ],
+          "isUnique": true
+        },
+        "edition_identifiers_primary_uq": {
+          "name": "edition_identifiers_primary_uq",
+          "columns": [
+            "edition_id"
+          ],
+          "isUnique": true,
+          "where": "\"edition_identifiers\".\"is_primary\" = 1"
+        },
+        "edition_identifiers_owner_idx": {
+          "name": "edition_identifiers_owner_idx",
+          "columns": [
+            "edition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "edition_identifiers_edition_id_editions_id_fk": {
+          "name": "edition_identifiers_edition_id_editions_id_fk",
+          "tableFrom": "edition_identifiers",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "edition_identifiers_scheme_ck": {
+          "name": "edition_identifiers_scheme_ck",
+          "value": "\"edition_identifiers\".\"scheme\" in ('isbn10', 'isbn13')"
+        },
+        "edition_identifiers_value_ck": {
+          "name": "edition_identifiers_value_ck",
+          "value": "length(trim(\"edition_identifiers\".\"value_normalized\")) > 0"
+        }
+      }
+    },
+    "edition_languages": {
+      "name": "edition_languages",
+      "columns": {
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language_tag": {
+          "name": "language_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "edition_languages_position_uq": {
+          "name": "edition_languages_position_uq",
+          "columns": [
+            "edition_id",
+            "position"
+          ],
+          "isUnique": true
+        },
+        "edition_languages_owner_position_idx": {
+          "name": "edition_languages_owner_position_idx",
+          "columns": [
+            "edition_id",
+            "position"
+          ],
+          "isUnique": false
+        },
+        "edition_languages_language_edition_idx": {
+          "name": "edition_languages_language_edition_idx",
+          "columns": [
+            "language_tag",
+            "edition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "edition_languages_edition_id_editions_id_fk": {
+          "name": "edition_languages_edition_id_editions_id_fk",
+          "tableFrom": "edition_languages",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edition_languages_language_tag_languages_tag_fk": {
+          "name": "edition_languages_language_tag_languages_tag_fk",
+          "tableFrom": "edition_languages",
+          "tableTo": "languages",
+          "columnsFrom": [
+            "language_tag"
+          ],
+          "columnsTo": [
+            "tag"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edition_languages_pk": {
+          "columns": [
+            "edition_id",
+            "language_tag"
+          ],
+          "name": "edition_languages_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "edition_languages_position_ck": {
+          "name": "edition_languages_position_ck",
+          "value": "\"edition_languages\".\"position\" >= 0"
+        }
+      }
+    },
+    "edition_publishers": {
+      "name": "edition_publishers",
+      "columns": {
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "publisher_id": {
+          "name": "publisher_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "edition_publishers_position_uq": {
+          "name": "edition_publishers_position_uq",
+          "columns": [
+            "edition_id",
+            "position"
+          ],
+          "isUnique": true
+        },
+        "edition_publishers_owner_position_idx": {
+          "name": "edition_publishers_owner_position_idx",
+          "columns": [
+            "edition_id",
+            "position"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "edition_publishers_edition_id_editions_id_fk": {
+          "name": "edition_publishers_edition_id_editions_id_fk",
+          "tableFrom": "edition_publishers",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edition_publishers_publisher_id_publishers_id_fk": {
+          "name": "edition_publishers_publisher_id_publishers_id_fk",
+          "tableFrom": "edition_publishers",
+          "tableTo": "publishers",
+          "columnsFrom": [
+            "publisher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edition_publishers_pk": {
+          "columns": [
+            "edition_id",
+            "publisher_id"
+          ],
+          "name": "edition_publishers_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "edition_publishers_position_ck": {
+          "name": "edition_publishers_position_ck",
+          "value": "\"edition_publishers\".\"position\" >= 0"
+        },
+        "edition_publishers_role_ck": {
+          "name": "edition_publishers_role_ck",
+          "value": "\"edition_publishers\".\"role\" is null or \"edition_publishers\".\"role\" in ('publisher', 'co_publisher', 'imprint', 'distributor')"
+        }
+      }
+    },
+    "editions": {
+      "name": "editions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publication_date": {
+          "name": "publication_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publication_precision": {
+          "name": "publication_precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publication_sort_date": {
+          "name": "publication_sort_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pages": {
+          "name": "pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cataloged_at": {
+          "name": "cataloged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "editions_work_id_idx": {
+          "name": "editions_work_id_idx",
+          "columns": [
+            "work_id"
+          ],
+          "isUnique": false
+        },
+        "editions_publication_sort_work_idx": {
+          "name": "editions_publication_sort_work_idx",
+          "columns": [
+            "publication_sort_date",
+            "work_id"
+          ],
+          "isUnique": false
+        },
+        "editions_cataloged_work_idx": {
+          "name": "editions_cataloged_work_idx",
+          "columns": [
+            "cataloged_at",
+            "work_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "editions_work_id_works_id_fk": {
+          "name": "editions_work_id_works_id_fk",
+          "tableFrom": "editions",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "editions_title_ck": {
+          "name": "editions_title_ck",
+          "value": "\"editions\".\"title\" is null or length(trim(\"editions\".\"title\")) > 0"
+        },
+        "editions_subtitle_ck": {
+          "name": "editions_subtitle_ck",
+          "value": "\"editions\".\"subtitle\" is null or length(trim(\"editions\".\"subtitle\")) > 0"
+        },
+        "editions_format_ck": {
+          "name": "editions_format_ck",
+          "value": "\"editions\".\"format\" is null or \"editions\".\"format\" in ('hardcover', 'paperback', 'ebook', 'audiobook', 'other')"
+        },
+        "editions_pages_ck": {
+          "name": "editions_pages_ck",
+          "value": "\"editions\".\"pages\" is null or \"editions\".\"pages\" > 0"
+        },
+        "editions_publication_precision_ck": {
+          "name": "editions_publication_precision_ck",
+          "value": "\"editions\".\"publication_precision\" is null or \"editions\".\"publication_precision\" in ('year', 'month', 'day')"
+        },
+        "editions_publication_date_ck": {
+          "name": "editions_publication_date_ck",
+          "value": "(\n        \"editions\".\"publication_date\" is null\n        and \"editions\".\"publication_precision\" is null\n        and \"editions\".\"publication_sort_date\" is null\n      ) or (\n        \"editions\".\"publication_precision\" = 'year'\n        and length(\"editions\".\"publication_date\") = 4\n        and \"editions\".\"publication_sort_date\" = \"editions\".\"publication_date\" || '-01-01'\n      ) or (\n        \"editions\".\"publication_precision\" = 'month'\n        and length(\"editions\".\"publication_date\") = 7\n        and substr(\"editions\".\"publication_date\", 5, 1) = '-'\n        and \"editions\".\"publication_sort_date\" = \"editions\".\"publication_date\" || '-01'\n      ) or (\n        \"editions\".\"publication_precision\" = 'day'\n        and length(\"editions\".\"publication_date\") = 10\n        and substr(\"editions\".\"publication_date\", 5, 1) = '-'\n        and substr(\"editions\".\"publication_date\", 8, 1) = '-'\n        and \"editions\".\"publication_sort_date\" = \"editions\".\"publication_date\"\n      )"
+        }
+      }
+    },
+    "entity_aliases": {
+      "name": "entity_aliases",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_id": {
+          "name": "from_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_id": {
+          "name": "to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "entity_aliases_target_idx": {
+          "name": "entity_aliases_target_idx",
+          "columns": [
+            "entity_type",
+            "to_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "entity_aliases_pk": {
+          "columns": [
+            "entity_type",
+            "from_id"
+          ],
+          "name": "entity_aliases_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "entity_aliases_ck": {
+          "name": "entity_aliases_ck",
+          "value": "\"entity_aliases\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset')\n        and \"entity_aliases\".\"from_id\" <> \"entity_aliases\".\"to_id\"\n        and length(trim(\"entity_aliases\".\"reason\")) > 0"
+        }
+      }
+    },
+    "field_observations": {
+      "name": "field_observations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_json": {
+          "name": "value_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comparison_hash": {
+          "name": "comparison_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provenance_kind": {
+          "name": "provenance_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_modified_at": {
+          "name": "source_modified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retrieved_at": {
+          "name": "retrieved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mapping_confidence": {
+          "name": "mapping_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "derivation_name": {
+          "name": "derivation_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "derivation_version": {
+          "name": "derivation_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_ids_json": {
+          "name": "parent_ids_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "field_observations_identity_uq": {
+          "name": "field_observations_identity_uq",
+          "columns": [
+            "id"
+          ],
+          "isUnique": true
+        },
+        "field_observations_source_field_state_idx": {
+          "name": "field_observations_source_field_state_idx",
+          "columns": [
+            "source_record_id",
+            "field_key",
+            "state"
+          ],
+          "isUnique": false
+        },
+        "field_observations_target_field_idx": {
+          "name": "field_observations_target_field_idx",
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "field_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "field_observations_source_record_id_source_records_id_fk": {
+          "name": "field_observations_source_record_id_source_records_id_fk",
+          "tableFrom": "field_observations",
+          "tableTo": "source_records",
+          "columnsFrom": [
+            "source_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "field_observations_target_ck": {
+          "name": "field_observations_target_ck",
+          "value": "\"field_observations\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and \"field_observations\".\"field_key\" in ('work.preferred_title', 'work.description', 'work.first_publication_date', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')"
+        },
+        "field_observations_json_ck": {
+          "name": "field_observations_json_ck",
+          "value": "json_valid(\"field_observations\".\"value_json\") and (\"field_observations\".\"parent_ids_json\" is null or json_valid(\"field_observations\".\"parent_ids_json\"))"
+        },
+        "field_observations_hash_ck": {
+          "name": "field_observations_hash_ck",
+          "value": "length(\"field_observations\".\"comparison_hash\") = 64"
+        },
+        "field_observations_provenance_ck": {
+          "name": "field_observations_provenance_ck",
+          "value": "\"field_observations\".\"provenance_kind\" in ('curated', 'imported', 'derived', 'synthetic')"
+        },
+        "field_observations_state_ck": {
+          "name": "field_observations_state_ck",
+          "value": "\"field_observations\".\"state\" in ('active', 'stale', 'withdrawn', 'invalid')"
+        },
+        "field_observations_confidence_ck": {
+          "name": "field_observations_confidence_ck",
+          "value": "\"field_observations\".\"mapping_confidence\" between 0 and 1"
+        },
+        "field_observations_curated_ck": {
+          "name": "field_observations_curated_ck",
+          "value": "\"field_observations\".\"provenance_kind\" <> 'curated'\n        or (length(trim(\"field_observations\".\"actor_ref\")) > 0 and length(trim(\"field_observations\".\"reason\")) > 0)"
+        },
+        "field_observations_derived_ck": {
+          "name": "field_observations_derived_ck",
+          "value": "\"field_observations\".\"provenance_kind\" <> 'derived'\n        or (\n          length(trim(\"field_observations\".\"derivation_name\")) > 0\n          and length(trim(\"field_observations\".\"derivation_version\")) > 0\n          and json_valid(\"field_observations\".\"parent_ids_json\")\n        )"
+        }
+      }
+    },
+    "field_resolution_heads": {
+      "name": "field_resolution_heads",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolution_id": {
+          "name": "resolution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "field_resolution_heads_resolution_uq": {
+          "name": "field_resolution_heads_resolution_uq",
+          "columns": [
+            "resolution_id"
+          ],
+          "isUnique": true
+        },
+        "field_resolution_heads_lookup_idx": {
+          "name": "field_resolution_heads_lookup_idx",
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "field_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "field_resolution_heads_resolution_id_field_resolutions_id_fk": {
+          "name": "field_resolution_heads_resolution_id_field_resolutions_id_fk",
+          "tableFrom": "field_resolution_heads",
+          "tableTo": "field_resolutions",
+          "columnsFrom": [
+            "resolution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "field_resolution_heads_pk": {
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "field_key"
+          ],
+          "name": "field_resolution_heads_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "field_resolution_heads_target_ck": {
+          "name": "field_resolution_heads_target_ck",
+          "value": "\"field_resolution_heads\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and \"field_resolution_heads\".\"field_key\" in ('work.preferred_title', 'work.description', 'work.first_publication_date', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')"
+        }
+      }
+    },
+    "field_resolutions": {
+      "name": "field_resolutions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "selected_observation_id": {
+          "name": "selected_observation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "previous_resolution_id": {
+          "name": "previous_resolution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolver_version": {
+          "name": "resolver_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "field_resolutions_target_history_idx": {
+          "name": "field_resolutions_target_history_idx",
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "field_key",
+            "resolved_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "field_resolutions_selected_observation_id_field_observations_id_fk": {
+          "name": "field_resolutions_selected_observation_id_field_observations_id_fk",
+          "tableFrom": "field_resolutions",
+          "tableTo": "field_observations",
+          "columnsFrom": [
+            "selected_observation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "field_resolutions_previous_resolution_id_field_resolutions_id_fk": {
+          "name": "field_resolutions_previous_resolution_id_field_resolutions_id_fk",
+          "tableFrom": "field_resolutions",
+          "tableTo": "field_resolutions",
+          "columnsFrom": [
+            "previous_resolution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "field_resolutions_target_ck": {
+          "name": "field_resolutions_target_ck",
+          "value": "\"field_resolutions\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and \"field_resolutions\".\"field_key\" in ('work.preferred_title', 'work.description', 'work.first_publication_date', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')"
+        },
+        "field_resolutions_state_ck": {
+          "name": "field_resolutions_state_ck",
+          "value": "\"field_resolutions\".\"state\" in ('present', 'missing', 'conflicting', 'stale', 'withdrawn')"
+        },
+        "field_resolutions_selection_ck": {
+          "name": "field_resolutions_selection_ck",
+          "value": "(\n        \"field_resolutions\".\"state\" in ('present', 'stale')\n        and \"field_resolutions\".\"selected_observation_id\" is not null\n      ) or (\n        \"field_resolutions\".\"state\" in ('missing', 'conflicting', 'withdrawn')\n        and \"field_resolutions\".\"selected_observation_id\" is null\n      )"
+        },
+        "field_resolutions_nonempty_ck": {
+          "name": "field_resolutions_nonempty_ck",
+          "value": "length(trim(\"field_resolutions\".\"reason\")) > 0\n        and length(trim(\"field_resolutions\".\"actor_ref\")) > 0\n        and length(trim(\"field_resolutions\".\"resolver_version\")) > 0"
+        }
+      }
+    },
+    "languages": {
+      "name": "languages",
+      "columns": {
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "languages_nonempty_ck": {
+          "name": "languages_nonempty_ck",
+          "value": "length(trim(\"languages\".\"tag\")) > 0 and length(trim(\"languages\".\"label\")) > 0"
+        }
+      }
+    },
+    "metadata_sources": {
+      "name": "metadata_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "terms_url": {
+          "name": "terms_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attribution_url": {
+          "name": "attribution_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approval_state": {
+          "name": "approval_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_policy": {
+          "name": "metadata_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "asset_policy": {
+          "name": "asset_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_policy": {
+          "name": "payload_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_interval_ms": {
+          "name": "refresh_interval_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "metadata_sources_key_uq": {
+          "name": "metadata_sources_key_uq",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "metadata_sources_nonempty_ck": {
+          "name": "metadata_sources_nonempty_ck",
+          "value": "length(trim(\"metadata_sources\".\"key\")) > 0 and length(trim(\"metadata_sources\".\"name\")) > 0"
+        },
+        "metadata_sources_approval_state_ck": {
+          "name": "metadata_sources_approval_state_ck",
+          "value": "\"metadata_sources\".\"approval_state\" in ('pending', 'approved', 'suspended', 'retired')"
+        },
+        "metadata_sources_payload_policy_ck": {
+          "name": "metadata_sources_payload_policy_ck",
+          "value": "\"metadata_sources\".\"payload_policy\" in ('none', 'selected_fields', 'full')"
+        },
+        "metadata_sources_policy_json_ck": {
+          "name": "metadata_sources_policy_json_ck",
+          "value": "json_valid(\"metadata_sources\".\"metadata_policy\") and json_valid(\"metadata_sources\".\"asset_policy\")"
+        },
+        "metadata_sources_approved_review_ck": {
+          "name": "metadata_sources_approved_review_ck",
+          "value": "\"metadata_sources\".\"approval_state\" <> 'approved' or \"metadata_sources\".\"reviewed_at\" is not null"
+        },
+        "metadata_sources_refresh_ck": {
+          "name": "metadata_sources_refresh_ck",
+          "value": "\"metadata_sources\".\"refresh_interval_ms\" is null or \"metadata_sources\".\"refresh_interval_ms\" > 0"
+        }
+      }
+    },
+    "publishers": {
+      "name": "publishers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "publishers_name_nonempty_ck": {
+          "name": "publishers_name_nonempty_ck",
+          "value": "length(trim(\"publishers\".\"display_name\")) > 0"
+        }
+      }
+    },
+    "source_record_links": {
+      "name": "source_record_links",
+      "columns": {
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "match_kind": {
+          "name": "match_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mapping_confidence": {
+          "name": "mapping_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "source_record_links_entity_idx": {
+          "name": "source_record_links_entity_idx",
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "state"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "source_record_links_source_record_id_source_records_id_fk": {
+          "name": "source_record_links_source_record_id_source_records_id_fk",
+          "tableFrom": "source_record_links",
+          "tableTo": "source_records",
+          "columnsFrom": [
+            "source_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "source_record_links_pk": {
+          "columns": [
+            "source_record_id",
+            "entity_type",
+            "entity_id"
+          ],
+          "name": "source_record_links_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "source_record_links_entity_type_ck": {
+          "name": "source_record_links_entity_type_ck",
+          "value": "\"source_record_links\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset')"
+        },
+        "source_record_links_match_kind_ck": {
+          "name": "source_record_links_match_kind_ck",
+          "value": "\"source_record_links\".\"match_kind\" in ('exact_identifier', 'source_relationship', 'curated', 'candidate')"
+        },
+        "source_record_links_state_ck": {
+          "name": "source_record_links_state_ck",
+          "value": "\"source_record_links\".\"state\" in ('active', 'candidate', 'rejected')"
+        },
+        "source_record_links_confidence_ck": {
+          "name": "source_record_links_confidence_ck",
+          "value": "\"source_record_links\".\"mapping_confidence\" between 0 and 1"
+        },
+        "source_record_links_actor_ck": {
+          "name": "source_record_links_actor_ck",
+          "value": "(\n        \"source_record_links\".\"match_kind\" <> 'curated' and \"source_record_links\".\"state\" <> 'rejected'\n      ) or (\n        length(trim(\"source_record_links\".\"actor_ref\")) > 0 and length(trim(\"source_record_links\".\"reason\")) > 0\n      )"
+        }
+      }
+    },
+    "source_records": {
+      "name": "source_records",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_modified_at": {
+          "name": "source_modified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retrieved_at": {
+          "name": "retrieved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "importer_version": {
+          "name": "importer_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_row_hash": {
+          "name": "source_row_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "source_records_source_key_uq": {
+          "name": "source_records_source_key_uq",
+          "columns": [
+            "source_id",
+            "record_key"
+          ],
+          "isUnique": true
+        },
+        "source_records_refresh_idx": {
+          "name": "source_records_refresh_idx",
+          "columns": [
+            "source_id",
+            "state",
+            "retrieved_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "source_records_source_id_metadata_sources_id_fk": {
+          "name": "source_records_source_id_metadata_sources_id_fk",
+          "tableFrom": "source_records",
+          "tableTo": "metadata_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "source_records_key_nonempty_ck": {
+          "name": "source_records_key_nonempty_ck",
+          "value": "length(trim(\"source_records\".\"record_key\")) > 0"
+        },
+        "source_records_state_ck": {
+          "name": "source_records_state_ck",
+          "value": "\"source_records\".\"state\" in ('active', 'withdrawn', 'deleted')"
+        },
+        "source_records_payload_json_ck": {
+          "name": "source_records_payload_json_ck",
+          "value": "\"source_records\".\"payload_json\" is null or json_valid(\"source_records\".\"payload_json\")"
+        },
+        "source_records_import_hash_ck": {
+          "name": "source_records_import_hash_ck",
+          "value": "(\"source_records\".\"importer_version\" is null and \"source_records\".\"source_row_hash\" is null)\n        or (length(trim(\"source_records\".\"importer_version\")) > 0 and length(\"source_records\".\"source_row_hash\") = 64)"
+        }
+      }
+    },
+    "work_authors": {
+      "name": "work_authors",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'author'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "work_authors_position_uq": {
+          "name": "work_authors_position_uq",
+          "columns": [
+            "work_id",
+            "position"
+          ],
+          "isUnique": true
+        },
+        "work_authors_owner_position_idx": {
+          "name": "work_authors_owner_position_idx",
+          "columns": [
+            "work_id",
+            "position"
+          ],
+          "isUnique": false
+        },
+        "work_authors_author_work_idx": {
+          "name": "work_authors_author_work_idx",
+          "columns": [
+            "author_id",
+            "work_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "work_authors_work_id_works_id_fk": {
+          "name": "work_authors_work_id_works_id_fk",
+          "tableFrom": "work_authors",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_authors_author_id_authors_id_fk": {
+          "name": "work_authors_author_id_authors_id_fk",
+          "tableFrom": "work_authors",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "work_authors_pk": {
+          "columns": [
+            "work_id",
+            "author_id",
+            "role"
+          ],
+          "name": "work_authors_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "work_authors_role_ck": {
+          "name": "work_authors_role_ck",
+          "value": "\"work_authors\".\"role\" in ('author', 'editor', 'translator', 'illustrator')"
+        },
+        "work_authors_position_ck": {
+          "name": "work_authors_position_ck",
+          "value": "\"work_authors\".\"position\" >= 0"
+        }
+      }
+    },
+    "work_categories": {
+      "name": "work_categories",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "work_categories_position_uq": {
+          "name": "work_categories_position_uq",
+          "columns": [
+            "work_id",
+            "position"
+          ],
+          "isUnique": true
+        },
+        "work_categories_primary_uq": {
+          "name": "work_categories_primary_uq",
+          "columns": [
+            "work_id"
+          ],
+          "isUnique": true,
+          "where": "\"work_categories\".\"is_primary\" = 1"
+        },
+        "work_categories_owner_position_idx": {
+          "name": "work_categories_owner_position_idx",
+          "columns": [
+            "work_id",
+            "position"
+          ],
+          "isUnique": false
+        },
+        "work_categories_category_work_idx": {
+          "name": "work_categories_category_work_idx",
+          "columns": [
+            "category_id",
+            "work_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "work_categories_work_id_works_id_fk": {
+          "name": "work_categories_work_id_works_id_fk",
+          "tableFrom": "work_categories",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_categories_category_id_categories_id_fk": {
+          "name": "work_categories_category_id_categories_id_fk",
+          "tableFrom": "work_categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "work_categories_pk": {
+          "columns": [
+            "work_id",
+            "category_id"
+          ],
+          "name": "work_categories_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "work_categories_position_ck": {
+          "name": "work_categories_position_ck",
+          "value": "\"work_categories\".\"position\" >= 0"
+        }
+      }
+    },
+    "works": {
+      "name": "works",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preferred_title": {
+          "name": "preferred_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_title": {
+          "name": "sort_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_publication_date": {
+          "name": "first_publication_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_publication_precision": {
+          "name": "first_publication_precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_publication_sort_date": {
+          "name": "first_publication_sort_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferred_edition_id": {
+          "name": "preferred_edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "works_sort_title_id_idx": {
+          "name": "works_sort_title_id_idx",
+          "columns": [
+            "sort_title",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "works_preferred_edition_idx": {
+          "name": "works_preferred_edition_idx",
+          "columns": [
+            "preferred_edition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "works_preferred_edition_id_editions_id_fk": {
+          "name": "works_preferred_edition_id_editions_id_fk",
+          "tableFrom": "works",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "preferred_edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "works_titles_nonempty_ck": {
+          "name": "works_titles_nonempty_ck",
+          "value": "length(trim(\"works\".\"preferred_title\")) > 0 and length(trim(\"works\".\"sort_title\")) > 0"
+        },
+        "works_first_publication_precision_ck": {
+          "name": "works_first_publication_precision_ck",
+          "value": "\"works\".\"first_publication_precision\" is null or \"works\".\"first_publication_precision\" in ('year', 'month', 'day')"
+        },
+        "works_first_publication_date_ck": {
+          "name": "works_first_publication_date_ck",
+          "value": "(\n        \"works\".\"first_publication_date\" is null\n        and \"works\".\"first_publication_precision\" is null\n        and \"works\".\"first_publication_sort_date\" is null\n      ) or (\n        \"works\".\"first_publication_date\" is not null\n        and \"works\".\"first_publication_precision\" is not null\n        and \"works\".\"first_publication_sort_date\" is not null\n        and (\n          (\n            \"works\".\"first_publication_precision\" = 'year'\n            and length(\"works\".\"first_publication_date\") = 4\n            and \"works\".\"first_publication_sort_date\" = \"works\".\"first_publication_date\" || '-01-01'\n          ) or (\n            \"works\".\"first_publication_precision\" = 'month'\n            and length(\"works\".\"first_publication_date\") = 7\n            and substr(\"works\".\"first_publication_date\", 5, 1) = '-'\n            and \"works\".\"first_publication_sort_date\" = \"works\".\"first_publication_date\" || '-01'\n          ) or (\n            \"works\".\"first_publication_precision\" = 'day'\n            and length(\"works\".\"first_publication_date\") = 10\n            and substr(\"works\".\"first_publication_date\", 5, 1) = '-'\n            and substr(\"works\".\"first_publication_date\", 8, 1) = '-'\n            and \"works\".\"first_publication_sort_date\" = \"works\".\"first_publication_date\"\n          )\n        )\n      )"
+        }
+      }
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,3080 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "150f4f10-3e1d-4324-9577-3bcbf3de2a47",
+  "prevId": "82e3a4bf-40f2-4028-b21d-036e8df800f6",
+  "tables": {
+    "authors": {
+      "name": "authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_name": {
+          "name": "sort_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authors_sort_name_idx": {
+          "name": "authors_sort_name_idx",
+          "columns": [
+            "sort_name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "authors_name_nonempty_ck": {
+          "name": "authors_name_nonempty_ck",
+          "value": "length(trim(\"authors\".\"display_name\")) > 0"
+        },
+        "authors_sort_name_ck": {
+          "name": "authors_sort_name_ck",
+          "value": "\"authors\".\"sort_name\" is null or length(trim(\"authors\".\"sort_name\")) > 0"
+        }
+      }
+    },
+    "catalog_change_events": {
+      "name": "catalog_change_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "catalog_change_events_type_created_idx": {
+          "name": "catalog_change_events_type_created_idx",
+          "columns": [
+            "change_type",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "catalog_change_events_type_ck": {
+          "name": "catalog_change_events_type_ck",
+          "value": "\"catalog_change_events\".\"change_type\" in ('work_merge', 'work_split', 'edition_reassignment')"
+        },
+        "catalog_change_events_json_ck": {
+          "name": "catalog_change_events_json_ck",
+          "value": "json_valid(\"catalog_change_events\".\"payload_json\")"
+        },
+        "catalog_change_events_nonempty_ck": {
+          "name": "catalog_change_events_nonempty_ck",
+          "value": "length(trim(\"catalog_change_events\".\"actor_ref\")) > 0 and length(trim(\"catalog_change_events\".\"reason\")) > 0"
+        }
+      }
+    },
+    "categories": {
+      "name": "categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "categories_slug_uq": {
+          "name": "categories_slug_uq",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "categories_nonempty_ck": {
+          "name": "categories_nonempty_ck",
+          "value": "length(trim(\"categories\".\"slug\")) > 0 and length(trim(\"categories\".\"label\")) > 0"
+        },
+        "categories_status_ck": {
+          "name": "categories_status_ck",
+          "value": "\"categories\".\"status\" in ('active', 'retired')"
+        }
+      }
+    },
+    "cover_assets": {
+      "name": "cover_assets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_policy_id": {
+          "name": "source_policy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cover_assets_object_key_uq": {
+          "name": "cover_assets_object_key_uq",
+          "columns": [
+            "object_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "cover_assets_source_policy_id_metadata_sources_id_fk": {
+          "name": "cover_assets_source_policy_id_metadata_sources_id_fk",
+          "tableFrom": "cover_assets",
+          "tableTo": "metadata_sources",
+          "columnsFrom": [
+            "source_policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "cover_assets_object_key_ck": {
+          "name": "cover_assets_object_key_ck",
+          "value": "length(trim(\"cover_assets\".\"object_key\")) > 0 and substr(\"cover_assets\".\"object_key\", 1, 8) = '/covers/'"
+        },
+        "cover_assets_state_ck": {
+          "name": "cover_assets_state_ck",
+          "value": "\"cover_assets\".\"state\" in ('available', 'missing', 'withdrawn', 'failed')"
+        },
+        "cover_assets_dimensions_ck": {
+          "name": "cover_assets_dimensions_ck",
+          "value": "(\"cover_assets\".\"width\" is null or \"cover_assets\".\"width\" > 0)\n        and (\"cover_assets\".\"height\" is null or \"cover_assets\".\"height\" > 0)\n        and (\"cover_assets\".\"bytes\" is null or \"cover_assets\".\"bytes\" > 0)"
+        }
+      }
+    },
+    "description_candidates": {
+      "name": "description_candidates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "observation_id": {
+          "name": "observation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description_class": {
+          "name": "description_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_hash": {
+          "name": "text_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_policy_version": {
+          "name": "source_policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description_policy_version": {
+          "name": "description_policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "license_name": {
+          "name": "license_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "license_url": {
+          "name": "license_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attribution_text": {
+          "name": "attribution_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "derivatives_permitted": {
+          "name": "derivatives_permitted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "licensed_source_text_hash": {
+          "name": "licensed_source_text_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "licensed_text_transformed": {
+          "name": "licensed_text_transformed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_ref": {
+          "name": "editor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editorial_reason": {
+          "name": "editorial_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editorial_revision": {
+          "name": "editorial_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generation_input_hash": {
+          "name": "generation_input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generation_duration_ms": {
+          "name": "generation_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_microusd": {
+          "name": "cost_microusd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ambiguous_identity": {
+          "name": "ambiguous_identity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sensitive_content": {
+          "name": "sensitive_content",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "description_candidates_observation_uq": {
+          "name": "description_candidates_observation_uq",
+          "columns": [
+            "observation_id"
+          ],
+          "isUnique": true
+        },
+        "description_candidates_work_created_idx": {
+          "name": "description_candidates_work_created_idx",
+          "columns": [
+            "work_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "description_candidates_work_id_works_id_fk": {
+          "name": "description_candidates_work_id_works_id_fk",
+          "tableFrom": "description_candidates",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_candidates_observation_id_field_observations_id_fk": {
+          "name": "description_candidates_observation_id_field_observations_id_fk",
+          "tableFrom": "description_candidates",
+          "tableTo": "field_observations",
+          "columnsFrom": [
+            "observation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "description_candidates_class_ck": {
+          "name": "description_candidates_class_ck",
+          "value": "\"description_candidates\".\"description_class\" in ('licensed_verbatim', 'bukie_editorial', 'model_assisted_candidate')"
+        },
+        "description_candidates_text_ck": {
+          "name": "description_candidates_text_ck",
+          "value": "length(trim(\"description_candidates\".\"text_content\")) > 0 and length(\"description_candidates\".\"text_hash\") = 64"
+        },
+        "description_candidates_versions_ck": {
+          "name": "description_candidates_versions_ck",
+          "value": "length(trim(\"description_candidates\".\"source_revision\")) > 0\n        and length(trim(\"description_candidates\".\"source_policy_version\")) > 0\n        and length(trim(\"description_candidates\".\"description_policy_version\")) > 0"
+        },
+        "description_candidates_license_ck": {
+          "name": "description_candidates_license_ck",
+          "value": "(\n        \"description_candidates\".\"description_class\" = 'licensed_verbatim'\n        and length(trim(\"description_candidates\".\"license_name\")) > 0\n        and length(trim(\"description_candidates\".\"license_url\")) > 0\n        and \"description_candidates\".\"derivatives_permitted\" is not null\n        and length(\"description_candidates\".\"licensed_source_text_hash\") = 64\n        and \"description_candidates\".\"licensed_text_transformed\" is not null\n      ) or (\n        \"description_candidates\".\"description_class\" <> 'licensed_verbatim'\n        and \"description_candidates\".\"license_name\" is null\n        and \"description_candidates\".\"license_url\" is null\n        and \"description_candidates\".\"attribution_text\" is null\n        and \"description_candidates\".\"derivatives_permitted\" is null\n        and \"description_candidates\".\"licensed_source_text_hash\" is null\n        and \"description_candidates\".\"licensed_text_transformed\" is null\n      )"
+        },
+        "description_candidates_editorial_ck": {
+          "name": "description_candidates_editorial_ck",
+          "value": "(\n        \"description_candidates\".\"description_class\" = 'bukie_editorial'\n        and length(trim(\"description_candidates\".\"editor_ref\")) > 0\n        and length(trim(\"description_candidates\".\"editorial_reason\")) > 0\n        and length(trim(\"description_candidates\".\"editorial_revision\")) > 0\n      ) or (\n        \"description_candidates\".\"description_class\" <> 'bukie_editorial'\n        and \"description_candidates\".\"editor_ref\" is null\n        and \"description_candidates\".\"editorial_reason\" is null\n        and \"description_candidates\".\"editorial_revision\" is null\n      )"
+        },
+        "description_candidates_model_ck": {
+          "name": "description_candidates_model_ck",
+          "value": "(\n        \"description_candidates\".\"description_class\" = 'model_assisted_candidate'\n        and length(trim(\"description_candidates\".\"model_id\")) > 0\n        and length(trim(\"description_candidates\".\"model_version\")) > 0\n        and length(trim(\"description_candidates\".\"prompt_version\")) > 0\n        and length(\"description_candidates\".\"generation_input_hash\") = 64\n        and \"description_candidates\".\"generated_at\" is not null\n        and \"description_candidates\".\"generation_duration_ms\" >= 0\n        and \"description_candidates\".\"input_tokens\" >= 0\n        and \"description_candidates\".\"output_tokens\" >= 0\n        and \"description_candidates\".\"cost_microusd\" >= 0\n      ) or (\n        \"description_candidates\".\"description_class\" <> 'model_assisted_candidate'\n        and \"description_candidates\".\"model_id\" is null\n        and \"description_candidates\".\"model_version\" is null\n        and \"description_candidates\".\"prompt_version\" is null\n        and \"description_candidates\".\"generation_input_hash\" is null\n        and \"description_candidates\".\"generated_at\" is null\n        and \"description_candidates\".\"generation_duration_ms\" is null\n        and \"description_candidates\".\"input_tokens\" is null\n        and \"description_candidates\".\"output_tokens\" is null\n        and \"description_candidates\".\"cost_microusd\" is null\n      )"
+        },
+        "description_candidates_quality_ck": {
+          "name": "description_candidates_quality_ck",
+          "value": "\"description_candidates\".\"quality_score\" is null or \"description_candidates\".\"quality_score\" between 0 and 100"
+        }
+      }
+    },
+    "description_claim_evidence": {
+      "name": "description_claim_evidence",
+      "columns": {
+        "claim_id": {
+          "name": "claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "observation_id": {
+          "name": "observation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "description_claim_evidence_observation_idx": {
+          "name": "description_claim_evidence_observation_idx",
+          "columns": [
+            "observation_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "description_claim_evidence_claim_id_description_claims_id_fk": {
+          "name": "description_claim_evidence_claim_id_description_claims_id_fk",
+          "tableFrom": "description_claim_evidence",
+          "tableTo": "description_claims",
+          "columnsFrom": [
+            "claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "description_claim_evidence_observation_id_field_observations_id_fk": {
+          "name": "description_claim_evidence_observation_id_field_observations_id_fk",
+          "tableFrom": "description_claim_evidence",
+          "tableTo": "field_observations",
+          "columnsFrom": [
+            "observation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "description_claim_evidence_pk": {
+          "columns": [
+            "claim_id",
+            "observation_id"
+          ],
+          "name": "description_claim_evidence_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "description_claims": {
+      "name": "description_claims",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claim_text": {
+          "name": "claim_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claim_hash": {
+          "name": "claim_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "description_claims_position_uq": {
+          "name": "description_claims_position_uq",
+          "columns": [
+            "candidate_id",
+            "position"
+          ],
+          "isUnique": true
+        },
+        "description_claims_candidate_idx": {
+          "name": "description_claims_candidate_idx",
+          "columns": [
+            "candidate_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "description_claims_candidate_id_description_candidates_id_fk": {
+          "name": "description_claims_candidate_id_description_candidates_id_fk",
+          "tableFrom": "description_claims",
+          "tableTo": "description_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "description_claims_content_ck": {
+          "name": "description_claims_content_ck",
+          "value": "\"description_claims\".\"position\" >= 0\n        and length(trim(\"description_claims\".\"claim_text\")) > 0\n        and length(\"description_claims\".\"claim_hash\") = 64"
+        }
+      }
+    },
+    "description_decision_heads": {
+      "name": "description_decision_heads",
+      "columns": {
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision_id": {
+          "name": "decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "description_decision_heads_decision_uq": {
+          "name": "description_decision_heads_decision_uq",
+          "columns": [
+            "decision_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "description_decision_heads_candidate_id_description_candidates_id_fk": {
+          "name": "description_decision_heads_candidate_id_description_candidates_id_fk",
+          "tableFrom": "description_decision_heads",
+          "tableTo": "description_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_decision_heads_decision_id_description_decisions_id_fk": {
+          "name": "description_decision_heads_decision_id_description_decisions_id_fk",
+          "tableFrom": "description_decision_heads",
+          "tableTo": "description_decisions",
+          "columnsFrom": [
+            "decision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "description_decisions": {
+      "name": "description_decisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rejection_codes_json": {
+          "name": "rejection_codes_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "warning_codes_json": {
+          "name": "warning_codes_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reviewer_ref": {
+          "name": "reviewer_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_reason": {
+          "name": "review_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_decision_id": {
+          "name": "previous_decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "description_decisions_candidate_history_idx": {
+          "name": "description_decisions_candidate_history_idx",
+          "columns": [
+            "candidate_id",
+            "decided_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "description_decisions_candidate_id_description_candidates_id_fk": {
+          "name": "description_decisions_candidate_id_description_candidates_id_fk",
+          "tableFrom": "description_decisions",
+          "tableTo": "description_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_decisions_previous_decision_id_description_decisions_id_fk": {
+          "name": "description_decisions_previous_decision_id_description_decisions_id_fk",
+          "tableFrom": "description_decisions",
+          "tableTo": "description_decisions",
+          "columnsFrom": [
+            "previous_decision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "description_decisions_state_ck": {
+          "name": "description_decisions_state_ck",
+          "value": "\"description_decisions\".\"state\" in ('candidate', 'review_required', 'paused', 'rejected', 'eligible', 'withdrawn', 'invalidated')"
+        },
+        "description_decisions_json_ck": {
+          "name": "description_decisions_json_ck",
+          "value": "json_valid(\"description_decisions\".\"rejection_codes_json\")\n        and json_valid(\"description_decisions\".\"warning_codes_json\")"
+        },
+        "description_decisions_review_ck": {
+          "name": "description_decisions_review_ck",
+          "value": "(\"description_decisions\".\"reviewer_ref\" is null and \"description_decisions\".\"review_reason\" is null)\n        or (\n          length(trim(\"description_decisions\".\"reviewer_ref\")) > 0\n          and length(trim(\"description_decisions\".\"review_reason\")) > 0\n        )"
+        },
+        "description_decisions_policy_ck": {
+          "name": "description_decisions_policy_ck",
+          "value": "length(trim(\"description_decisions\".\"policy_version\")) > 0"
+        }
+      }
+    },
+    "description_projection_heads": {
+      "name": "description_projection_heads",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projection_id": {
+          "name": "projection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "description_projection_heads_projection_uq": {
+          "name": "description_projection_heads_projection_uq",
+          "columns": [
+            "projection_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "description_projection_heads_work_id_works_id_fk": {
+          "name": "description_projection_heads_work_id_works_id_fk",
+          "tableFrom": "description_projection_heads",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_projection_heads_projection_id_description_projections_id_fk": {
+          "name": "description_projection_heads_projection_id_description_projections_id_fk",
+          "tableFrom": "description_projection_heads",
+          "tableTo": "description_projections",
+          "columnsFrom": [
+            "projection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "description_projections": {
+      "name": "description_projections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "previous_projection_id": {
+          "name": "previous_projection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projected_at": {
+          "name": "projected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "description_projections_work_history_idx": {
+          "name": "description_projections_work_history_idx",
+          "columns": [
+            "work_id",
+            "projected_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "description_projections_work_id_works_id_fk": {
+          "name": "description_projections_work_id_works_id_fk",
+          "tableFrom": "description_projections",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_projections_candidate_id_description_candidates_id_fk": {
+          "name": "description_projections_candidate_id_description_candidates_id_fk",
+          "tableFrom": "description_projections",
+          "tableTo": "description_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_projections_previous_projection_id_description_projections_id_fk": {
+          "name": "description_projections_previous_projection_id_description_projections_id_fk",
+          "tableFrom": "description_projections",
+          "tableTo": "description_projections",
+          "columnsFrom": [
+            "previous_projection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "description_projections_state_ck": {
+          "name": "description_projections_state_ck",
+          "value": "\"description_projections\".\"state\" in ('selected', 'withdrawn', 'invalidated', 'rolled_back')"
+        },
+        "description_projections_selection_ck": {
+          "name": "description_projections_selection_ck",
+          "value": "(\"description_projections\".\"state\" in ('selected', 'rolled_back') and \"description_projections\".\"candidate_id\" is not null)\n        or (\"description_projections\".\"state\" in ('withdrawn', 'invalidated') and \"description_projections\".\"candidate_id\" is null)"
+        },
+        "description_projections_nonempty_ck": {
+          "name": "description_projections_nonempty_ck",
+          "value": "length(trim(\"description_projections\".\"reason_code\")) > 0\n        and length(trim(\"description_projections\".\"actor_ref\")) > 0\n        and length(trim(\"description_projections\".\"policy_version\")) > 0"
+        }
+      }
+    },
+    "description_review_queue": {
+      "name": "description_review_queue",
+      "columns": {
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason_codes_json": {
+          "name": "reason_codes_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reviewer_ref": {
+          "name": "reviewer_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "description_review_queue_active_idx": {
+          "name": "description_review_queue_active_idx",
+          "columns": [
+            "state",
+            "priority",
+            "queued_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "description_review_queue_candidate_id_description_candidates_id_fk": {
+          "name": "description_review_queue_candidate_id_description_candidates_id_fk",
+          "tableFrom": "description_review_queue",
+          "tableTo": "description_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "description_review_queue_state_ck": {
+          "name": "description_review_queue_state_ck",
+          "value": "\"description_review_queue\".\"state\" in ('queued', 'claimed', 'completed', 'cancelled')"
+        },
+        "description_review_queue_values_ck": {
+          "name": "description_review_queue_values_ck",
+          "value": "\"description_review_queue\".\"priority\" >= 0\n        and json_valid(\"description_review_queue\".\"reason_codes_json\")\n        and (\"description_review_queue\".\"reviewer_ref\" is null or length(trim(\"description_review_queue\".\"reviewer_ref\")) > 0)"
+        }
+      }
+    },
+    "edition_covers": {
+      "name": "edition_covers",
+      "columns": {
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cover_asset_id": {
+          "name": "cover_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "edition_covers_position_uq": {
+          "name": "edition_covers_position_uq",
+          "columns": [
+            "edition_id",
+            "position"
+          ],
+          "isUnique": true
+        },
+        "edition_covers_primary_uq": {
+          "name": "edition_covers_primary_uq",
+          "columns": [
+            "edition_id"
+          ],
+          "isUnique": true,
+          "where": "\"edition_covers\".\"is_primary\" = 1"
+        },
+        "edition_covers_owner_position_idx": {
+          "name": "edition_covers_owner_position_idx",
+          "columns": [
+            "edition_id",
+            "position"
+          ],
+          "isUnique": false
+        },
+        "edition_covers_primary_lookup_idx": {
+          "name": "edition_covers_primary_lookup_idx",
+          "columns": [
+            "edition_id",
+            "is_primary"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "edition_covers_edition_id_editions_id_fk": {
+          "name": "edition_covers_edition_id_editions_id_fk",
+          "tableFrom": "edition_covers",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edition_covers_cover_asset_id_cover_assets_id_fk": {
+          "name": "edition_covers_cover_asset_id_cover_assets_id_fk",
+          "tableFrom": "edition_covers",
+          "tableTo": "cover_assets",
+          "columnsFrom": [
+            "cover_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edition_covers_pk": {
+          "columns": [
+            "edition_id",
+            "cover_asset_id"
+          ],
+          "name": "edition_covers_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "edition_covers_position_ck": {
+          "name": "edition_covers_position_ck",
+          "value": "\"edition_covers\".\"position\" >= 0"
+        }
+      }
+    },
+    "edition_identifiers": {
+      "name": "edition_identifiers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheme": {
+          "name": "scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_normalized": {
+          "name": "value_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_display": {
+          "name": "value_display",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "edition_identifiers_value_uq": {
+          "name": "edition_identifiers_value_uq",
+          "columns": [
+            "scheme",
+            "value_normalized"
+          ],
+          "isUnique": true
+        },
+        "edition_identifiers_primary_uq": {
+          "name": "edition_identifiers_primary_uq",
+          "columns": [
+            "edition_id"
+          ],
+          "isUnique": true,
+          "where": "\"edition_identifiers\".\"is_primary\" = 1"
+        },
+        "edition_identifiers_owner_idx": {
+          "name": "edition_identifiers_owner_idx",
+          "columns": [
+            "edition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "edition_identifiers_edition_id_editions_id_fk": {
+          "name": "edition_identifiers_edition_id_editions_id_fk",
+          "tableFrom": "edition_identifiers",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "edition_identifiers_scheme_ck": {
+          "name": "edition_identifiers_scheme_ck",
+          "value": "\"edition_identifiers\".\"scheme\" in ('isbn10', 'isbn13')"
+        },
+        "edition_identifiers_value_ck": {
+          "name": "edition_identifiers_value_ck",
+          "value": "length(trim(\"edition_identifiers\".\"value_normalized\")) > 0"
+        }
+      }
+    },
+    "edition_languages": {
+      "name": "edition_languages",
+      "columns": {
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language_tag": {
+          "name": "language_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "edition_languages_position_uq": {
+          "name": "edition_languages_position_uq",
+          "columns": [
+            "edition_id",
+            "position"
+          ],
+          "isUnique": true
+        },
+        "edition_languages_owner_position_idx": {
+          "name": "edition_languages_owner_position_idx",
+          "columns": [
+            "edition_id",
+            "position"
+          ],
+          "isUnique": false
+        },
+        "edition_languages_language_edition_idx": {
+          "name": "edition_languages_language_edition_idx",
+          "columns": [
+            "language_tag",
+            "edition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "edition_languages_edition_id_editions_id_fk": {
+          "name": "edition_languages_edition_id_editions_id_fk",
+          "tableFrom": "edition_languages",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edition_languages_language_tag_languages_tag_fk": {
+          "name": "edition_languages_language_tag_languages_tag_fk",
+          "tableFrom": "edition_languages",
+          "tableTo": "languages",
+          "columnsFrom": [
+            "language_tag"
+          ],
+          "columnsTo": [
+            "tag"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edition_languages_pk": {
+          "columns": [
+            "edition_id",
+            "language_tag"
+          ],
+          "name": "edition_languages_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "edition_languages_position_ck": {
+          "name": "edition_languages_position_ck",
+          "value": "\"edition_languages\".\"position\" >= 0"
+        }
+      }
+    },
+    "edition_publishers": {
+      "name": "edition_publishers",
+      "columns": {
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "publisher_id": {
+          "name": "publisher_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "edition_publishers_position_uq": {
+          "name": "edition_publishers_position_uq",
+          "columns": [
+            "edition_id",
+            "position"
+          ],
+          "isUnique": true
+        },
+        "edition_publishers_owner_position_idx": {
+          "name": "edition_publishers_owner_position_idx",
+          "columns": [
+            "edition_id",
+            "position"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "edition_publishers_edition_id_editions_id_fk": {
+          "name": "edition_publishers_edition_id_editions_id_fk",
+          "tableFrom": "edition_publishers",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edition_publishers_publisher_id_publishers_id_fk": {
+          "name": "edition_publishers_publisher_id_publishers_id_fk",
+          "tableFrom": "edition_publishers",
+          "tableTo": "publishers",
+          "columnsFrom": [
+            "publisher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edition_publishers_pk": {
+          "columns": [
+            "edition_id",
+            "publisher_id"
+          ],
+          "name": "edition_publishers_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "edition_publishers_position_ck": {
+          "name": "edition_publishers_position_ck",
+          "value": "\"edition_publishers\".\"position\" >= 0"
+        },
+        "edition_publishers_role_ck": {
+          "name": "edition_publishers_role_ck",
+          "value": "\"edition_publishers\".\"role\" is null or \"edition_publishers\".\"role\" in ('publisher', 'co_publisher', 'imprint', 'distributor')"
+        }
+      }
+    },
+    "editions": {
+      "name": "editions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publication_date": {
+          "name": "publication_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publication_precision": {
+          "name": "publication_precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publication_sort_date": {
+          "name": "publication_sort_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pages": {
+          "name": "pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cataloged_at": {
+          "name": "cataloged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "editions_work_id_idx": {
+          "name": "editions_work_id_idx",
+          "columns": [
+            "work_id"
+          ],
+          "isUnique": false
+        },
+        "editions_publication_sort_work_idx": {
+          "name": "editions_publication_sort_work_idx",
+          "columns": [
+            "publication_sort_date",
+            "work_id"
+          ],
+          "isUnique": false
+        },
+        "editions_cataloged_work_idx": {
+          "name": "editions_cataloged_work_idx",
+          "columns": [
+            "cataloged_at",
+            "work_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "editions_work_id_works_id_fk": {
+          "name": "editions_work_id_works_id_fk",
+          "tableFrom": "editions",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "editions_title_ck": {
+          "name": "editions_title_ck",
+          "value": "\"editions\".\"title\" is null or length(trim(\"editions\".\"title\")) > 0"
+        },
+        "editions_subtitle_ck": {
+          "name": "editions_subtitle_ck",
+          "value": "\"editions\".\"subtitle\" is null or length(trim(\"editions\".\"subtitle\")) > 0"
+        },
+        "editions_format_ck": {
+          "name": "editions_format_ck",
+          "value": "\"editions\".\"format\" is null or \"editions\".\"format\" in ('hardcover', 'paperback', 'ebook', 'audiobook', 'other')"
+        },
+        "editions_pages_ck": {
+          "name": "editions_pages_ck",
+          "value": "\"editions\".\"pages\" is null or \"editions\".\"pages\" > 0"
+        },
+        "editions_publication_precision_ck": {
+          "name": "editions_publication_precision_ck",
+          "value": "\"editions\".\"publication_precision\" is null or \"editions\".\"publication_precision\" in ('year', 'month', 'day')"
+        },
+        "editions_publication_date_ck": {
+          "name": "editions_publication_date_ck",
+          "value": "(\n        \"editions\".\"publication_date\" is null\n        and \"editions\".\"publication_precision\" is null\n        and \"editions\".\"publication_sort_date\" is null\n      ) or (\n        \"editions\".\"publication_precision\" = 'year'\n        and length(\"editions\".\"publication_date\") = 4\n        and \"editions\".\"publication_sort_date\" = \"editions\".\"publication_date\" || '-01-01'\n      ) or (\n        \"editions\".\"publication_precision\" = 'month'\n        and length(\"editions\".\"publication_date\") = 7\n        and substr(\"editions\".\"publication_date\", 5, 1) = '-'\n        and \"editions\".\"publication_sort_date\" = \"editions\".\"publication_date\" || '-01'\n      ) or (\n        \"editions\".\"publication_precision\" = 'day'\n        and length(\"editions\".\"publication_date\") = 10\n        and substr(\"editions\".\"publication_date\", 5, 1) = '-'\n        and substr(\"editions\".\"publication_date\", 8, 1) = '-'\n        and \"editions\".\"publication_sort_date\" = \"editions\".\"publication_date\"\n      )"
+        }
+      }
+    },
+    "entity_aliases": {
+      "name": "entity_aliases",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_id": {
+          "name": "from_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_id": {
+          "name": "to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "entity_aliases_target_idx": {
+          "name": "entity_aliases_target_idx",
+          "columns": [
+            "entity_type",
+            "to_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "entity_aliases_pk": {
+          "columns": [
+            "entity_type",
+            "from_id"
+          ],
+          "name": "entity_aliases_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "entity_aliases_ck": {
+          "name": "entity_aliases_ck",
+          "value": "\"entity_aliases\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset')\n        and \"entity_aliases\".\"from_id\" <> \"entity_aliases\".\"to_id\"\n        and length(trim(\"entity_aliases\".\"reason\")) > 0"
+        }
+      }
+    },
+    "field_observations": {
+      "name": "field_observations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_json": {
+          "name": "value_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comparison_hash": {
+          "name": "comparison_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provenance_kind": {
+          "name": "provenance_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_modified_at": {
+          "name": "source_modified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retrieved_at": {
+          "name": "retrieved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mapping_confidence": {
+          "name": "mapping_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "derivation_name": {
+          "name": "derivation_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "derivation_version": {
+          "name": "derivation_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_ids_json": {
+          "name": "parent_ids_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "field_observations_identity_uq": {
+          "name": "field_observations_identity_uq",
+          "columns": [
+            "id"
+          ],
+          "isUnique": true
+        },
+        "field_observations_source_field_state_idx": {
+          "name": "field_observations_source_field_state_idx",
+          "columns": [
+            "source_record_id",
+            "field_key",
+            "state"
+          ],
+          "isUnique": false
+        },
+        "field_observations_target_field_idx": {
+          "name": "field_observations_target_field_idx",
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "field_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "field_observations_source_record_id_source_records_id_fk": {
+          "name": "field_observations_source_record_id_source_records_id_fk",
+          "tableFrom": "field_observations",
+          "tableTo": "source_records",
+          "columnsFrom": [
+            "source_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "field_observations_target_ck": {
+          "name": "field_observations_target_ck",
+          "value": "\"field_observations\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and \"field_observations\".\"field_key\" in ('work.preferred_title', 'work.description', 'work.first_publication_date', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')"
+        },
+        "field_observations_json_ck": {
+          "name": "field_observations_json_ck",
+          "value": "json_valid(\"field_observations\".\"value_json\") and (\"field_observations\".\"parent_ids_json\" is null or json_valid(\"field_observations\".\"parent_ids_json\"))"
+        },
+        "field_observations_hash_ck": {
+          "name": "field_observations_hash_ck",
+          "value": "length(\"field_observations\".\"comparison_hash\") = 64"
+        },
+        "field_observations_provenance_ck": {
+          "name": "field_observations_provenance_ck",
+          "value": "\"field_observations\".\"provenance_kind\" in ('curated', 'imported', 'derived', 'synthetic')"
+        },
+        "field_observations_state_ck": {
+          "name": "field_observations_state_ck",
+          "value": "\"field_observations\".\"state\" in ('active', 'stale', 'withdrawn', 'invalid')"
+        },
+        "field_observations_confidence_ck": {
+          "name": "field_observations_confidence_ck",
+          "value": "\"field_observations\".\"mapping_confidence\" between 0 and 1"
+        },
+        "field_observations_curated_ck": {
+          "name": "field_observations_curated_ck",
+          "value": "\"field_observations\".\"provenance_kind\" <> 'curated'\n        or (length(trim(\"field_observations\".\"actor_ref\")) > 0 and length(trim(\"field_observations\".\"reason\")) > 0)"
+        },
+        "field_observations_derived_ck": {
+          "name": "field_observations_derived_ck",
+          "value": "\"field_observations\".\"provenance_kind\" <> 'derived'\n        or (\n          length(trim(\"field_observations\".\"derivation_name\")) > 0\n          and length(trim(\"field_observations\".\"derivation_version\")) > 0\n          and json_valid(\"field_observations\".\"parent_ids_json\")\n        )"
+        }
+      }
+    },
+    "field_resolution_heads": {
+      "name": "field_resolution_heads",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolution_id": {
+          "name": "resolution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "field_resolution_heads_resolution_uq": {
+          "name": "field_resolution_heads_resolution_uq",
+          "columns": [
+            "resolution_id"
+          ],
+          "isUnique": true
+        },
+        "field_resolution_heads_lookup_idx": {
+          "name": "field_resolution_heads_lookup_idx",
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "field_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "field_resolution_heads_resolution_id_field_resolutions_id_fk": {
+          "name": "field_resolution_heads_resolution_id_field_resolutions_id_fk",
+          "tableFrom": "field_resolution_heads",
+          "tableTo": "field_resolutions",
+          "columnsFrom": [
+            "resolution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "field_resolution_heads_pk": {
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "field_key"
+          ],
+          "name": "field_resolution_heads_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "field_resolution_heads_target_ck": {
+          "name": "field_resolution_heads_target_ck",
+          "value": "\"field_resolution_heads\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and \"field_resolution_heads\".\"field_key\" in ('work.preferred_title', 'work.description', 'work.first_publication_date', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')"
+        }
+      }
+    },
+    "field_resolutions": {
+      "name": "field_resolutions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "selected_observation_id": {
+          "name": "selected_observation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "previous_resolution_id": {
+          "name": "previous_resolution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolver_version": {
+          "name": "resolver_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "field_resolutions_target_history_idx": {
+          "name": "field_resolutions_target_history_idx",
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "field_key",
+            "resolved_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "field_resolutions_selected_observation_id_field_observations_id_fk": {
+          "name": "field_resolutions_selected_observation_id_field_observations_id_fk",
+          "tableFrom": "field_resolutions",
+          "tableTo": "field_observations",
+          "columnsFrom": [
+            "selected_observation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "field_resolutions_previous_resolution_id_field_resolutions_id_fk": {
+          "name": "field_resolutions_previous_resolution_id_field_resolutions_id_fk",
+          "tableFrom": "field_resolutions",
+          "tableTo": "field_resolutions",
+          "columnsFrom": [
+            "previous_resolution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "field_resolutions_target_ck": {
+          "name": "field_resolutions_target_ck",
+          "value": "\"field_resolutions\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and \"field_resolutions\".\"field_key\" in ('work.preferred_title', 'work.description', 'work.first_publication_date', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')"
+        },
+        "field_resolutions_state_ck": {
+          "name": "field_resolutions_state_ck",
+          "value": "\"field_resolutions\".\"state\" in ('present', 'missing', 'conflicting', 'stale', 'withdrawn')"
+        },
+        "field_resolutions_selection_ck": {
+          "name": "field_resolutions_selection_ck",
+          "value": "(\n        \"field_resolutions\".\"state\" in ('present', 'stale')\n        and \"field_resolutions\".\"selected_observation_id\" is not null\n      ) or (\n        \"field_resolutions\".\"state\" in ('missing', 'conflicting', 'withdrawn')\n        and \"field_resolutions\".\"selected_observation_id\" is null\n      )"
+        },
+        "field_resolutions_nonempty_ck": {
+          "name": "field_resolutions_nonempty_ck",
+          "value": "length(trim(\"field_resolutions\".\"reason\")) > 0\n        and length(trim(\"field_resolutions\".\"actor_ref\")) > 0\n        and length(trim(\"field_resolutions\".\"resolver_version\")) > 0"
+        }
+      }
+    },
+    "languages": {
+      "name": "languages",
+      "columns": {
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "languages_nonempty_ck": {
+          "name": "languages_nonempty_ck",
+          "value": "length(trim(\"languages\".\"tag\")) > 0 and length(trim(\"languages\".\"label\")) > 0"
+        }
+      }
+    },
+    "metadata_sources": {
+      "name": "metadata_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "terms_url": {
+          "name": "terms_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attribution_url": {
+          "name": "attribution_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approval_state": {
+          "name": "approval_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_policy": {
+          "name": "metadata_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "asset_policy": {
+          "name": "asset_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_policy": {
+          "name": "payload_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_interval_ms": {
+          "name": "refresh_interval_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "metadata_sources_key_uq": {
+          "name": "metadata_sources_key_uq",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "metadata_sources_nonempty_ck": {
+          "name": "metadata_sources_nonempty_ck",
+          "value": "length(trim(\"metadata_sources\".\"key\")) > 0 and length(trim(\"metadata_sources\".\"name\")) > 0"
+        },
+        "metadata_sources_approval_state_ck": {
+          "name": "metadata_sources_approval_state_ck",
+          "value": "\"metadata_sources\".\"approval_state\" in ('pending', 'approved', 'suspended', 'retired')"
+        },
+        "metadata_sources_payload_policy_ck": {
+          "name": "metadata_sources_payload_policy_ck",
+          "value": "\"metadata_sources\".\"payload_policy\" in ('none', 'selected_fields', 'full')"
+        },
+        "metadata_sources_policy_json_ck": {
+          "name": "metadata_sources_policy_json_ck",
+          "value": "json_valid(\"metadata_sources\".\"metadata_policy\") and json_valid(\"metadata_sources\".\"asset_policy\")"
+        },
+        "metadata_sources_approved_review_ck": {
+          "name": "metadata_sources_approved_review_ck",
+          "value": "\"metadata_sources\".\"approval_state\" <> 'approved' or \"metadata_sources\".\"reviewed_at\" is not null"
+        },
+        "metadata_sources_refresh_ck": {
+          "name": "metadata_sources_refresh_ck",
+          "value": "\"metadata_sources\".\"refresh_interval_ms\" is null or \"metadata_sources\".\"refresh_interval_ms\" > 0"
+        }
+      }
+    },
+    "publishers": {
+      "name": "publishers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "publishers_name_nonempty_ck": {
+          "name": "publishers_name_nonempty_ck",
+          "value": "length(trim(\"publishers\".\"display_name\")) > 0"
+        }
+      }
+    },
+    "source_record_links": {
+      "name": "source_record_links",
+      "columns": {
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "match_kind": {
+          "name": "match_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mapping_confidence": {
+          "name": "mapping_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "source_record_links_entity_idx": {
+          "name": "source_record_links_entity_idx",
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "state"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "source_record_links_source_record_id_source_records_id_fk": {
+          "name": "source_record_links_source_record_id_source_records_id_fk",
+          "tableFrom": "source_record_links",
+          "tableTo": "source_records",
+          "columnsFrom": [
+            "source_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "source_record_links_pk": {
+          "columns": [
+            "source_record_id",
+            "entity_type",
+            "entity_id"
+          ],
+          "name": "source_record_links_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "source_record_links_entity_type_ck": {
+          "name": "source_record_links_entity_type_ck",
+          "value": "\"source_record_links\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset')"
+        },
+        "source_record_links_match_kind_ck": {
+          "name": "source_record_links_match_kind_ck",
+          "value": "\"source_record_links\".\"match_kind\" in ('exact_identifier', 'source_relationship', 'curated', 'candidate')"
+        },
+        "source_record_links_state_ck": {
+          "name": "source_record_links_state_ck",
+          "value": "\"source_record_links\".\"state\" in ('active', 'candidate', 'rejected')"
+        },
+        "source_record_links_confidence_ck": {
+          "name": "source_record_links_confidence_ck",
+          "value": "\"source_record_links\".\"mapping_confidence\" between 0 and 1"
+        },
+        "source_record_links_actor_ck": {
+          "name": "source_record_links_actor_ck",
+          "value": "(\n        \"source_record_links\".\"match_kind\" <> 'curated' and \"source_record_links\".\"state\" <> 'rejected'\n      ) or (\n        length(trim(\"source_record_links\".\"actor_ref\")) > 0 and length(trim(\"source_record_links\".\"reason\")) > 0\n      )"
+        }
+      }
+    },
+    "source_records": {
+      "name": "source_records",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_modified_at": {
+          "name": "source_modified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retrieved_at": {
+          "name": "retrieved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "importer_version": {
+          "name": "importer_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_row_hash": {
+          "name": "source_row_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "source_records_source_key_uq": {
+          "name": "source_records_source_key_uq",
+          "columns": [
+            "source_id",
+            "record_key"
+          ],
+          "isUnique": true
+        },
+        "source_records_refresh_idx": {
+          "name": "source_records_refresh_idx",
+          "columns": [
+            "source_id",
+            "state",
+            "retrieved_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "source_records_source_id_metadata_sources_id_fk": {
+          "name": "source_records_source_id_metadata_sources_id_fk",
+          "tableFrom": "source_records",
+          "tableTo": "metadata_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "source_records_key_nonempty_ck": {
+          "name": "source_records_key_nonempty_ck",
+          "value": "length(trim(\"source_records\".\"record_key\")) > 0"
+        },
+        "source_records_state_ck": {
+          "name": "source_records_state_ck",
+          "value": "\"source_records\".\"state\" in ('active', 'withdrawn', 'deleted')"
+        },
+        "source_records_payload_json_ck": {
+          "name": "source_records_payload_json_ck",
+          "value": "\"source_records\".\"payload_json\" is null or json_valid(\"source_records\".\"payload_json\")"
+        },
+        "source_records_import_hash_ck": {
+          "name": "source_records_import_hash_ck",
+          "value": "(\"source_records\".\"importer_version\" is null and \"source_records\".\"source_row_hash\" is null)\n        or (length(trim(\"source_records\".\"importer_version\")) > 0 and length(\"source_records\".\"source_row_hash\") = 64)"
+        }
+      }
+    },
+    "work_authors": {
+      "name": "work_authors",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'author'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "work_authors_position_uq": {
+          "name": "work_authors_position_uq",
+          "columns": [
+            "work_id",
+            "position"
+          ],
+          "isUnique": true
+        },
+        "work_authors_owner_position_idx": {
+          "name": "work_authors_owner_position_idx",
+          "columns": [
+            "work_id",
+            "position"
+          ],
+          "isUnique": false
+        },
+        "work_authors_author_work_idx": {
+          "name": "work_authors_author_work_idx",
+          "columns": [
+            "author_id",
+            "work_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "work_authors_work_id_works_id_fk": {
+          "name": "work_authors_work_id_works_id_fk",
+          "tableFrom": "work_authors",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_authors_author_id_authors_id_fk": {
+          "name": "work_authors_author_id_authors_id_fk",
+          "tableFrom": "work_authors",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "work_authors_pk": {
+          "columns": [
+            "work_id",
+            "author_id",
+            "role"
+          ],
+          "name": "work_authors_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "work_authors_role_ck": {
+          "name": "work_authors_role_ck",
+          "value": "\"work_authors\".\"role\" in ('author', 'editor', 'translator', 'illustrator')"
+        },
+        "work_authors_position_ck": {
+          "name": "work_authors_position_ck",
+          "value": "\"work_authors\".\"position\" >= 0"
+        }
+      }
+    },
+    "work_categories": {
+      "name": "work_categories",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "work_categories_position_uq": {
+          "name": "work_categories_position_uq",
+          "columns": [
+            "work_id",
+            "position"
+          ],
+          "isUnique": true
+        },
+        "work_categories_primary_uq": {
+          "name": "work_categories_primary_uq",
+          "columns": [
+            "work_id"
+          ],
+          "isUnique": true,
+          "where": "\"work_categories\".\"is_primary\" = 1"
+        },
+        "work_categories_owner_position_idx": {
+          "name": "work_categories_owner_position_idx",
+          "columns": [
+            "work_id",
+            "position"
+          ],
+          "isUnique": false
+        },
+        "work_categories_category_work_idx": {
+          "name": "work_categories_category_work_idx",
+          "columns": [
+            "category_id",
+            "work_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "work_categories_work_id_works_id_fk": {
+          "name": "work_categories_work_id_works_id_fk",
+          "tableFrom": "work_categories",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_categories_category_id_categories_id_fk": {
+          "name": "work_categories_category_id_categories_id_fk",
+          "tableFrom": "work_categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "work_categories_pk": {
+          "columns": [
+            "work_id",
+            "category_id"
+          ],
+          "name": "work_categories_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "work_categories_position_ck": {
+          "name": "work_categories_position_ck",
+          "value": "\"work_categories\".\"position\" >= 0"
+        }
+      }
+    },
+    "works": {
+      "name": "works",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preferred_title": {
+          "name": "preferred_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_title": {
+          "name": "sort_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_publication_date": {
+          "name": "first_publication_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_publication_precision": {
+          "name": "first_publication_precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_publication_sort_date": {
+          "name": "first_publication_sort_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferred_edition_id": {
+          "name": "preferred_edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "works_sort_title_id_idx": {
+          "name": "works_sort_title_id_idx",
+          "columns": [
+            "sort_title",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "works_preferred_edition_idx": {
+          "name": "works_preferred_edition_idx",
+          "columns": [
+            "preferred_edition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "works_preferred_edition_id_editions_id_fk": {
+          "name": "works_preferred_edition_id_editions_id_fk",
+          "tableFrom": "works",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "preferred_edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "works_titles_nonempty_ck": {
+          "name": "works_titles_nonempty_ck",
+          "value": "length(trim(\"works\".\"preferred_title\")) > 0 and length(trim(\"works\".\"sort_title\")) > 0"
+        },
+        "works_first_publication_precision_ck": {
+          "name": "works_first_publication_precision_ck",
+          "value": "\"works\".\"first_publication_precision\" is null or \"works\".\"first_publication_precision\" in ('year', 'month', 'day')"
+        },
+        "works_first_publication_date_ck": {
+          "name": "works_first_publication_date_ck",
+          "value": "(\n        \"works\".\"first_publication_date\" is null\n        and \"works\".\"first_publication_precision\" is null\n        and \"works\".\"first_publication_sort_date\" is null\n      ) or (\n        \"works\".\"first_publication_date\" is not null\n        and \"works\".\"first_publication_precision\" is not null\n        and \"works\".\"first_publication_sort_date\" is not null\n        and (\n          (\n            \"works\".\"first_publication_precision\" = 'year'\n            and length(\"works\".\"first_publication_date\") = 4\n            and \"works\".\"first_publication_sort_date\" = \"works\".\"first_publication_date\" || '-01-01'\n          ) or (\n            \"works\".\"first_publication_precision\" = 'month'\n            and length(\"works\".\"first_publication_date\") = 7\n            and substr(\"works\".\"first_publication_date\", 5, 1) = '-'\n            and \"works\".\"first_publication_sort_date\" = \"works\".\"first_publication_date\" || '-01'\n          ) or (\n            \"works\".\"first_publication_precision\" = 'day'\n            and length(\"works\".\"first_publication_date\") = 10\n            and substr(\"works\".\"first_publication_date\", 5, 1) = '-'\n            and substr(\"works\".\"first_publication_date\", 8, 1) = '-'\n            and \"works\".\"first_publication_sort_date\" = \"works\".\"first_publication_date\"\n          )\n        )\n      )"
+        }
+      }
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1785312699829,
       "tag": "0006_legal_trish_tilby",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1785319005748,
+      "tag": "0007_milky_omega_red",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1785258818562,
       "tag": "0005_cuddly_bloodscream",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1785312699829,
+      "tag": "0006_legal_trish_tilby",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/pg/0008_gifted_typhoid_mary.sql
+++ b/drizzle/pg/0008_gifted_typhoid_mary.sql
@@ -1,0 +1,187 @@
+CREATE TABLE "description_candidates" (
+	"id" text PRIMARY KEY NOT NULL,
+	"work_id" text NOT NULL,
+	"observation_id" text NOT NULL,
+	"description_class" text NOT NULL,
+	"text_content" text NOT NULL,
+	"text_hash" text NOT NULL,
+	"source_revision" text NOT NULL,
+	"source_policy_version" text NOT NULL,
+	"description_policy_version" text NOT NULL,
+	"license_name" text,
+	"license_url" text,
+	"attribution_text" text,
+	"derivatives_permitted" boolean,
+	"editor_ref" text,
+	"editorial_reason" text,
+	"editorial_revision" text,
+	"model_id" text,
+	"model_version" text,
+	"prompt_version" text,
+	"generation_input_hash" text,
+	"generated_at" bigint,
+	"generation_duration_ms" bigint,
+	"input_tokens" integer,
+	"output_tokens" integer,
+	"cost_microusd" bigint,
+	"quality_score" double precision,
+	"ambiguous_identity" boolean DEFAULT false NOT NULL,
+	"sensitive_content" boolean DEFAULT false NOT NULL,
+	"created_at" bigint NOT NULL,
+	CONSTRAINT "description_candidates_class_ck" CHECK ("description_candidates"."description_class" in ('licensed_verbatim', 'bukie_editorial', 'model_assisted_candidate')),
+	CONSTRAINT "description_candidates_text_ck" CHECK (length(trim("description_candidates"."text_content")) > 0 and length("description_candidates"."text_hash") = 64),
+	CONSTRAINT "description_candidates_versions_ck" CHECK (length(trim("description_candidates"."source_revision")) > 0
+        and length(trim("description_candidates"."source_policy_version")) > 0
+        and length(trim("description_candidates"."description_policy_version")) > 0),
+	CONSTRAINT "description_candidates_license_ck" CHECK ((
+        "description_candidates"."description_class" = 'licensed_verbatim'
+        and length(trim("description_candidates"."license_name")) > 0
+        and length(trim("description_candidates"."license_url")) > 0
+        and "description_candidates"."derivatives_permitted" is not null
+      ) or (
+        "description_candidates"."description_class" <> 'licensed_verbatim'
+        and "description_candidates"."license_name" is null
+        and "description_candidates"."license_url" is null
+        and "description_candidates"."attribution_text" is null
+        and "description_candidates"."derivatives_permitted" is null
+      )),
+	CONSTRAINT "description_candidates_editorial_ck" CHECK ((
+        "description_candidates"."description_class" = 'bukie_editorial'
+        and length(trim("description_candidates"."editor_ref")) > 0
+        and length(trim("description_candidates"."editorial_reason")) > 0
+        and length(trim("description_candidates"."editorial_revision")) > 0
+      ) or (
+        "description_candidates"."description_class" <> 'bukie_editorial'
+        and "description_candidates"."editor_ref" is null
+        and "description_candidates"."editorial_reason" is null
+        and "description_candidates"."editorial_revision" is null
+      )),
+	CONSTRAINT "description_candidates_model_ck" CHECK ((
+        "description_candidates"."description_class" = 'model_assisted_candidate'
+        and length(trim("description_candidates"."model_id")) > 0
+        and length(trim("description_candidates"."model_version")) > 0
+        and length(trim("description_candidates"."prompt_version")) > 0
+        and length("description_candidates"."generation_input_hash") = 64
+        and "description_candidates"."generated_at" is not null
+        and "description_candidates"."generation_duration_ms" >= 0
+        and "description_candidates"."input_tokens" >= 0
+        and "description_candidates"."output_tokens" >= 0
+        and "description_candidates"."cost_microusd" >= 0
+      ) or (
+        "description_candidates"."description_class" <> 'model_assisted_candidate'
+        and "description_candidates"."model_id" is null
+        and "description_candidates"."model_version" is null
+        and "description_candidates"."prompt_version" is null
+        and "description_candidates"."generation_input_hash" is null
+        and "description_candidates"."generated_at" is null
+        and "description_candidates"."generation_duration_ms" is null
+        and "description_candidates"."input_tokens" is null
+        and "description_candidates"."output_tokens" is null
+        and "description_candidates"."cost_microusd" is null
+      )),
+	CONSTRAINT "description_candidates_quality_ck" CHECK ("description_candidates"."quality_score" is null or "description_candidates"."quality_score" between 0 and 100)
+);
+--> statement-breakpoint
+CREATE TABLE "description_claim_evidence" (
+	"claim_id" text NOT NULL,
+	"observation_id" text NOT NULL,
+	CONSTRAINT "description_claim_evidence_pk" PRIMARY KEY("claim_id","observation_id")
+);
+--> statement-breakpoint
+CREATE TABLE "description_claims" (
+	"id" text PRIMARY KEY NOT NULL,
+	"candidate_id" text NOT NULL,
+	"position" integer NOT NULL,
+	"claim_text" text NOT NULL,
+	"claim_hash" text NOT NULL,
+	CONSTRAINT "description_claims_content_ck" CHECK ("description_claims"."position" >= 0
+        and length(trim("description_claims"."claim_text")) > 0
+        and length("description_claims"."claim_hash") = 64)
+);
+--> statement-breakpoint
+CREATE TABLE "description_decision_heads" (
+	"candidate_id" text PRIMARY KEY NOT NULL,
+	"decision_id" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "description_decisions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"candidate_id" text NOT NULL,
+	"state" text NOT NULL,
+	"rejection_codes_json" jsonb NOT NULL,
+	"warning_codes_json" jsonb NOT NULL,
+	"reviewer_ref" text,
+	"review_reason" text,
+	"previous_decision_id" text,
+	"policy_version" text NOT NULL,
+	"decided_at" bigint NOT NULL,
+	CONSTRAINT "description_decisions_state_ck" CHECK ("description_decisions"."state" in ('candidate', 'review_required', 'paused', 'rejected', 'eligible', 'withdrawn', 'invalidated')),
+	CONSTRAINT "description_decisions_review_ck" CHECK (("description_decisions"."reviewer_ref" is null and "description_decisions"."review_reason" is null)
+        or (
+          length(trim("description_decisions"."reviewer_ref")) > 0
+          and length(trim("description_decisions"."review_reason")) > 0
+        )),
+	CONSTRAINT "description_decisions_policy_ck" CHECK (length(trim("description_decisions"."policy_version")) > 0)
+);
+--> statement-breakpoint
+CREATE TABLE "description_projection_heads" (
+	"work_id" text PRIMARY KEY NOT NULL,
+	"projection_id" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "description_projections" (
+	"id" text PRIMARY KEY NOT NULL,
+	"work_id" text NOT NULL,
+	"candidate_id" text,
+	"state" text NOT NULL,
+	"previous_projection_id" text,
+	"reason_code" text NOT NULL,
+	"actor_ref" text NOT NULL,
+	"policy_version" text NOT NULL,
+	"projected_at" bigint NOT NULL,
+	CONSTRAINT "description_projections_state_ck" CHECK ("description_projections"."state" in ('selected', 'withdrawn', 'invalidated', 'rolled_back')),
+	CONSTRAINT "description_projections_selection_ck" CHECK (("description_projections"."state" in ('selected', 'rolled_back') and "description_projections"."candidate_id" is not null)
+        or ("description_projections"."state" in ('withdrawn', 'invalidated') and "description_projections"."candidate_id" is null)),
+	CONSTRAINT "description_projections_nonempty_ck" CHECK (length(trim("description_projections"."reason_code")) > 0
+        and length(trim("description_projections"."actor_ref")) > 0
+        and length(trim("description_projections"."policy_version")) > 0)
+);
+--> statement-breakpoint
+CREATE TABLE "description_review_queue" (
+	"candidate_id" text PRIMARY KEY NOT NULL,
+	"state" text NOT NULL,
+	"priority" integer NOT NULL,
+	"reason_codes_json" jsonb NOT NULL,
+	"queued_at" bigint NOT NULL,
+	"updated_at" bigint NOT NULL,
+	"reviewer_ref" text,
+	CONSTRAINT "description_review_queue_state_ck" CHECK ("description_review_queue"."state" in ('queued', 'claimed', 'completed', 'cancelled')),
+	CONSTRAINT "description_review_queue_values_ck" CHECK ("description_review_queue"."priority" >= 0
+        and ("description_review_queue"."reviewer_ref" is null or length(trim("description_review_queue"."reviewer_ref")) > 0))
+);
+--> statement-breakpoint
+ALTER TABLE "description_candidates" ADD CONSTRAINT "description_candidates_work_id_works_id_fk" FOREIGN KEY ("work_id") REFERENCES "public"."works"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "description_candidates" ADD CONSTRAINT "description_candidates_observation_id_field_observations_id_fk" FOREIGN KEY ("observation_id") REFERENCES "public"."field_observations"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "description_claim_evidence" ADD CONSTRAINT "description_claim_evidence_claim_id_description_claims_id_fk" FOREIGN KEY ("claim_id") REFERENCES "public"."description_claims"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "description_claim_evidence" ADD CONSTRAINT "description_claim_evidence_observation_id_field_observations_id_fk" FOREIGN KEY ("observation_id") REFERENCES "public"."field_observations"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "description_claims" ADD CONSTRAINT "description_claims_candidate_id_description_candidates_id_fk" FOREIGN KEY ("candidate_id") REFERENCES "public"."description_candidates"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "description_decision_heads" ADD CONSTRAINT "description_decision_heads_candidate_id_description_candidates_id_fk" FOREIGN KEY ("candidate_id") REFERENCES "public"."description_candidates"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "description_decision_heads" ADD CONSTRAINT "description_decision_heads_decision_id_description_decisions_id_fk" FOREIGN KEY ("decision_id") REFERENCES "public"."description_decisions"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "description_decisions" ADD CONSTRAINT "description_decisions_candidate_id_description_candidates_id_fk" FOREIGN KEY ("candidate_id") REFERENCES "public"."description_candidates"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "description_decisions" ADD CONSTRAINT "description_decisions_previous_decision_id_description_decisions_id_fk" FOREIGN KEY ("previous_decision_id") REFERENCES "public"."description_decisions"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "description_projection_heads" ADD CONSTRAINT "description_projection_heads_work_id_works_id_fk" FOREIGN KEY ("work_id") REFERENCES "public"."works"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "description_projection_heads" ADD CONSTRAINT "description_projection_heads_projection_id_description_projections_id_fk" FOREIGN KEY ("projection_id") REFERENCES "public"."description_projections"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "description_projections" ADD CONSTRAINT "description_projections_work_id_works_id_fk" FOREIGN KEY ("work_id") REFERENCES "public"."works"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "description_projections" ADD CONSTRAINT "description_projections_candidate_id_description_candidates_id_fk" FOREIGN KEY ("candidate_id") REFERENCES "public"."description_candidates"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "description_projections" ADD CONSTRAINT "description_projections_previous_projection_id_description_projections_id_fk" FOREIGN KEY ("previous_projection_id") REFERENCES "public"."description_projections"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "description_review_queue" ADD CONSTRAINT "description_review_queue_candidate_id_description_candidates_id_fk" FOREIGN KEY ("candidate_id") REFERENCES "public"."description_candidates"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "description_candidates_observation_uq" ON "description_candidates" USING btree ("observation_id");--> statement-breakpoint
+CREATE INDEX "description_candidates_work_created_idx" ON "description_candidates" USING btree ("work_id","created_at");--> statement-breakpoint
+CREATE INDEX "description_claim_evidence_observation_idx" ON "description_claim_evidence" USING btree ("observation_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "description_claims_position_uq" ON "description_claims" USING btree ("candidate_id","position");--> statement-breakpoint
+CREATE INDEX "description_claims_candidate_idx" ON "description_claims" USING btree ("candidate_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "description_decision_heads_decision_uq" ON "description_decision_heads" USING btree ("decision_id");--> statement-breakpoint
+CREATE INDEX "description_decisions_candidate_history_idx" ON "description_decisions" USING btree ("candidate_id","decided_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "description_projection_heads_projection_uq" ON "description_projection_heads" USING btree ("projection_id");--> statement-breakpoint
+CREATE INDEX "description_projections_work_history_idx" ON "description_projections" USING btree ("work_id","projected_at");--> statement-breakpoint
+CREATE INDEX "description_review_queue_active_idx" ON "description_review_queue" USING btree ("state","priority","queued_at");

--- a/drizzle/pg/0009_moaning_catseye.sql
+++ b/drizzle/pg/0009_moaning_catseye.sql
@@ -1,0 +1,24 @@
+ALTER TABLE "description_candidates" DROP CONSTRAINT "description_candidates_license_ck";--> statement-breakpoint
+ALTER TABLE "description_candidates" ADD COLUMN "licensed_source_text_hash" text;--> statement-breakpoint
+ALTER TABLE "description_candidates" ADD COLUMN "licensed_text_transformed" boolean;--> statement-breakpoint
+UPDATE "description_candidates"
+SET
+  "licensed_source_text_hash" = "text_hash",
+  "licensed_text_transformed" = false
+WHERE "description_class" = 'licensed_verbatim';--> statement-breakpoint
+ALTER TABLE "description_candidates" ADD CONSTRAINT "description_candidates_license_ck" CHECK ((
+        "description_candidates"."description_class" = 'licensed_verbatim'
+        and length(trim("description_candidates"."license_name")) > 0
+        and length(trim("description_candidates"."license_url")) > 0
+        and "description_candidates"."derivatives_permitted" is not null
+        and length("description_candidates"."licensed_source_text_hash") = 64
+        and "description_candidates"."licensed_text_transformed" is not null
+      ) or (
+        "description_candidates"."description_class" <> 'licensed_verbatim'
+        and "description_candidates"."license_name" is null
+        and "description_candidates"."license_url" is null
+        and "description_candidates"."attribution_text" is null
+        and "description_candidates"."derivatives_permitted" is null
+        and "description_candidates"."licensed_source_text_hash" is null
+        and "description_candidates"."licensed_text_transformed" is null
+      ));

--- a/drizzle/pg/meta/0008_snapshot.json
+++ b/drizzle/pg/meta/0008_snapshot.json
@@ -1,0 +1,3518 @@
+{
+  "id": "32ab3ae9-c3bb-4fd1-8773-bf3a0a7473a0",
+  "prevId": "543da6a3-e3a7-47bb-988d-d6f1f72bbb49",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.authors": {
+      "name": "authors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_name": {
+          "name": "sort_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "authors_sort_name_idx": {
+          "name": "authors_sort_name_idx",
+          "columns": [
+            {
+              "expression": "sort_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "authors_name_nonempty_ck": {
+          "name": "authors_name_nonempty_ck",
+          "value": "length(trim(\"authors\".\"display_name\")) > 0"
+        },
+        "authors_sort_name_ck": {
+          "name": "authors_sort_name_ck",
+          "value": "\"authors\".\"sort_name\" is null or length(trim(\"authors\".\"sort_name\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.catalog_change_events": {
+      "name": "catalog_change_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "catalog_change_events_type_created_idx": {
+          "name": "catalog_change_events_type_created_idx",
+          "columns": [
+            {
+              "expression": "change_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_change_events_type_ck": {
+          "name": "catalog_change_events_type_ck",
+          "value": "\"catalog_change_events\".\"change_type\" in ('work_merge', 'work_split', 'edition_reassignment')"
+        },
+        "catalog_change_events_nonempty_ck": {
+          "name": "catalog_change_events_nonempty_ck",
+          "value": "length(trim(\"catalog_change_events\".\"actor_ref\")) > 0 and length(trim(\"catalog_change_events\".\"reason\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "categories_slug_uq": {
+          "name": "categories_slug_uq",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "categories_nonempty_ck": {
+          "name": "categories_nonempty_ck",
+          "value": "length(trim(\"categories\".\"slug\")) > 0 and length(trim(\"categories\".\"label\")) > 0"
+        },
+        "categories_status_ck": {
+          "name": "categories_status_ck",
+          "value": "\"categories\".\"status\" in ('active', 'retired')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.cover_assets": {
+      "name": "cover_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_policy_id": {
+          "name": "source_policy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cover_assets_object_key_uq": {
+          "name": "cover_assets_object_key_uq",
+          "columns": [
+            {
+              "expression": "object_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cover_assets_source_policy_id_metadata_sources_id_fk": {
+          "name": "cover_assets_source_policy_id_metadata_sources_id_fk",
+          "tableFrom": "cover_assets",
+          "tableTo": "metadata_sources",
+          "columnsFrom": [
+            "source_policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cover_assets_object_key_ck": {
+          "name": "cover_assets_object_key_ck",
+          "value": "length(trim(\"cover_assets\".\"object_key\")) > 0 and substring(\"cover_assets\".\"object_key\" from 1 for 8) = '/covers/'"
+        },
+        "cover_assets_state_ck": {
+          "name": "cover_assets_state_ck",
+          "value": "\"cover_assets\".\"state\" in ('available', 'missing', 'withdrawn', 'failed')"
+        },
+        "cover_assets_dimensions_ck": {
+          "name": "cover_assets_dimensions_ck",
+          "value": "(\"cover_assets\".\"width\" is null or \"cover_assets\".\"width\" > 0)\n        and (\"cover_assets\".\"height\" is null or \"cover_assets\".\"height\" > 0)\n        and (\"cover_assets\".\"bytes\" is null or \"cover_assets\".\"bytes\" > 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.description_candidates": {
+      "name": "description_candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observation_id": {
+          "name": "observation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_class": {
+          "name": "description_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_hash": {
+          "name": "text_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_policy_version": {
+          "name": "source_policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_policy_version": {
+          "name": "description_policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "license_name": {
+          "name": "license_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_url": {
+          "name": "license_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution_text": {
+          "name": "attribution_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "derivatives_permitted": {
+          "name": "derivatives_permitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editor_ref": {
+          "name": "editor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editorial_reason": {
+          "name": "editorial_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editorial_revision": {
+          "name": "editorial_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation_input_hash": {
+          "name": "generation_input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation_duration_ms": {
+          "name": "generation_duration_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_microusd": {
+          "name": "cost_microusd",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ambiguous_identity": {
+          "name": "ambiguous_identity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sensitive_content": {
+          "name": "sensitive_content",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "description_candidates_observation_uq": {
+          "name": "description_candidates_observation_uq",
+          "columns": [
+            {
+              "expression": "observation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "description_candidates_work_created_idx": {
+          "name": "description_candidates_work_created_idx",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "description_candidates_work_id_works_id_fk": {
+          "name": "description_candidates_work_id_works_id_fk",
+          "tableFrom": "description_candidates",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_candidates_observation_id_field_observations_id_fk": {
+          "name": "description_candidates_observation_id_field_observations_id_fk",
+          "tableFrom": "description_candidates",
+          "tableTo": "field_observations",
+          "columnsFrom": [
+            "observation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "description_candidates_class_ck": {
+          "name": "description_candidates_class_ck",
+          "value": "\"description_candidates\".\"description_class\" in ('licensed_verbatim', 'bukie_editorial', 'model_assisted_candidate')"
+        },
+        "description_candidates_text_ck": {
+          "name": "description_candidates_text_ck",
+          "value": "length(trim(\"description_candidates\".\"text_content\")) > 0 and length(\"description_candidates\".\"text_hash\") = 64"
+        },
+        "description_candidates_versions_ck": {
+          "name": "description_candidates_versions_ck",
+          "value": "length(trim(\"description_candidates\".\"source_revision\")) > 0\n        and length(trim(\"description_candidates\".\"source_policy_version\")) > 0\n        and length(trim(\"description_candidates\".\"description_policy_version\")) > 0"
+        },
+        "description_candidates_license_ck": {
+          "name": "description_candidates_license_ck",
+          "value": "(\n        \"description_candidates\".\"description_class\" = 'licensed_verbatim'\n        and length(trim(\"description_candidates\".\"license_name\")) > 0\n        and length(trim(\"description_candidates\".\"license_url\")) > 0\n        and \"description_candidates\".\"derivatives_permitted\" is not null\n      ) or (\n        \"description_candidates\".\"description_class\" <> 'licensed_verbatim'\n        and \"description_candidates\".\"license_name\" is null\n        and \"description_candidates\".\"license_url\" is null\n        and \"description_candidates\".\"attribution_text\" is null\n        and \"description_candidates\".\"derivatives_permitted\" is null\n      )"
+        },
+        "description_candidates_editorial_ck": {
+          "name": "description_candidates_editorial_ck",
+          "value": "(\n        \"description_candidates\".\"description_class\" = 'bukie_editorial'\n        and length(trim(\"description_candidates\".\"editor_ref\")) > 0\n        and length(trim(\"description_candidates\".\"editorial_reason\")) > 0\n        and length(trim(\"description_candidates\".\"editorial_revision\")) > 0\n      ) or (\n        \"description_candidates\".\"description_class\" <> 'bukie_editorial'\n        and \"description_candidates\".\"editor_ref\" is null\n        and \"description_candidates\".\"editorial_reason\" is null\n        and \"description_candidates\".\"editorial_revision\" is null\n      )"
+        },
+        "description_candidates_model_ck": {
+          "name": "description_candidates_model_ck",
+          "value": "(\n        \"description_candidates\".\"description_class\" = 'model_assisted_candidate'\n        and length(trim(\"description_candidates\".\"model_id\")) > 0\n        and length(trim(\"description_candidates\".\"model_version\")) > 0\n        and length(trim(\"description_candidates\".\"prompt_version\")) > 0\n        and length(\"description_candidates\".\"generation_input_hash\") = 64\n        and \"description_candidates\".\"generated_at\" is not null\n        and \"description_candidates\".\"generation_duration_ms\" >= 0\n        and \"description_candidates\".\"input_tokens\" >= 0\n        and \"description_candidates\".\"output_tokens\" >= 0\n        and \"description_candidates\".\"cost_microusd\" >= 0\n      ) or (\n        \"description_candidates\".\"description_class\" <> 'model_assisted_candidate'\n        and \"description_candidates\".\"model_id\" is null\n        and \"description_candidates\".\"model_version\" is null\n        and \"description_candidates\".\"prompt_version\" is null\n        and \"description_candidates\".\"generation_input_hash\" is null\n        and \"description_candidates\".\"generated_at\" is null\n        and \"description_candidates\".\"generation_duration_ms\" is null\n        and \"description_candidates\".\"input_tokens\" is null\n        and \"description_candidates\".\"output_tokens\" is null\n        and \"description_candidates\".\"cost_microusd\" is null\n      )"
+        },
+        "description_candidates_quality_ck": {
+          "name": "description_candidates_quality_ck",
+          "value": "\"description_candidates\".\"quality_score\" is null or \"description_candidates\".\"quality_score\" between 0 and 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.description_claim_evidence": {
+      "name": "description_claim_evidence",
+      "schema": "",
+      "columns": {
+        "claim_id": {
+          "name": "claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observation_id": {
+          "name": "observation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "description_claim_evidence_observation_idx": {
+          "name": "description_claim_evidence_observation_idx",
+          "columns": [
+            {
+              "expression": "observation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "description_claim_evidence_claim_id_description_claims_id_fk": {
+          "name": "description_claim_evidence_claim_id_description_claims_id_fk",
+          "tableFrom": "description_claim_evidence",
+          "tableTo": "description_claims",
+          "columnsFrom": [
+            "claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "description_claim_evidence_observation_id_field_observations_id_fk": {
+          "name": "description_claim_evidence_observation_id_field_observations_id_fk",
+          "tableFrom": "description_claim_evidence",
+          "tableTo": "field_observations",
+          "columnsFrom": [
+            "observation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "description_claim_evidence_pk": {
+          "name": "description_claim_evidence_pk",
+          "columns": [
+            "claim_id",
+            "observation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.description_claims": {
+      "name": "description_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_text": {
+          "name": "claim_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_hash": {
+          "name": "claim_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "description_claims_position_uq": {
+          "name": "description_claims_position_uq",
+          "columns": [
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "description_claims_candidate_idx": {
+          "name": "description_claims_candidate_idx",
+          "columns": [
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "description_claims_candidate_id_description_candidates_id_fk": {
+          "name": "description_claims_candidate_id_description_candidates_id_fk",
+          "tableFrom": "description_claims",
+          "tableTo": "description_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "description_claims_content_ck": {
+          "name": "description_claims_content_ck",
+          "value": "\"description_claims\".\"position\" >= 0\n        and length(trim(\"description_claims\".\"claim_text\")) > 0\n        and length(\"description_claims\".\"claim_hash\") = 64"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.description_decision_heads": {
+      "name": "description_decision_heads",
+      "schema": "",
+      "columns": {
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "decision_id": {
+          "name": "decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "description_decision_heads_decision_uq": {
+          "name": "description_decision_heads_decision_uq",
+          "columns": [
+            {
+              "expression": "decision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "description_decision_heads_candidate_id_description_candidates_id_fk": {
+          "name": "description_decision_heads_candidate_id_description_candidates_id_fk",
+          "tableFrom": "description_decision_heads",
+          "tableTo": "description_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_decision_heads_decision_id_description_decisions_id_fk": {
+          "name": "description_decision_heads_decision_id_description_decisions_id_fk",
+          "tableFrom": "description_decision_heads",
+          "tableTo": "description_decisions",
+          "columnsFrom": [
+            "decision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.description_decisions": {
+      "name": "description_decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_codes_json": {
+          "name": "rejection_codes_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "warning_codes_json": {
+          "name": "warning_codes_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer_ref": {
+          "name": "reviewer_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_reason": {
+          "name": "review_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_decision_id": {
+          "name": "previous_decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "description_decisions_candidate_history_idx": {
+          "name": "description_decisions_candidate_history_idx",
+          "columns": [
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "description_decisions_candidate_id_description_candidates_id_fk": {
+          "name": "description_decisions_candidate_id_description_candidates_id_fk",
+          "tableFrom": "description_decisions",
+          "tableTo": "description_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_decisions_previous_decision_id_description_decisions_id_fk": {
+          "name": "description_decisions_previous_decision_id_description_decisions_id_fk",
+          "tableFrom": "description_decisions",
+          "tableTo": "description_decisions",
+          "columnsFrom": [
+            "previous_decision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "description_decisions_state_ck": {
+          "name": "description_decisions_state_ck",
+          "value": "\"description_decisions\".\"state\" in ('candidate', 'review_required', 'paused', 'rejected', 'eligible', 'withdrawn', 'invalidated')"
+        },
+        "description_decisions_review_ck": {
+          "name": "description_decisions_review_ck",
+          "value": "(\"description_decisions\".\"reviewer_ref\" is null and \"description_decisions\".\"review_reason\" is null)\n        or (\n          length(trim(\"description_decisions\".\"reviewer_ref\")) > 0\n          and length(trim(\"description_decisions\".\"review_reason\")) > 0\n        )"
+        },
+        "description_decisions_policy_ck": {
+          "name": "description_decisions_policy_ck",
+          "value": "length(trim(\"description_decisions\".\"policy_version\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.description_projection_heads": {
+      "name": "description_projection_heads",
+      "schema": "",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "projection_id": {
+          "name": "projection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "description_projection_heads_projection_uq": {
+          "name": "description_projection_heads_projection_uq",
+          "columns": [
+            {
+              "expression": "projection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "description_projection_heads_work_id_works_id_fk": {
+          "name": "description_projection_heads_work_id_works_id_fk",
+          "tableFrom": "description_projection_heads",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_projection_heads_projection_id_description_projections_id_fk": {
+          "name": "description_projection_heads_projection_id_description_projections_id_fk",
+          "tableFrom": "description_projection_heads",
+          "tableTo": "description_projections",
+          "columnsFrom": [
+            "projection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.description_projections": {
+      "name": "description_projections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_projection_id": {
+          "name": "previous_projection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projected_at": {
+          "name": "projected_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "description_projections_work_history_idx": {
+          "name": "description_projections_work_history_idx",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "projected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "description_projections_work_id_works_id_fk": {
+          "name": "description_projections_work_id_works_id_fk",
+          "tableFrom": "description_projections",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_projections_candidate_id_description_candidates_id_fk": {
+          "name": "description_projections_candidate_id_description_candidates_id_fk",
+          "tableFrom": "description_projections",
+          "tableTo": "description_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_projections_previous_projection_id_description_projections_id_fk": {
+          "name": "description_projections_previous_projection_id_description_projections_id_fk",
+          "tableFrom": "description_projections",
+          "tableTo": "description_projections",
+          "columnsFrom": [
+            "previous_projection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "description_projections_state_ck": {
+          "name": "description_projections_state_ck",
+          "value": "\"description_projections\".\"state\" in ('selected', 'withdrawn', 'invalidated', 'rolled_back')"
+        },
+        "description_projections_selection_ck": {
+          "name": "description_projections_selection_ck",
+          "value": "(\"description_projections\".\"state\" in ('selected', 'rolled_back') and \"description_projections\".\"candidate_id\" is not null)\n        or (\"description_projections\".\"state\" in ('withdrawn', 'invalidated') and \"description_projections\".\"candidate_id\" is null)"
+        },
+        "description_projections_nonempty_ck": {
+          "name": "description_projections_nonempty_ck",
+          "value": "length(trim(\"description_projections\".\"reason_code\")) > 0\n        and length(trim(\"description_projections\".\"actor_ref\")) > 0\n        and length(trim(\"description_projections\".\"policy_version\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.description_review_queue": {
+      "name": "description_review_queue",
+      "schema": "",
+      "columns": {
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_codes_json": {
+          "name": "reason_codes_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer_ref": {
+          "name": "reviewer_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "description_review_queue_active_idx": {
+          "name": "description_review_queue_active_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "queued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "description_review_queue_candidate_id_description_candidates_id_fk": {
+          "name": "description_review_queue_candidate_id_description_candidates_id_fk",
+          "tableFrom": "description_review_queue",
+          "tableTo": "description_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "description_review_queue_state_ck": {
+          "name": "description_review_queue_state_ck",
+          "value": "\"description_review_queue\".\"state\" in ('queued', 'claimed', 'completed', 'cancelled')"
+        },
+        "description_review_queue_values_ck": {
+          "name": "description_review_queue_values_ck",
+          "value": "\"description_review_queue\".\"priority\" >= 0\n        and (\"description_review_queue\".\"reviewer_ref\" is null or length(trim(\"description_review_queue\".\"reviewer_ref\")) > 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.edition_covers": {
+      "name": "edition_covers",
+      "schema": "",
+      "columns": {
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_asset_id": {
+          "name": "cover_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "edition_covers_position_uq": {
+          "name": "edition_covers_position_uq",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_covers_primary_uq": {
+          "name": "edition_covers_primary_uq",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"edition_covers\".\"is_primary\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_covers_owner_position_idx": {
+          "name": "edition_covers_owner_position_idx",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_covers_primary_lookup_idx": {
+          "name": "edition_covers_primary_lookup_idx",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "edition_covers_edition_id_editions_id_fk": {
+          "name": "edition_covers_edition_id_editions_id_fk",
+          "tableFrom": "edition_covers",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edition_covers_cover_asset_id_cover_assets_id_fk": {
+          "name": "edition_covers_cover_asset_id_cover_assets_id_fk",
+          "tableFrom": "edition_covers",
+          "tableTo": "cover_assets",
+          "columnsFrom": [
+            "cover_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edition_covers_pk": {
+          "name": "edition_covers_pk",
+          "columns": [
+            "edition_id",
+            "cover_asset_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "edition_covers_position_ck": {
+          "name": "edition_covers_position_ck",
+          "value": "\"edition_covers\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.edition_identifiers": {
+      "name": "edition_identifiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheme": {
+          "name": "scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_normalized": {
+          "name": "value_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_display": {
+          "name": "value_display",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "edition_identifiers_value_uq": {
+          "name": "edition_identifiers_value_uq",
+          "columns": [
+            {
+              "expression": "scheme",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_identifiers_primary_uq": {
+          "name": "edition_identifiers_primary_uq",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"edition_identifiers\".\"is_primary\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_identifiers_owner_idx": {
+          "name": "edition_identifiers_owner_idx",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "edition_identifiers_edition_id_editions_id_fk": {
+          "name": "edition_identifiers_edition_id_editions_id_fk",
+          "tableFrom": "edition_identifiers",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "edition_identifiers_scheme_ck": {
+          "name": "edition_identifiers_scheme_ck",
+          "value": "\"edition_identifiers\".\"scheme\" in ('isbn10', 'isbn13')"
+        },
+        "edition_identifiers_value_ck": {
+          "name": "edition_identifiers_value_ck",
+          "value": "length(trim(\"edition_identifiers\".\"value_normalized\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.edition_languages": {
+      "name": "edition_languages",
+      "schema": "",
+      "columns": {
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_tag": {
+          "name": "language_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "edition_languages_position_uq": {
+          "name": "edition_languages_position_uq",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_languages_owner_position_idx": {
+          "name": "edition_languages_owner_position_idx",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_languages_language_edition_idx": {
+          "name": "edition_languages_language_edition_idx",
+          "columns": [
+            {
+              "expression": "language_tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "edition_languages_edition_id_editions_id_fk": {
+          "name": "edition_languages_edition_id_editions_id_fk",
+          "tableFrom": "edition_languages",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edition_languages_language_tag_languages_tag_fk": {
+          "name": "edition_languages_language_tag_languages_tag_fk",
+          "tableFrom": "edition_languages",
+          "tableTo": "languages",
+          "columnsFrom": [
+            "language_tag"
+          ],
+          "columnsTo": [
+            "tag"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edition_languages_pk": {
+          "name": "edition_languages_pk",
+          "columns": [
+            "edition_id",
+            "language_tag"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "edition_languages_position_ck": {
+          "name": "edition_languages_position_ck",
+          "value": "\"edition_languages\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.edition_publishers": {
+      "name": "edition_publishers",
+      "schema": "",
+      "columns": {
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publisher_id": {
+          "name": "publisher_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "edition_publishers_position_uq": {
+          "name": "edition_publishers_position_uq",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_publishers_owner_position_idx": {
+          "name": "edition_publishers_owner_position_idx",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "edition_publishers_edition_id_editions_id_fk": {
+          "name": "edition_publishers_edition_id_editions_id_fk",
+          "tableFrom": "edition_publishers",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edition_publishers_publisher_id_publishers_id_fk": {
+          "name": "edition_publishers_publisher_id_publishers_id_fk",
+          "tableFrom": "edition_publishers",
+          "tableTo": "publishers",
+          "columnsFrom": [
+            "publisher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edition_publishers_pk": {
+          "name": "edition_publishers_pk",
+          "columns": [
+            "edition_id",
+            "publisher_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "edition_publishers_position_ck": {
+          "name": "edition_publishers_position_ck",
+          "value": "\"edition_publishers\".\"position\" >= 0"
+        },
+        "edition_publishers_role_ck": {
+          "name": "edition_publishers_role_ck",
+          "value": "\"edition_publishers\".\"role\" is null or \"edition_publishers\".\"role\" in ('publisher', 'co_publisher', 'imprint', 'distributor')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.editions": {
+      "name": "editions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_date": {
+          "name": "publication_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_precision": {
+          "name": "publication_precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_sort_date": {
+          "name": "publication_sort_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pages": {
+          "name": "pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cataloged_at": {
+          "name": "cataloged_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "editions_work_id_idx": {
+          "name": "editions_work_id_idx",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "editions_publication_sort_work_idx": {
+          "name": "editions_publication_sort_work_idx",
+          "columns": [
+            {
+              "expression": "publication_sort_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "editions_cataloged_work_idx": {
+          "name": "editions_cataloged_work_idx",
+          "columns": [
+            {
+              "expression": "cataloged_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "editions_work_id_works_id_fk": {
+          "name": "editions_work_id_works_id_fk",
+          "tableFrom": "editions",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "editions_title_ck": {
+          "name": "editions_title_ck",
+          "value": "\"editions\".\"title\" is null or length(trim(\"editions\".\"title\")) > 0"
+        },
+        "editions_subtitle_ck": {
+          "name": "editions_subtitle_ck",
+          "value": "\"editions\".\"subtitle\" is null or length(trim(\"editions\".\"subtitle\")) > 0"
+        },
+        "editions_format_ck": {
+          "name": "editions_format_ck",
+          "value": "\"editions\".\"format\" is null or \"editions\".\"format\" in ('hardcover', 'paperback', 'ebook', 'audiobook', 'other')"
+        },
+        "editions_pages_ck": {
+          "name": "editions_pages_ck",
+          "value": "\"editions\".\"pages\" is null or \"editions\".\"pages\" > 0"
+        },
+        "editions_publication_precision_ck": {
+          "name": "editions_publication_precision_ck",
+          "value": "\"editions\".\"publication_precision\" is null or \"editions\".\"publication_precision\" in ('year', 'month', 'day')"
+        },
+        "editions_publication_date_ck": {
+          "name": "editions_publication_date_ck",
+          "value": "(\n        \"editions\".\"publication_date\" is null\n        and \"editions\".\"publication_precision\" is null\n        and \"editions\".\"publication_sort_date\" is null\n      ) or (\n        \"editions\".\"publication_precision\" = 'year'\n        and length(\"editions\".\"publication_date\") = 4\n        and \"editions\".\"publication_sort_date\" = \"editions\".\"publication_date\" || '-01-01'\n      ) or (\n        \"editions\".\"publication_precision\" = 'month'\n        and length(\"editions\".\"publication_date\") = 7\n        and substring(\"editions\".\"publication_date\" from 5 for 1) = '-'\n        and \"editions\".\"publication_sort_date\" = \"editions\".\"publication_date\" || '-01'\n      ) or (\n        \"editions\".\"publication_precision\" = 'day'\n        and length(\"editions\".\"publication_date\") = 10\n        and substring(\"editions\".\"publication_date\" from 5 for 1) = '-'\n        and substring(\"editions\".\"publication_date\" from 8 for 1) = '-'\n        and \"editions\".\"publication_sort_date\" = \"editions\".\"publication_date\"\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.entity_aliases": {
+      "name": "entity_aliases",
+      "schema": "",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_id": {
+          "name": "from_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_id": {
+          "name": "to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "entity_aliases_target_idx": {
+          "name": "entity_aliases_target_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "entity_aliases_pk": {
+          "name": "entity_aliases_pk",
+          "columns": [
+            "entity_type",
+            "from_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "entity_aliases_ck": {
+          "name": "entity_aliases_ck",
+          "value": "\"entity_aliases\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset')\n        and \"entity_aliases\".\"from_id\" <> \"entity_aliases\".\"to_id\"\n        and length(trim(\"entity_aliases\".\"reason\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.field_observations": {
+      "name": "field_observations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_json": {
+          "name": "value_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comparison_hash": {
+          "name": "comparison_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provenance_kind": {
+          "name": "provenance_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_modified_at": {
+          "name": "source_modified_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retrieved_at": {
+          "name": "retrieved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mapping_confidence": {
+          "name": "mapping_confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "derivation_name": {
+          "name": "derivation_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "derivation_version": {
+          "name": "derivation_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_ids_json": {
+          "name": "parent_ids_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "field_observations_identity_uq": {
+          "name": "field_observations_identity_uq",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "field_observations_source_field_state_idx": {
+          "name": "field_observations_source_field_state_idx",
+          "columns": [
+            {
+              "expression": "source_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "field_observations_target_field_idx": {
+          "name": "field_observations_target_field_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "field_observations_source_record_id_source_records_id_fk": {
+          "name": "field_observations_source_record_id_source_records_id_fk",
+          "tableFrom": "field_observations",
+          "tableTo": "source_records",
+          "columnsFrom": [
+            "source_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "field_observations_target_ck": {
+          "name": "field_observations_target_ck",
+          "value": "\"field_observations\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and \"field_observations\".\"field_key\" in ('work.preferred_title', 'work.description', 'work.first_publication_date', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')"
+        },
+        "field_observations_hash_ck": {
+          "name": "field_observations_hash_ck",
+          "value": "length(\"field_observations\".\"comparison_hash\") = 64"
+        },
+        "field_observations_provenance_ck": {
+          "name": "field_observations_provenance_ck",
+          "value": "\"field_observations\".\"provenance_kind\" in ('curated', 'imported', 'derived', 'synthetic')"
+        },
+        "field_observations_state_ck": {
+          "name": "field_observations_state_ck",
+          "value": "\"field_observations\".\"state\" in ('active', 'stale', 'withdrawn', 'invalid')"
+        },
+        "field_observations_confidence_ck": {
+          "name": "field_observations_confidence_ck",
+          "value": "\"field_observations\".\"mapping_confidence\" between 0 and 1"
+        },
+        "field_observations_curated_ck": {
+          "name": "field_observations_curated_ck",
+          "value": "\"field_observations\".\"provenance_kind\" <> 'curated'\n        or (length(trim(\"field_observations\".\"actor_ref\")) > 0 and length(trim(\"field_observations\".\"reason\")) > 0)"
+        },
+        "field_observations_derived_ck": {
+          "name": "field_observations_derived_ck",
+          "value": "\"field_observations\".\"provenance_kind\" <> 'derived'\n        or (\n          length(trim(\"field_observations\".\"derivation_name\")) > 0\n          and length(trim(\"field_observations\".\"derivation_version\")) > 0\n          and \"field_observations\".\"parent_ids_json\" is not null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.field_resolution_heads": {
+      "name": "field_resolution_heads",
+      "schema": "",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution_id": {
+          "name": "resolution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "field_resolution_heads_resolution_uq": {
+          "name": "field_resolution_heads_resolution_uq",
+          "columns": [
+            {
+              "expression": "resolution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "field_resolution_heads_lookup_idx": {
+          "name": "field_resolution_heads_lookup_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "field_resolution_heads_resolution_id_field_resolutions_id_fk": {
+          "name": "field_resolution_heads_resolution_id_field_resolutions_id_fk",
+          "tableFrom": "field_resolution_heads",
+          "tableTo": "field_resolutions",
+          "columnsFrom": [
+            "resolution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "field_resolution_heads_pk": {
+          "name": "field_resolution_heads_pk",
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "field_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "field_resolution_heads_target_ck": {
+          "name": "field_resolution_heads_target_ck",
+          "value": "\"field_resolution_heads\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and \"field_resolution_heads\".\"field_key\" in ('work.preferred_title', 'work.description', 'work.first_publication_date', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.field_resolutions": {
+      "name": "field_resolutions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_observation_id": {
+          "name": "selected_observation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_resolution_id": {
+          "name": "previous_resolution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolver_version": {
+          "name": "resolver_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "field_resolutions_target_history_idx": {
+          "name": "field_resolutions_target_history_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "field_resolutions_selected_observation_id_field_observations_id_fk": {
+          "name": "field_resolutions_selected_observation_id_field_observations_id_fk",
+          "tableFrom": "field_resolutions",
+          "tableTo": "field_observations",
+          "columnsFrom": [
+            "selected_observation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "field_resolutions_previous_resolution_id_field_resolutions_id_fk": {
+          "name": "field_resolutions_previous_resolution_id_field_resolutions_id_fk",
+          "tableFrom": "field_resolutions",
+          "tableTo": "field_resolutions",
+          "columnsFrom": [
+            "previous_resolution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "field_resolutions_target_ck": {
+          "name": "field_resolutions_target_ck",
+          "value": "\"field_resolutions\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and \"field_resolutions\".\"field_key\" in ('work.preferred_title', 'work.description', 'work.first_publication_date', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')"
+        },
+        "field_resolutions_state_ck": {
+          "name": "field_resolutions_state_ck",
+          "value": "\"field_resolutions\".\"state\" in ('present', 'missing', 'conflicting', 'stale', 'withdrawn')"
+        },
+        "field_resolutions_selection_ck": {
+          "name": "field_resolutions_selection_ck",
+          "value": "(\n        \"field_resolutions\".\"state\" in ('present', 'stale')\n        and \"field_resolutions\".\"selected_observation_id\" is not null\n      ) or (\n        \"field_resolutions\".\"state\" in ('missing', 'conflicting', 'withdrawn')\n        and \"field_resolutions\".\"selected_observation_id\" is null\n      )"
+        },
+        "field_resolutions_nonempty_ck": {
+          "name": "field_resolutions_nonempty_ck",
+          "value": "length(trim(\"field_resolutions\".\"reason\")) > 0\n        and length(trim(\"field_resolutions\".\"actor_ref\")) > 0\n        and length(trim(\"field_resolutions\".\"resolver_version\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.languages": {
+      "name": "languages",
+      "schema": "",
+      "columns": {
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "languages_nonempty_ck": {
+          "name": "languages_nonempty_ck",
+          "value": "length(trim(\"languages\".\"tag\")) > 0 and length(trim(\"languages\".\"label\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.metadata_sources": {
+      "name": "metadata_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terms_url": {
+          "name": "terms_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution_url": {
+          "name": "attribution_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_state": {
+          "name": "approval_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata_policy": {
+          "name": "metadata_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_policy": {
+          "name": "asset_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_policy": {
+          "name": "payload_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_interval_ms": {
+          "name": "refresh_interval_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "metadata_sources_key_uq": {
+          "name": "metadata_sources_key_uq",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "metadata_sources_nonempty_ck": {
+          "name": "metadata_sources_nonempty_ck",
+          "value": "length(trim(\"metadata_sources\".\"key\")) > 0 and length(trim(\"metadata_sources\".\"name\")) > 0"
+        },
+        "metadata_sources_approval_state_ck": {
+          "name": "metadata_sources_approval_state_ck",
+          "value": "\"metadata_sources\".\"approval_state\" in ('pending', 'approved', 'suspended', 'retired')"
+        },
+        "metadata_sources_payload_policy_ck": {
+          "name": "metadata_sources_payload_policy_ck",
+          "value": "\"metadata_sources\".\"payload_policy\" in ('none', 'selected_fields', 'full')"
+        },
+        "metadata_sources_approved_review_ck": {
+          "name": "metadata_sources_approved_review_ck",
+          "value": "\"metadata_sources\".\"approval_state\" <> 'approved' or \"metadata_sources\".\"reviewed_at\" is not null"
+        },
+        "metadata_sources_refresh_ck": {
+          "name": "metadata_sources_refresh_ck",
+          "value": "\"metadata_sources\".\"refresh_interval_ms\" is null or \"metadata_sources\".\"refresh_interval_ms\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.publishers": {
+      "name": "publishers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "publishers_name_nonempty_ck": {
+          "name": "publishers_name_nonempty_ck",
+          "value": "length(trim(\"publishers\".\"display_name\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.source_record_links": {
+      "name": "source_record_links",
+      "schema": "",
+      "columns": {
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_kind": {
+          "name": "match_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mapping_confidence": {
+          "name": "mapping_confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "source_record_links_entity_idx": {
+          "name": "source_record_links_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_record_links_source_record_id_source_records_id_fk": {
+          "name": "source_record_links_source_record_id_source_records_id_fk",
+          "tableFrom": "source_record_links",
+          "tableTo": "source_records",
+          "columnsFrom": [
+            "source_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "source_record_links_pk": {
+          "name": "source_record_links_pk",
+          "columns": [
+            "source_record_id",
+            "entity_type",
+            "entity_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "source_record_links_entity_type_ck": {
+          "name": "source_record_links_entity_type_ck",
+          "value": "\"source_record_links\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset')"
+        },
+        "source_record_links_match_kind_ck": {
+          "name": "source_record_links_match_kind_ck",
+          "value": "\"source_record_links\".\"match_kind\" in ('exact_identifier', 'source_relationship', 'curated', 'candidate')"
+        },
+        "source_record_links_state_ck": {
+          "name": "source_record_links_state_ck",
+          "value": "\"source_record_links\".\"state\" in ('active', 'candidate', 'rejected')"
+        },
+        "source_record_links_confidence_ck": {
+          "name": "source_record_links_confidence_ck",
+          "value": "\"source_record_links\".\"mapping_confidence\" between 0 and 1"
+        },
+        "source_record_links_actor_ck": {
+          "name": "source_record_links_actor_ck",
+          "value": "(\n        \"source_record_links\".\"match_kind\" <> 'curated' and \"source_record_links\".\"state\" <> 'rejected'\n      ) or (\n        length(trim(\"source_record_links\".\"actor_ref\")) > 0 and length(trim(\"source_record_links\".\"reason\")) > 0\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.source_records": {
+      "name": "source_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_modified_at": {
+          "name": "source_modified_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retrieved_at": {
+          "name": "retrieved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "importer_version": {
+          "name": "importer_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_row_hash": {
+          "name": "source_row_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "source_records_source_key_uq": {
+          "name": "source_records_source_key_uq",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "record_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_records_refresh_idx": {
+          "name": "source_records_refresh_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "retrieved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_records_source_id_metadata_sources_id_fk": {
+          "name": "source_records_source_id_metadata_sources_id_fk",
+          "tableFrom": "source_records",
+          "tableTo": "metadata_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "source_records_key_nonempty_ck": {
+          "name": "source_records_key_nonempty_ck",
+          "value": "length(trim(\"source_records\".\"record_key\")) > 0"
+        },
+        "source_records_state_ck": {
+          "name": "source_records_state_ck",
+          "value": "\"source_records\".\"state\" in ('active', 'withdrawn', 'deleted')"
+        },
+        "source_records_import_hash_ck": {
+          "name": "source_records_import_hash_ck",
+          "value": "(\"source_records\".\"importer_version\" is null and \"source_records\".\"source_row_hash\" is null)\n        or (length(trim(\"source_records\".\"importer_version\")) > 0 and length(\"source_records\".\"source_row_hash\") = 64)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.work_authors": {
+      "name": "work_authors",
+      "schema": "",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'author'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "work_authors_position_uq": {
+          "name": "work_authors_position_uq",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_authors_owner_position_idx": {
+          "name": "work_authors_owner_position_idx",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_authors_author_work_idx": {
+          "name": "work_authors_author_work_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "work_authors_work_id_works_id_fk": {
+          "name": "work_authors_work_id_works_id_fk",
+          "tableFrom": "work_authors",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_authors_author_id_authors_id_fk": {
+          "name": "work_authors_author_id_authors_id_fk",
+          "tableFrom": "work_authors",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "work_authors_pk": {
+          "name": "work_authors_pk",
+          "columns": [
+            "work_id",
+            "author_id",
+            "role"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "work_authors_role_ck": {
+          "name": "work_authors_role_ck",
+          "value": "\"work_authors\".\"role\" in ('author', 'editor', 'translator', 'illustrator')"
+        },
+        "work_authors_position_ck": {
+          "name": "work_authors_position_ck",
+          "value": "\"work_authors\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.work_categories": {
+      "name": "work_categories",
+      "schema": "",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "work_categories_position_uq": {
+          "name": "work_categories_position_uq",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_categories_primary_uq": {
+          "name": "work_categories_primary_uq",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"work_categories\".\"is_primary\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_categories_owner_position_idx": {
+          "name": "work_categories_owner_position_idx",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_categories_category_work_idx": {
+          "name": "work_categories_category_work_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "work_categories_work_id_works_id_fk": {
+          "name": "work_categories_work_id_works_id_fk",
+          "tableFrom": "work_categories",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_categories_category_id_categories_id_fk": {
+          "name": "work_categories_category_id_categories_id_fk",
+          "tableFrom": "work_categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "work_categories_pk": {
+          "name": "work_categories_pk",
+          "columns": [
+            "work_id",
+            "category_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "work_categories_position_ck": {
+          "name": "work_categories_position_ck",
+          "value": "\"work_categories\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.works": {
+      "name": "works",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "preferred_title": {
+          "name": "preferred_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_title": {
+          "name": "sort_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_publication_date": {
+          "name": "first_publication_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_publication_precision": {
+          "name": "first_publication_precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_publication_sort_date": {
+          "name": "first_publication_sort_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_edition_id": {
+          "name": "preferred_edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "works_sort_title_id_idx": {
+          "name": "works_sort_title_id_idx",
+          "columns": [
+            {
+              "expression": "sort_title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "works_preferred_edition_idx": {
+          "name": "works_preferred_edition_idx",
+          "columns": [
+            {
+              "expression": "preferred_edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "works_preferred_edition_id_editions_id_fk": {
+          "name": "works_preferred_edition_id_editions_id_fk",
+          "tableFrom": "works",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "preferred_edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "works_titles_nonempty_ck": {
+          "name": "works_titles_nonempty_ck",
+          "value": "length(trim(\"works\".\"preferred_title\")) > 0 and length(trim(\"works\".\"sort_title\")) > 0"
+        },
+        "works_first_publication_precision_ck": {
+          "name": "works_first_publication_precision_ck",
+          "value": "\"works\".\"first_publication_precision\" is null or \"works\".\"first_publication_precision\" in ('year', 'month', 'day')"
+        },
+        "works_first_publication_date_ck": {
+          "name": "works_first_publication_date_ck",
+          "value": "(\n        \"works\".\"first_publication_date\" is null\n        and \"works\".\"first_publication_precision\" is null\n        and \"works\".\"first_publication_sort_date\" is null\n      ) or (\n        \"works\".\"first_publication_date\" is not null\n        and \"works\".\"first_publication_precision\" is not null\n        and \"works\".\"first_publication_sort_date\" is not null\n        and (\n          (\n            \"works\".\"first_publication_precision\" = 'year'\n            and length(\"works\".\"first_publication_date\") = 4\n            and \"works\".\"first_publication_sort_date\" = \"works\".\"first_publication_date\" || '-01-01'\n          ) or (\n            \"works\".\"first_publication_precision\" = 'month'\n            and length(\"works\".\"first_publication_date\") = 7\n            and substring(\"works\".\"first_publication_date\" from 5 for 1) = '-'\n            and \"works\".\"first_publication_sort_date\" = \"works\".\"first_publication_date\" || '-01'\n          ) or (\n            \"works\".\"first_publication_precision\" = 'day'\n            and length(\"works\".\"first_publication_date\") = 10\n            and substring(\"works\".\"first_publication_date\" from 5 for 1) = '-'\n            and substring(\"works\".\"first_publication_date\" from 8 for 1) = '-'\n            and \"works\".\"first_publication_sort_date\" = \"works\".\"first_publication_date\"\n          )\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/pg/meta/0009_snapshot.json
+++ b/drizzle/pg/meta/0009_snapshot.json
@@ -1,0 +1,3530 @@
+{
+  "id": "e1dc8dbf-eaf7-44ef-85a9-4e44280ce5f7",
+  "prevId": "32ab3ae9-c3bb-4fd1-8773-bf3a0a7473a0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.authors": {
+      "name": "authors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_name": {
+          "name": "sort_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "authors_sort_name_idx": {
+          "name": "authors_sort_name_idx",
+          "columns": [
+            {
+              "expression": "sort_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "authors_name_nonempty_ck": {
+          "name": "authors_name_nonempty_ck",
+          "value": "length(trim(\"authors\".\"display_name\")) > 0"
+        },
+        "authors_sort_name_ck": {
+          "name": "authors_sort_name_ck",
+          "value": "\"authors\".\"sort_name\" is null or length(trim(\"authors\".\"sort_name\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.catalog_change_events": {
+      "name": "catalog_change_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "catalog_change_events_type_created_idx": {
+          "name": "catalog_change_events_type_created_idx",
+          "columns": [
+            {
+              "expression": "change_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_change_events_type_ck": {
+          "name": "catalog_change_events_type_ck",
+          "value": "\"catalog_change_events\".\"change_type\" in ('work_merge', 'work_split', 'edition_reassignment')"
+        },
+        "catalog_change_events_nonempty_ck": {
+          "name": "catalog_change_events_nonempty_ck",
+          "value": "length(trim(\"catalog_change_events\".\"actor_ref\")) > 0 and length(trim(\"catalog_change_events\".\"reason\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "categories_slug_uq": {
+          "name": "categories_slug_uq",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "categories_nonempty_ck": {
+          "name": "categories_nonempty_ck",
+          "value": "length(trim(\"categories\".\"slug\")) > 0 and length(trim(\"categories\".\"label\")) > 0"
+        },
+        "categories_status_ck": {
+          "name": "categories_status_ck",
+          "value": "\"categories\".\"status\" in ('active', 'retired')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.cover_assets": {
+      "name": "cover_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_policy_id": {
+          "name": "source_policy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cover_assets_object_key_uq": {
+          "name": "cover_assets_object_key_uq",
+          "columns": [
+            {
+              "expression": "object_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cover_assets_source_policy_id_metadata_sources_id_fk": {
+          "name": "cover_assets_source_policy_id_metadata_sources_id_fk",
+          "tableFrom": "cover_assets",
+          "tableTo": "metadata_sources",
+          "columnsFrom": [
+            "source_policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cover_assets_object_key_ck": {
+          "name": "cover_assets_object_key_ck",
+          "value": "length(trim(\"cover_assets\".\"object_key\")) > 0 and substring(\"cover_assets\".\"object_key\" from 1 for 8) = '/covers/'"
+        },
+        "cover_assets_state_ck": {
+          "name": "cover_assets_state_ck",
+          "value": "\"cover_assets\".\"state\" in ('available', 'missing', 'withdrawn', 'failed')"
+        },
+        "cover_assets_dimensions_ck": {
+          "name": "cover_assets_dimensions_ck",
+          "value": "(\"cover_assets\".\"width\" is null or \"cover_assets\".\"width\" > 0)\n        and (\"cover_assets\".\"height\" is null or \"cover_assets\".\"height\" > 0)\n        and (\"cover_assets\".\"bytes\" is null or \"cover_assets\".\"bytes\" > 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.description_candidates": {
+      "name": "description_candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observation_id": {
+          "name": "observation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_class": {
+          "name": "description_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_hash": {
+          "name": "text_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_policy_version": {
+          "name": "source_policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_policy_version": {
+          "name": "description_policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "license_name": {
+          "name": "license_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_url": {
+          "name": "license_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution_text": {
+          "name": "attribution_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "derivatives_permitted": {
+          "name": "derivatives_permitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "licensed_source_text_hash": {
+          "name": "licensed_source_text_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "licensed_text_transformed": {
+          "name": "licensed_text_transformed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editor_ref": {
+          "name": "editor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editorial_reason": {
+          "name": "editorial_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editorial_revision": {
+          "name": "editorial_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation_input_hash": {
+          "name": "generation_input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation_duration_ms": {
+          "name": "generation_duration_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_microusd": {
+          "name": "cost_microusd",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ambiguous_identity": {
+          "name": "ambiguous_identity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sensitive_content": {
+          "name": "sensitive_content",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "description_candidates_observation_uq": {
+          "name": "description_candidates_observation_uq",
+          "columns": [
+            {
+              "expression": "observation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "description_candidates_work_created_idx": {
+          "name": "description_candidates_work_created_idx",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "description_candidates_work_id_works_id_fk": {
+          "name": "description_candidates_work_id_works_id_fk",
+          "tableFrom": "description_candidates",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_candidates_observation_id_field_observations_id_fk": {
+          "name": "description_candidates_observation_id_field_observations_id_fk",
+          "tableFrom": "description_candidates",
+          "tableTo": "field_observations",
+          "columnsFrom": [
+            "observation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "description_candidates_class_ck": {
+          "name": "description_candidates_class_ck",
+          "value": "\"description_candidates\".\"description_class\" in ('licensed_verbatim', 'bukie_editorial', 'model_assisted_candidate')"
+        },
+        "description_candidates_text_ck": {
+          "name": "description_candidates_text_ck",
+          "value": "length(trim(\"description_candidates\".\"text_content\")) > 0 and length(\"description_candidates\".\"text_hash\") = 64"
+        },
+        "description_candidates_versions_ck": {
+          "name": "description_candidates_versions_ck",
+          "value": "length(trim(\"description_candidates\".\"source_revision\")) > 0\n        and length(trim(\"description_candidates\".\"source_policy_version\")) > 0\n        and length(trim(\"description_candidates\".\"description_policy_version\")) > 0"
+        },
+        "description_candidates_license_ck": {
+          "name": "description_candidates_license_ck",
+          "value": "(\n        \"description_candidates\".\"description_class\" = 'licensed_verbatim'\n        and length(trim(\"description_candidates\".\"license_name\")) > 0\n        and length(trim(\"description_candidates\".\"license_url\")) > 0\n        and \"description_candidates\".\"derivatives_permitted\" is not null\n        and length(\"description_candidates\".\"licensed_source_text_hash\") = 64\n        and \"description_candidates\".\"licensed_text_transformed\" is not null\n      ) or (\n        \"description_candidates\".\"description_class\" <> 'licensed_verbatim'\n        and \"description_candidates\".\"license_name\" is null\n        and \"description_candidates\".\"license_url\" is null\n        and \"description_candidates\".\"attribution_text\" is null\n        and \"description_candidates\".\"derivatives_permitted\" is null\n        and \"description_candidates\".\"licensed_source_text_hash\" is null\n        and \"description_candidates\".\"licensed_text_transformed\" is null\n      )"
+        },
+        "description_candidates_editorial_ck": {
+          "name": "description_candidates_editorial_ck",
+          "value": "(\n        \"description_candidates\".\"description_class\" = 'bukie_editorial'\n        and length(trim(\"description_candidates\".\"editor_ref\")) > 0\n        and length(trim(\"description_candidates\".\"editorial_reason\")) > 0\n        and length(trim(\"description_candidates\".\"editorial_revision\")) > 0\n      ) or (\n        \"description_candidates\".\"description_class\" <> 'bukie_editorial'\n        and \"description_candidates\".\"editor_ref\" is null\n        and \"description_candidates\".\"editorial_reason\" is null\n        and \"description_candidates\".\"editorial_revision\" is null\n      )"
+        },
+        "description_candidates_model_ck": {
+          "name": "description_candidates_model_ck",
+          "value": "(\n        \"description_candidates\".\"description_class\" = 'model_assisted_candidate'\n        and length(trim(\"description_candidates\".\"model_id\")) > 0\n        and length(trim(\"description_candidates\".\"model_version\")) > 0\n        and length(trim(\"description_candidates\".\"prompt_version\")) > 0\n        and length(\"description_candidates\".\"generation_input_hash\") = 64\n        and \"description_candidates\".\"generated_at\" is not null\n        and \"description_candidates\".\"generation_duration_ms\" >= 0\n        and \"description_candidates\".\"input_tokens\" >= 0\n        and \"description_candidates\".\"output_tokens\" >= 0\n        and \"description_candidates\".\"cost_microusd\" >= 0\n      ) or (\n        \"description_candidates\".\"description_class\" <> 'model_assisted_candidate'\n        and \"description_candidates\".\"model_id\" is null\n        and \"description_candidates\".\"model_version\" is null\n        and \"description_candidates\".\"prompt_version\" is null\n        and \"description_candidates\".\"generation_input_hash\" is null\n        and \"description_candidates\".\"generated_at\" is null\n        and \"description_candidates\".\"generation_duration_ms\" is null\n        and \"description_candidates\".\"input_tokens\" is null\n        and \"description_candidates\".\"output_tokens\" is null\n        and \"description_candidates\".\"cost_microusd\" is null\n      )"
+        },
+        "description_candidates_quality_ck": {
+          "name": "description_candidates_quality_ck",
+          "value": "\"description_candidates\".\"quality_score\" is null or \"description_candidates\".\"quality_score\" between 0 and 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.description_claim_evidence": {
+      "name": "description_claim_evidence",
+      "schema": "",
+      "columns": {
+        "claim_id": {
+          "name": "claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observation_id": {
+          "name": "observation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "description_claim_evidence_observation_idx": {
+          "name": "description_claim_evidence_observation_idx",
+          "columns": [
+            {
+              "expression": "observation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "description_claim_evidence_claim_id_description_claims_id_fk": {
+          "name": "description_claim_evidence_claim_id_description_claims_id_fk",
+          "tableFrom": "description_claim_evidence",
+          "tableTo": "description_claims",
+          "columnsFrom": [
+            "claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "description_claim_evidence_observation_id_field_observations_id_fk": {
+          "name": "description_claim_evidence_observation_id_field_observations_id_fk",
+          "tableFrom": "description_claim_evidence",
+          "tableTo": "field_observations",
+          "columnsFrom": [
+            "observation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "description_claim_evidence_pk": {
+          "name": "description_claim_evidence_pk",
+          "columns": [
+            "claim_id",
+            "observation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.description_claims": {
+      "name": "description_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_text": {
+          "name": "claim_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_hash": {
+          "name": "claim_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "description_claims_position_uq": {
+          "name": "description_claims_position_uq",
+          "columns": [
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "description_claims_candidate_idx": {
+          "name": "description_claims_candidate_idx",
+          "columns": [
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "description_claims_candidate_id_description_candidates_id_fk": {
+          "name": "description_claims_candidate_id_description_candidates_id_fk",
+          "tableFrom": "description_claims",
+          "tableTo": "description_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "description_claims_content_ck": {
+          "name": "description_claims_content_ck",
+          "value": "\"description_claims\".\"position\" >= 0\n        and length(trim(\"description_claims\".\"claim_text\")) > 0\n        and length(\"description_claims\".\"claim_hash\") = 64"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.description_decision_heads": {
+      "name": "description_decision_heads",
+      "schema": "",
+      "columns": {
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "decision_id": {
+          "name": "decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "description_decision_heads_decision_uq": {
+          "name": "description_decision_heads_decision_uq",
+          "columns": [
+            {
+              "expression": "decision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "description_decision_heads_candidate_id_description_candidates_id_fk": {
+          "name": "description_decision_heads_candidate_id_description_candidates_id_fk",
+          "tableFrom": "description_decision_heads",
+          "tableTo": "description_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_decision_heads_decision_id_description_decisions_id_fk": {
+          "name": "description_decision_heads_decision_id_description_decisions_id_fk",
+          "tableFrom": "description_decision_heads",
+          "tableTo": "description_decisions",
+          "columnsFrom": [
+            "decision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.description_decisions": {
+      "name": "description_decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_codes_json": {
+          "name": "rejection_codes_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "warning_codes_json": {
+          "name": "warning_codes_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer_ref": {
+          "name": "reviewer_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_reason": {
+          "name": "review_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_decision_id": {
+          "name": "previous_decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "description_decisions_candidate_history_idx": {
+          "name": "description_decisions_candidate_history_idx",
+          "columns": [
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "description_decisions_candidate_id_description_candidates_id_fk": {
+          "name": "description_decisions_candidate_id_description_candidates_id_fk",
+          "tableFrom": "description_decisions",
+          "tableTo": "description_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_decisions_previous_decision_id_description_decisions_id_fk": {
+          "name": "description_decisions_previous_decision_id_description_decisions_id_fk",
+          "tableFrom": "description_decisions",
+          "tableTo": "description_decisions",
+          "columnsFrom": [
+            "previous_decision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "description_decisions_state_ck": {
+          "name": "description_decisions_state_ck",
+          "value": "\"description_decisions\".\"state\" in ('candidate', 'review_required', 'paused', 'rejected', 'eligible', 'withdrawn', 'invalidated')"
+        },
+        "description_decisions_review_ck": {
+          "name": "description_decisions_review_ck",
+          "value": "(\"description_decisions\".\"reviewer_ref\" is null and \"description_decisions\".\"review_reason\" is null)\n        or (\n          length(trim(\"description_decisions\".\"reviewer_ref\")) > 0\n          and length(trim(\"description_decisions\".\"review_reason\")) > 0\n        )"
+        },
+        "description_decisions_policy_ck": {
+          "name": "description_decisions_policy_ck",
+          "value": "length(trim(\"description_decisions\".\"policy_version\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.description_projection_heads": {
+      "name": "description_projection_heads",
+      "schema": "",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "projection_id": {
+          "name": "projection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "description_projection_heads_projection_uq": {
+          "name": "description_projection_heads_projection_uq",
+          "columns": [
+            {
+              "expression": "projection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "description_projection_heads_work_id_works_id_fk": {
+          "name": "description_projection_heads_work_id_works_id_fk",
+          "tableFrom": "description_projection_heads",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_projection_heads_projection_id_description_projections_id_fk": {
+          "name": "description_projection_heads_projection_id_description_projections_id_fk",
+          "tableFrom": "description_projection_heads",
+          "tableTo": "description_projections",
+          "columnsFrom": [
+            "projection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.description_projections": {
+      "name": "description_projections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_projection_id": {
+          "name": "previous_projection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projected_at": {
+          "name": "projected_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "description_projections_work_history_idx": {
+          "name": "description_projections_work_history_idx",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "projected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "description_projections_work_id_works_id_fk": {
+          "name": "description_projections_work_id_works_id_fk",
+          "tableFrom": "description_projections",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_projections_candidate_id_description_candidates_id_fk": {
+          "name": "description_projections_candidate_id_description_candidates_id_fk",
+          "tableFrom": "description_projections",
+          "tableTo": "description_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_projections_previous_projection_id_description_projections_id_fk": {
+          "name": "description_projections_previous_projection_id_description_projections_id_fk",
+          "tableFrom": "description_projections",
+          "tableTo": "description_projections",
+          "columnsFrom": [
+            "previous_projection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "description_projections_state_ck": {
+          "name": "description_projections_state_ck",
+          "value": "\"description_projections\".\"state\" in ('selected', 'withdrawn', 'invalidated', 'rolled_back')"
+        },
+        "description_projections_selection_ck": {
+          "name": "description_projections_selection_ck",
+          "value": "(\"description_projections\".\"state\" in ('selected', 'rolled_back') and \"description_projections\".\"candidate_id\" is not null)\n        or (\"description_projections\".\"state\" in ('withdrawn', 'invalidated') and \"description_projections\".\"candidate_id\" is null)"
+        },
+        "description_projections_nonempty_ck": {
+          "name": "description_projections_nonempty_ck",
+          "value": "length(trim(\"description_projections\".\"reason_code\")) > 0\n        and length(trim(\"description_projections\".\"actor_ref\")) > 0\n        and length(trim(\"description_projections\".\"policy_version\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.description_review_queue": {
+      "name": "description_review_queue",
+      "schema": "",
+      "columns": {
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_codes_json": {
+          "name": "reason_codes_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer_ref": {
+          "name": "reviewer_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "description_review_queue_active_idx": {
+          "name": "description_review_queue_active_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "queued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "description_review_queue_candidate_id_description_candidates_id_fk": {
+          "name": "description_review_queue_candidate_id_description_candidates_id_fk",
+          "tableFrom": "description_review_queue",
+          "tableTo": "description_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "description_review_queue_state_ck": {
+          "name": "description_review_queue_state_ck",
+          "value": "\"description_review_queue\".\"state\" in ('queued', 'claimed', 'completed', 'cancelled')"
+        },
+        "description_review_queue_values_ck": {
+          "name": "description_review_queue_values_ck",
+          "value": "\"description_review_queue\".\"priority\" >= 0\n        and (\"description_review_queue\".\"reviewer_ref\" is null or length(trim(\"description_review_queue\".\"reviewer_ref\")) > 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.edition_covers": {
+      "name": "edition_covers",
+      "schema": "",
+      "columns": {
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_asset_id": {
+          "name": "cover_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "edition_covers_position_uq": {
+          "name": "edition_covers_position_uq",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_covers_primary_uq": {
+          "name": "edition_covers_primary_uq",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"edition_covers\".\"is_primary\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_covers_owner_position_idx": {
+          "name": "edition_covers_owner_position_idx",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_covers_primary_lookup_idx": {
+          "name": "edition_covers_primary_lookup_idx",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "edition_covers_edition_id_editions_id_fk": {
+          "name": "edition_covers_edition_id_editions_id_fk",
+          "tableFrom": "edition_covers",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edition_covers_cover_asset_id_cover_assets_id_fk": {
+          "name": "edition_covers_cover_asset_id_cover_assets_id_fk",
+          "tableFrom": "edition_covers",
+          "tableTo": "cover_assets",
+          "columnsFrom": [
+            "cover_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edition_covers_pk": {
+          "name": "edition_covers_pk",
+          "columns": [
+            "edition_id",
+            "cover_asset_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "edition_covers_position_ck": {
+          "name": "edition_covers_position_ck",
+          "value": "\"edition_covers\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.edition_identifiers": {
+      "name": "edition_identifiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheme": {
+          "name": "scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_normalized": {
+          "name": "value_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_display": {
+          "name": "value_display",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "edition_identifiers_value_uq": {
+          "name": "edition_identifiers_value_uq",
+          "columns": [
+            {
+              "expression": "scheme",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_identifiers_primary_uq": {
+          "name": "edition_identifiers_primary_uq",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"edition_identifiers\".\"is_primary\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_identifiers_owner_idx": {
+          "name": "edition_identifiers_owner_idx",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "edition_identifiers_edition_id_editions_id_fk": {
+          "name": "edition_identifiers_edition_id_editions_id_fk",
+          "tableFrom": "edition_identifiers",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "edition_identifiers_scheme_ck": {
+          "name": "edition_identifiers_scheme_ck",
+          "value": "\"edition_identifiers\".\"scheme\" in ('isbn10', 'isbn13')"
+        },
+        "edition_identifiers_value_ck": {
+          "name": "edition_identifiers_value_ck",
+          "value": "length(trim(\"edition_identifiers\".\"value_normalized\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.edition_languages": {
+      "name": "edition_languages",
+      "schema": "",
+      "columns": {
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_tag": {
+          "name": "language_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "edition_languages_position_uq": {
+          "name": "edition_languages_position_uq",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_languages_owner_position_idx": {
+          "name": "edition_languages_owner_position_idx",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_languages_language_edition_idx": {
+          "name": "edition_languages_language_edition_idx",
+          "columns": [
+            {
+              "expression": "language_tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "edition_languages_edition_id_editions_id_fk": {
+          "name": "edition_languages_edition_id_editions_id_fk",
+          "tableFrom": "edition_languages",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edition_languages_language_tag_languages_tag_fk": {
+          "name": "edition_languages_language_tag_languages_tag_fk",
+          "tableFrom": "edition_languages",
+          "tableTo": "languages",
+          "columnsFrom": [
+            "language_tag"
+          ],
+          "columnsTo": [
+            "tag"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edition_languages_pk": {
+          "name": "edition_languages_pk",
+          "columns": [
+            "edition_id",
+            "language_tag"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "edition_languages_position_ck": {
+          "name": "edition_languages_position_ck",
+          "value": "\"edition_languages\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.edition_publishers": {
+      "name": "edition_publishers",
+      "schema": "",
+      "columns": {
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publisher_id": {
+          "name": "publisher_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "edition_publishers_position_uq": {
+          "name": "edition_publishers_position_uq",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_publishers_owner_position_idx": {
+          "name": "edition_publishers_owner_position_idx",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "edition_publishers_edition_id_editions_id_fk": {
+          "name": "edition_publishers_edition_id_editions_id_fk",
+          "tableFrom": "edition_publishers",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edition_publishers_publisher_id_publishers_id_fk": {
+          "name": "edition_publishers_publisher_id_publishers_id_fk",
+          "tableFrom": "edition_publishers",
+          "tableTo": "publishers",
+          "columnsFrom": [
+            "publisher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edition_publishers_pk": {
+          "name": "edition_publishers_pk",
+          "columns": [
+            "edition_id",
+            "publisher_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "edition_publishers_position_ck": {
+          "name": "edition_publishers_position_ck",
+          "value": "\"edition_publishers\".\"position\" >= 0"
+        },
+        "edition_publishers_role_ck": {
+          "name": "edition_publishers_role_ck",
+          "value": "\"edition_publishers\".\"role\" is null or \"edition_publishers\".\"role\" in ('publisher', 'co_publisher', 'imprint', 'distributor')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.editions": {
+      "name": "editions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_date": {
+          "name": "publication_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_precision": {
+          "name": "publication_precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_sort_date": {
+          "name": "publication_sort_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pages": {
+          "name": "pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cataloged_at": {
+          "name": "cataloged_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "editions_work_id_idx": {
+          "name": "editions_work_id_idx",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "editions_publication_sort_work_idx": {
+          "name": "editions_publication_sort_work_idx",
+          "columns": [
+            {
+              "expression": "publication_sort_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "editions_cataloged_work_idx": {
+          "name": "editions_cataloged_work_idx",
+          "columns": [
+            {
+              "expression": "cataloged_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "editions_work_id_works_id_fk": {
+          "name": "editions_work_id_works_id_fk",
+          "tableFrom": "editions",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "editions_title_ck": {
+          "name": "editions_title_ck",
+          "value": "\"editions\".\"title\" is null or length(trim(\"editions\".\"title\")) > 0"
+        },
+        "editions_subtitle_ck": {
+          "name": "editions_subtitle_ck",
+          "value": "\"editions\".\"subtitle\" is null or length(trim(\"editions\".\"subtitle\")) > 0"
+        },
+        "editions_format_ck": {
+          "name": "editions_format_ck",
+          "value": "\"editions\".\"format\" is null or \"editions\".\"format\" in ('hardcover', 'paperback', 'ebook', 'audiobook', 'other')"
+        },
+        "editions_pages_ck": {
+          "name": "editions_pages_ck",
+          "value": "\"editions\".\"pages\" is null or \"editions\".\"pages\" > 0"
+        },
+        "editions_publication_precision_ck": {
+          "name": "editions_publication_precision_ck",
+          "value": "\"editions\".\"publication_precision\" is null or \"editions\".\"publication_precision\" in ('year', 'month', 'day')"
+        },
+        "editions_publication_date_ck": {
+          "name": "editions_publication_date_ck",
+          "value": "(\n        \"editions\".\"publication_date\" is null\n        and \"editions\".\"publication_precision\" is null\n        and \"editions\".\"publication_sort_date\" is null\n      ) or (\n        \"editions\".\"publication_precision\" = 'year'\n        and length(\"editions\".\"publication_date\") = 4\n        and \"editions\".\"publication_sort_date\" = \"editions\".\"publication_date\" || '-01-01'\n      ) or (\n        \"editions\".\"publication_precision\" = 'month'\n        and length(\"editions\".\"publication_date\") = 7\n        and substring(\"editions\".\"publication_date\" from 5 for 1) = '-'\n        and \"editions\".\"publication_sort_date\" = \"editions\".\"publication_date\" || '-01'\n      ) or (\n        \"editions\".\"publication_precision\" = 'day'\n        and length(\"editions\".\"publication_date\") = 10\n        and substring(\"editions\".\"publication_date\" from 5 for 1) = '-'\n        and substring(\"editions\".\"publication_date\" from 8 for 1) = '-'\n        and \"editions\".\"publication_sort_date\" = \"editions\".\"publication_date\"\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.entity_aliases": {
+      "name": "entity_aliases",
+      "schema": "",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_id": {
+          "name": "from_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_id": {
+          "name": "to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "entity_aliases_target_idx": {
+          "name": "entity_aliases_target_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "entity_aliases_pk": {
+          "name": "entity_aliases_pk",
+          "columns": [
+            "entity_type",
+            "from_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "entity_aliases_ck": {
+          "name": "entity_aliases_ck",
+          "value": "\"entity_aliases\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset')\n        and \"entity_aliases\".\"from_id\" <> \"entity_aliases\".\"to_id\"\n        and length(trim(\"entity_aliases\".\"reason\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.field_observations": {
+      "name": "field_observations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_json": {
+          "name": "value_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comparison_hash": {
+          "name": "comparison_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provenance_kind": {
+          "name": "provenance_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_modified_at": {
+          "name": "source_modified_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retrieved_at": {
+          "name": "retrieved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mapping_confidence": {
+          "name": "mapping_confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "derivation_name": {
+          "name": "derivation_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "derivation_version": {
+          "name": "derivation_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_ids_json": {
+          "name": "parent_ids_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "field_observations_identity_uq": {
+          "name": "field_observations_identity_uq",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "field_observations_source_field_state_idx": {
+          "name": "field_observations_source_field_state_idx",
+          "columns": [
+            {
+              "expression": "source_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "field_observations_target_field_idx": {
+          "name": "field_observations_target_field_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "field_observations_source_record_id_source_records_id_fk": {
+          "name": "field_observations_source_record_id_source_records_id_fk",
+          "tableFrom": "field_observations",
+          "tableTo": "source_records",
+          "columnsFrom": [
+            "source_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "field_observations_target_ck": {
+          "name": "field_observations_target_ck",
+          "value": "\"field_observations\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and \"field_observations\".\"field_key\" in ('work.preferred_title', 'work.description', 'work.first_publication_date', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')"
+        },
+        "field_observations_hash_ck": {
+          "name": "field_observations_hash_ck",
+          "value": "length(\"field_observations\".\"comparison_hash\") = 64"
+        },
+        "field_observations_provenance_ck": {
+          "name": "field_observations_provenance_ck",
+          "value": "\"field_observations\".\"provenance_kind\" in ('curated', 'imported', 'derived', 'synthetic')"
+        },
+        "field_observations_state_ck": {
+          "name": "field_observations_state_ck",
+          "value": "\"field_observations\".\"state\" in ('active', 'stale', 'withdrawn', 'invalid')"
+        },
+        "field_observations_confidence_ck": {
+          "name": "field_observations_confidence_ck",
+          "value": "\"field_observations\".\"mapping_confidence\" between 0 and 1"
+        },
+        "field_observations_curated_ck": {
+          "name": "field_observations_curated_ck",
+          "value": "\"field_observations\".\"provenance_kind\" <> 'curated'\n        or (length(trim(\"field_observations\".\"actor_ref\")) > 0 and length(trim(\"field_observations\".\"reason\")) > 0)"
+        },
+        "field_observations_derived_ck": {
+          "name": "field_observations_derived_ck",
+          "value": "\"field_observations\".\"provenance_kind\" <> 'derived'\n        or (\n          length(trim(\"field_observations\".\"derivation_name\")) > 0\n          and length(trim(\"field_observations\".\"derivation_version\")) > 0\n          and \"field_observations\".\"parent_ids_json\" is not null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.field_resolution_heads": {
+      "name": "field_resolution_heads",
+      "schema": "",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution_id": {
+          "name": "resolution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "field_resolution_heads_resolution_uq": {
+          "name": "field_resolution_heads_resolution_uq",
+          "columns": [
+            {
+              "expression": "resolution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "field_resolution_heads_lookup_idx": {
+          "name": "field_resolution_heads_lookup_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "field_resolution_heads_resolution_id_field_resolutions_id_fk": {
+          "name": "field_resolution_heads_resolution_id_field_resolutions_id_fk",
+          "tableFrom": "field_resolution_heads",
+          "tableTo": "field_resolutions",
+          "columnsFrom": [
+            "resolution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "field_resolution_heads_pk": {
+          "name": "field_resolution_heads_pk",
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "field_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "field_resolution_heads_target_ck": {
+          "name": "field_resolution_heads_target_ck",
+          "value": "\"field_resolution_heads\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and \"field_resolution_heads\".\"field_key\" in ('work.preferred_title', 'work.description', 'work.first_publication_date', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.field_resolutions": {
+      "name": "field_resolutions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_observation_id": {
+          "name": "selected_observation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_resolution_id": {
+          "name": "previous_resolution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolver_version": {
+          "name": "resolver_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "field_resolutions_target_history_idx": {
+          "name": "field_resolutions_target_history_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "field_resolutions_selected_observation_id_field_observations_id_fk": {
+          "name": "field_resolutions_selected_observation_id_field_observations_id_fk",
+          "tableFrom": "field_resolutions",
+          "tableTo": "field_observations",
+          "columnsFrom": [
+            "selected_observation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "field_resolutions_previous_resolution_id_field_resolutions_id_fk": {
+          "name": "field_resolutions_previous_resolution_id_field_resolutions_id_fk",
+          "tableFrom": "field_resolutions",
+          "tableTo": "field_resolutions",
+          "columnsFrom": [
+            "previous_resolution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "field_resolutions_target_ck": {
+          "name": "field_resolutions_target_ck",
+          "value": "\"field_resolutions\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and \"field_resolutions\".\"field_key\" in ('work.preferred_title', 'work.description', 'work.first_publication_date', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')"
+        },
+        "field_resolutions_state_ck": {
+          "name": "field_resolutions_state_ck",
+          "value": "\"field_resolutions\".\"state\" in ('present', 'missing', 'conflicting', 'stale', 'withdrawn')"
+        },
+        "field_resolutions_selection_ck": {
+          "name": "field_resolutions_selection_ck",
+          "value": "(\n        \"field_resolutions\".\"state\" in ('present', 'stale')\n        and \"field_resolutions\".\"selected_observation_id\" is not null\n      ) or (\n        \"field_resolutions\".\"state\" in ('missing', 'conflicting', 'withdrawn')\n        and \"field_resolutions\".\"selected_observation_id\" is null\n      )"
+        },
+        "field_resolutions_nonempty_ck": {
+          "name": "field_resolutions_nonempty_ck",
+          "value": "length(trim(\"field_resolutions\".\"reason\")) > 0\n        and length(trim(\"field_resolutions\".\"actor_ref\")) > 0\n        and length(trim(\"field_resolutions\".\"resolver_version\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.languages": {
+      "name": "languages",
+      "schema": "",
+      "columns": {
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "languages_nonempty_ck": {
+          "name": "languages_nonempty_ck",
+          "value": "length(trim(\"languages\".\"tag\")) > 0 and length(trim(\"languages\".\"label\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.metadata_sources": {
+      "name": "metadata_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terms_url": {
+          "name": "terms_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution_url": {
+          "name": "attribution_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_state": {
+          "name": "approval_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata_policy": {
+          "name": "metadata_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_policy": {
+          "name": "asset_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_policy": {
+          "name": "payload_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_interval_ms": {
+          "name": "refresh_interval_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "metadata_sources_key_uq": {
+          "name": "metadata_sources_key_uq",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "metadata_sources_nonempty_ck": {
+          "name": "metadata_sources_nonempty_ck",
+          "value": "length(trim(\"metadata_sources\".\"key\")) > 0 and length(trim(\"metadata_sources\".\"name\")) > 0"
+        },
+        "metadata_sources_approval_state_ck": {
+          "name": "metadata_sources_approval_state_ck",
+          "value": "\"metadata_sources\".\"approval_state\" in ('pending', 'approved', 'suspended', 'retired')"
+        },
+        "metadata_sources_payload_policy_ck": {
+          "name": "metadata_sources_payload_policy_ck",
+          "value": "\"metadata_sources\".\"payload_policy\" in ('none', 'selected_fields', 'full')"
+        },
+        "metadata_sources_approved_review_ck": {
+          "name": "metadata_sources_approved_review_ck",
+          "value": "\"metadata_sources\".\"approval_state\" <> 'approved' or \"metadata_sources\".\"reviewed_at\" is not null"
+        },
+        "metadata_sources_refresh_ck": {
+          "name": "metadata_sources_refresh_ck",
+          "value": "\"metadata_sources\".\"refresh_interval_ms\" is null or \"metadata_sources\".\"refresh_interval_ms\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.publishers": {
+      "name": "publishers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "publishers_name_nonempty_ck": {
+          "name": "publishers_name_nonempty_ck",
+          "value": "length(trim(\"publishers\".\"display_name\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.source_record_links": {
+      "name": "source_record_links",
+      "schema": "",
+      "columns": {
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_kind": {
+          "name": "match_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mapping_confidence": {
+          "name": "mapping_confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "source_record_links_entity_idx": {
+          "name": "source_record_links_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_record_links_source_record_id_source_records_id_fk": {
+          "name": "source_record_links_source_record_id_source_records_id_fk",
+          "tableFrom": "source_record_links",
+          "tableTo": "source_records",
+          "columnsFrom": [
+            "source_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "source_record_links_pk": {
+          "name": "source_record_links_pk",
+          "columns": [
+            "source_record_id",
+            "entity_type",
+            "entity_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "source_record_links_entity_type_ck": {
+          "name": "source_record_links_entity_type_ck",
+          "value": "\"source_record_links\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset')"
+        },
+        "source_record_links_match_kind_ck": {
+          "name": "source_record_links_match_kind_ck",
+          "value": "\"source_record_links\".\"match_kind\" in ('exact_identifier', 'source_relationship', 'curated', 'candidate')"
+        },
+        "source_record_links_state_ck": {
+          "name": "source_record_links_state_ck",
+          "value": "\"source_record_links\".\"state\" in ('active', 'candidate', 'rejected')"
+        },
+        "source_record_links_confidence_ck": {
+          "name": "source_record_links_confidence_ck",
+          "value": "\"source_record_links\".\"mapping_confidence\" between 0 and 1"
+        },
+        "source_record_links_actor_ck": {
+          "name": "source_record_links_actor_ck",
+          "value": "(\n        \"source_record_links\".\"match_kind\" <> 'curated' and \"source_record_links\".\"state\" <> 'rejected'\n      ) or (\n        length(trim(\"source_record_links\".\"actor_ref\")) > 0 and length(trim(\"source_record_links\".\"reason\")) > 0\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.source_records": {
+      "name": "source_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_modified_at": {
+          "name": "source_modified_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retrieved_at": {
+          "name": "retrieved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "importer_version": {
+          "name": "importer_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_row_hash": {
+          "name": "source_row_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "source_records_source_key_uq": {
+          "name": "source_records_source_key_uq",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "record_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_records_refresh_idx": {
+          "name": "source_records_refresh_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "retrieved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_records_source_id_metadata_sources_id_fk": {
+          "name": "source_records_source_id_metadata_sources_id_fk",
+          "tableFrom": "source_records",
+          "tableTo": "metadata_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "source_records_key_nonempty_ck": {
+          "name": "source_records_key_nonempty_ck",
+          "value": "length(trim(\"source_records\".\"record_key\")) > 0"
+        },
+        "source_records_state_ck": {
+          "name": "source_records_state_ck",
+          "value": "\"source_records\".\"state\" in ('active', 'withdrawn', 'deleted')"
+        },
+        "source_records_import_hash_ck": {
+          "name": "source_records_import_hash_ck",
+          "value": "(\"source_records\".\"importer_version\" is null and \"source_records\".\"source_row_hash\" is null)\n        or (length(trim(\"source_records\".\"importer_version\")) > 0 and length(\"source_records\".\"source_row_hash\") = 64)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.work_authors": {
+      "name": "work_authors",
+      "schema": "",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'author'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "work_authors_position_uq": {
+          "name": "work_authors_position_uq",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_authors_owner_position_idx": {
+          "name": "work_authors_owner_position_idx",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_authors_author_work_idx": {
+          "name": "work_authors_author_work_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "work_authors_work_id_works_id_fk": {
+          "name": "work_authors_work_id_works_id_fk",
+          "tableFrom": "work_authors",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_authors_author_id_authors_id_fk": {
+          "name": "work_authors_author_id_authors_id_fk",
+          "tableFrom": "work_authors",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "work_authors_pk": {
+          "name": "work_authors_pk",
+          "columns": [
+            "work_id",
+            "author_id",
+            "role"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "work_authors_role_ck": {
+          "name": "work_authors_role_ck",
+          "value": "\"work_authors\".\"role\" in ('author', 'editor', 'translator', 'illustrator')"
+        },
+        "work_authors_position_ck": {
+          "name": "work_authors_position_ck",
+          "value": "\"work_authors\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.work_categories": {
+      "name": "work_categories",
+      "schema": "",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "work_categories_position_uq": {
+          "name": "work_categories_position_uq",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_categories_primary_uq": {
+          "name": "work_categories_primary_uq",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"work_categories\".\"is_primary\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_categories_owner_position_idx": {
+          "name": "work_categories_owner_position_idx",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_categories_category_work_idx": {
+          "name": "work_categories_category_work_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "work_categories_work_id_works_id_fk": {
+          "name": "work_categories_work_id_works_id_fk",
+          "tableFrom": "work_categories",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_categories_category_id_categories_id_fk": {
+          "name": "work_categories_category_id_categories_id_fk",
+          "tableFrom": "work_categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "work_categories_pk": {
+          "name": "work_categories_pk",
+          "columns": [
+            "work_id",
+            "category_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "work_categories_position_ck": {
+          "name": "work_categories_position_ck",
+          "value": "\"work_categories\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.works": {
+      "name": "works",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "preferred_title": {
+          "name": "preferred_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_title": {
+          "name": "sort_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_publication_date": {
+          "name": "first_publication_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_publication_precision": {
+          "name": "first_publication_precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_publication_sort_date": {
+          "name": "first_publication_sort_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_edition_id": {
+          "name": "preferred_edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "works_sort_title_id_idx": {
+          "name": "works_sort_title_id_idx",
+          "columns": [
+            {
+              "expression": "sort_title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "works_preferred_edition_idx": {
+          "name": "works_preferred_edition_idx",
+          "columns": [
+            {
+              "expression": "preferred_edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "works_preferred_edition_id_editions_id_fk": {
+          "name": "works_preferred_edition_id_editions_id_fk",
+          "tableFrom": "works",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "preferred_edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "works_titles_nonempty_ck": {
+          "name": "works_titles_nonempty_ck",
+          "value": "length(trim(\"works\".\"preferred_title\")) > 0 and length(trim(\"works\".\"sort_title\")) > 0"
+        },
+        "works_first_publication_precision_ck": {
+          "name": "works_first_publication_precision_ck",
+          "value": "\"works\".\"first_publication_precision\" is null or \"works\".\"first_publication_precision\" in ('year', 'month', 'day')"
+        },
+        "works_first_publication_date_ck": {
+          "name": "works_first_publication_date_ck",
+          "value": "(\n        \"works\".\"first_publication_date\" is null\n        and \"works\".\"first_publication_precision\" is null\n        and \"works\".\"first_publication_sort_date\" is null\n      ) or (\n        \"works\".\"first_publication_date\" is not null\n        and \"works\".\"first_publication_precision\" is not null\n        and \"works\".\"first_publication_sort_date\" is not null\n        and (\n          (\n            \"works\".\"first_publication_precision\" = 'year'\n            and length(\"works\".\"first_publication_date\") = 4\n            and \"works\".\"first_publication_sort_date\" = \"works\".\"first_publication_date\" || '-01-01'\n          ) or (\n            \"works\".\"first_publication_precision\" = 'month'\n            and length(\"works\".\"first_publication_date\") = 7\n            and substring(\"works\".\"first_publication_date\" from 5 for 1) = '-'\n            and \"works\".\"first_publication_sort_date\" = \"works\".\"first_publication_date\" || '-01'\n          ) or (\n            \"works\".\"first_publication_precision\" = 'day'\n            and length(\"works\".\"first_publication_date\") = 10\n            and substring(\"works\".\"first_publication_date\" from 5 for 1) = '-'\n            and substring(\"works\".\"first_publication_date\" from 8 for 1) = '-'\n            and \"works\".\"first_publication_sort_date\" = \"works\".\"first_publication_date\"\n          )\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/pg/meta/_journal.json
+++ b/drizzle/pg/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1785312701489,
       "tag": "0008_gifted_typhoid_mary",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1785319007333,
+      "tag": "0009_moaning_catseye",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/pg/meta/_journal.json
+++ b/drizzle/pg/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1785258819351,
       "tag": "0007_third_blizzard",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1785312701489,
+      "tag": "0008_gifted_typhoid_mary",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "db:reseed": "bun run db:reset && bun run db:init",
     "db:catalog:rebuild": "bunx tsx ./scripts/db/rebuild-catalog.ts",
     "db:catalog:enrichment-sample": "bunx tsx ./scripts/db/run-enrichment-sample.ts",
+    "db:catalog:description-sample": "bunx tsx ./scripts/db/run-description-enrichment-sample.ts",
     "lint": "bunx @biomejs/biome check --no-errors-on-unmatched .",
     "lint:fix": "bunx @biomejs/biome check --write --no-errors-on-unmatched .",
     "release": "semantic-release",

--- a/scripts/db/run-description-enrichment-sample.ts
+++ b/scripts/db/run-description-enrichment-sample.ts
@@ -8,6 +8,7 @@ import {
   reviewDescriptionCandidateSqlite,
   withdrawDescriptionCandidateSqlite,
 } from "@/db/catalog/enrichment/descriptions/repository";
+import { DESCRIPTION_POLICY_VERSION } from "@/db/catalog/enrichment/descriptions/types";
 import { SAMPLE_BASELINE_IMPORT_RECORDS } from "@/db/catalog/enrichment/fixtures";
 import { ENRICHMENT_SAMPLE_MANIFEST } from "@/db/catalog/enrichment/sample-manifest";
 import { canonicalJson, hashCanonicalJson } from "@/db/catalog/identity";
@@ -69,6 +70,9 @@ try {
   });
   for (let index = 0; index < 2; index += 1) {
     reviewDescriptionCandidateSqlite(raw, {
+      descriptionPolicyVersion: DESCRIPTION_POLICY_VERSION,
+      currentModelVersion: "fixture-model-v1",
+      currentPromptVersion: "fixture-prompt-v1",
       candidateId: candidates[index].candidateId,
       reviewerRef: `user:diagnostic-reviewer-${index}`,
       decision: "approve",
@@ -78,6 +82,9 @@ try {
     });
   }
   reviewDescriptionCandidateSqlite(raw, {
+    descriptionPolicyVersion: DESCRIPTION_POLICY_VERSION,
+    currentModelVersion: "fixture-model-v1",
+    currentPromptVersion: "fixture-prompt-v1",
     candidateId: candidates[2].candidateId,
     reviewerRef: "user:diagnostic-reviewer-2",
     decision: "reject",

--- a/scripts/db/run-description-enrichment-sample.ts
+++ b/scripts/db/run-description-enrichment-sample.ts
@@ -1,0 +1,147 @@
+import {
+  modelDescriptionFixture,
+  seedDescriptionFixturesSqlite,
+} from "@/db/catalog/enrichment/descriptions/fixtures";
+import {
+  createDescriptionCandidateSqlite,
+  descriptionMetricsSqlite,
+  reviewDescriptionCandidateSqlite,
+  withdrawDescriptionCandidateSqlite,
+} from "@/db/catalog/enrichment/descriptions/repository";
+import { SAMPLE_BASELINE_IMPORT_RECORDS } from "@/db/catalog/enrichment/fixtures";
+import { ENRICHMENT_SAMPLE_MANIFEST } from "@/db/catalog/enrichment/sample-manifest";
+import { canonicalJson, hashCanonicalJson } from "@/db/catalog/identity";
+import { buildCatalogImportGraph } from "@/db/catalog/importer";
+import { resolveRebuildTarget } from "@/db/catalog/rebuild-safety";
+import {
+  openCatalogSqlite,
+  rebuildCatalogSqlite,
+} from "@/db/catalog/sqlite-rebuild";
+
+const rawTarget = process.argv
+  .find((argument) => argument.startsWith("--target="))
+  ?.slice("--target=".length);
+const target = resolveRebuildTarget({
+  rawTarget,
+  confirmDisposable: process.argv.includes("--confirm-disposable"),
+});
+if (target.driver !== "sqlite") {
+  throw new Error(
+    "The issue #133 description proof currently accepts disposable SQLite targets only",
+  );
+}
+
+const graph = buildCatalogImportGraph(SAMPLE_BASELINE_IMPORT_RECORDS);
+rebuildCatalogSqlite({ sqlitePath: target.path, graph });
+const { raw } = openCatalogSqlite(target.path);
+try {
+  seedDescriptionFixturesSqlite(raw);
+  const publicHeadsBefore = hashCanonicalJson(
+    raw
+      .prepare(
+        `select entity_type, entity_id, field_key, resolution_id
+         from field_resolution_heads
+         order by entity_type, entity_id, field_key`,
+      )
+      .all(),
+  );
+  const publicDescriptionsBefore = canonicalJson(
+    raw
+      .prepare("select id, description from works order by id")
+      .all(),
+  );
+  const candidates = ENRICHMENT_SAMPLE_MANIFEST.works.map((work, index) => {
+    const candidate = modelDescriptionFixture(work.workId, {
+      createdAt: Date.UTC(2026, 6, 29, 13, 0, index),
+    });
+    const first = createDescriptionCandidateSqlite(raw, {
+      candidate,
+      queueCapacity: 10,
+    });
+    const retry = createDescriptionCandidateSqlite(raw, {
+      candidate,
+      queueCapacity: 10,
+    });
+    if (retry.changed || retry.candidateId !== first.candidateId) {
+      throw new Error("Description candidate retry was not idempotent");
+    }
+    return first;
+  });
+  for (let index = 0; index < 2; index += 1) {
+    reviewDescriptionCandidateSqlite(raw, {
+      candidateId: candidates[index].candidateId,
+      reviewerRef: `user:diagnostic-reviewer-${index}`,
+      decision: "approve",
+      reason: "Deterministic five-work proof approval",
+      acknowledgedWarningCodes: candidates[index].validation.warningCodes,
+      reviewedAt: Date.UTC(2026, 6, 29, 14, 0, index),
+    });
+  }
+  reviewDescriptionCandidateSqlite(raw, {
+    candidateId: candidates[2].candidateId,
+    reviewerRef: "user:diagnostic-reviewer-2",
+    decision: "reject",
+    reason: "Deterministic five-work proof rejection",
+    reviewedAt: Date.UTC(2026, 6, 29, 14, 0, 2),
+  });
+  withdrawDescriptionCandidateSqlite(raw, {
+    candidateId: candidates[0].candidateId,
+    actorRef: "user:diagnostic-reviewer-0",
+    reason: "Deterministic five-work proof withdrawal",
+    withdrawnAt: Date.UTC(2026, 6, 29, 14, 1, 0),
+  });
+
+  const publicHeadsAfter = hashCanonicalJson(
+    raw
+      .prepare(
+        `select entity_type, entity_id, field_key, resolution_id
+         from field_resolution_heads
+         order by entity_type, entity_id, field_key`,
+      )
+      .all(),
+  );
+  const publicDescriptionsAfter = canonicalJson(
+    raw
+      .prepare("select id, description from works order by id")
+      .all(),
+  );
+  if (publicHeadsBefore !== publicHeadsAfter) {
+    throw new Error("Description proof changed public resolution heads");
+  }
+  if (publicDescriptionsBefore !== publicDescriptionsAfter) {
+    throw new Error("Description proof changed work description projections");
+  }
+  const descriptionSnapshot = raw
+    .prepare(
+      `select
+         c.id, c.work_id, c.description_class, c.text_hash,
+         d.state, d.rejection_codes_json, d.warning_codes_json
+       from description_candidates c
+       join description_decision_heads h on h.candidate_id = c.id
+       join description_decisions d on d.id = h.decision_id
+       order by c.work_id, c.id`,
+    )
+    .all();
+  console.log(
+    JSON.stringify(
+      {
+        target: target.description,
+        manifest: `${ENRICHMENT_SAMPLE_MANIFEST.id}@${ENRICHMENT_SAMPLE_MANIFEST.version}`,
+        candidateIds: candidates.map((candidate) => candidate.candidateId),
+        snapshotHash: hashCanonicalJson(descriptionSnapshot),
+        metrics: descriptionMetricsSqlite(raw, 5),
+        safeguards: {
+          catalogWideScan: false,
+          publicProjectionWrites: false,
+          currentResolutionHeadWrites: false,
+          productionDataWrites: false,
+          providerCalls: false,
+        },
+      },
+      null,
+      2,
+    ),
+  );
+} finally {
+  raw.close();
+}

--- a/src/db/catalog/description-migration.test.ts
+++ b/src/db/catalog/description-migration.test.ts
@@ -1,0 +1,129 @@
+import {
+  cpSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { describe, expect, it } from "vitest";
+import {
+  licensedDescriptionFixture,
+  seedDescriptionFixturesSqlite,
+} from "./enrichment/descriptions/fixtures";
+import {
+  descriptionCandidateIdentity,
+  descriptionObservationIdentity,
+} from "./enrichment/descriptions/repository";
+import { SAMPLE_BASELINE_IMPORT_RECORDS } from "./enrichment/fixtures";
+import { canonicalJson, hashCanonicalJson } from "./identity";
+import { buildCatalogImportGraph } from "./importer";
+import { importCatalogGraphSqlite } from "./sqlite-rebuild";
+
+describe("description provenance SQLite migration", () => {
+  it("backfills old licensed candidates with exact-text transformation proof", () => {
+    const directory = mkdtempSync(
+      path.join(tmpdir(), "bukie-description-migration-"),
+    );
+    const sqlitePath = path.join(directory, "catalog.sqlite");
+    const oldMigrations = path.join(directory, "old-migrations");
+    const raw = new Database(sqlitePath);
+    try {
+      cpSync(path.resolve("drizzle"), oldMigrations, { recursive: true });
+      rmSync(path.join(oldMigrations, "0007_milky_omega_red.sql"));
+      rmSync(path.join(oldMigrations, "meta", "0007_snapshot.json"));
+      const journalPath = path.join(oldMigrations, "meta", "_journal.json");
+      const journal = JSON.parse(readFileSync(journalPath, "utf8")) as {
+        entries: Array<{ idx: number }>;
+      };
+      journal.entries = journal.entries.filter((entry) => entry.idx < 7);
+      writeFileSync(journalPath, JSON.stringify(journal, null, 2));
+
+      migrate(drizzle(raw), { migrationsFolder: oldMigrations });
+      importCatalogGraphSqlite(
+        raw,
+        buildCatalogImportGraph(SAMPLE_BASELINE_IMPORT_RECORDS),
+      );
+      seedDescriptionFixturesSqlite(raw);
+      const candidate = licensedDescriptionFixture();
+      const candidateId = descriptionCandidateIdentity(candidate);
+      const observationId = descriptionObservationIdentity(candidateId);
+      const textHash = hashCanonicalJson(candidate.text);
+      raw
+        .prepare(
+          `insert into field_observations (
+             id, source_record_id, entity_type, entity_id, field_key,
+             value_json, comparison_hash, provenance_kind, source_path,
+             source_modified_at, retrieved_at, mapping_confidence, state,
+             actor_ref, reason, derivation_name, derivation_version,
+             parent_ids_json
+           ) values (
+             ?, ?, 'work', ?, 'work.description', ?, ?, 'imported',
+             'licensed.description', null, ?, 1, 'active', null, null,
+             null, null, null
+           )`,
+        )
+        .run(
+          observationId,
+          candidate.sourceRecordId,
+          candidate.workId,
+          canonicalJson(candidate.text),
+          textHash,
+          candidate.createdAt,
+        );
+      raw
+        .prepare(
+          `insert into description_candidates (
+             id, work_id, observation_id, description_class, text_content,
+             text_hash, source_revision, source_policy_version,
+             description_policy_version, license_name, license_url,
+             attribution_text, derivatives_permitted, editor_ref,
+             editorial_reason, editorial_revision, model_id, model_version,
+             prompt_version, generation_input_hash, generated_at,
+             generation_duration_ms, input_tokens, output_tokens,
+             cost_microusd, quality_score, ambiguous_identity,
+             sensitive_content, created_at
+           ) values (
+             ?, ?, ?, 'licensed_verbatim', ?, ?, ?, ?, ?, ?, ?, ?, 0,
+             null, null, null, null, null, null, null, null, null, null,
+             null, null, 80, 0, 0, ?
+           )`,
+        )
+        .run(
+          candidateId,
+          candidate.workId,
+          observationId,
+          candidate.text,
+          textHash,
+          candidate.sourceRevision,
+          candidate.sourcePolicyVersion,
+          candidate.descriptionPolicyVersion,
+          candidate.license.name,
+          candidate.license.url,
+          candidate.license.attributionText,
+          candidate.createdAt,
+        );
+
+      migrate(drizzle(raw), { migrationsFolder: path.resolve("drizzle") });
+
+      expect(
+        raw
+          .prepare(
+            `select
+               licensed_source_text_hash as sourceTextHash,
+               licensed_text_transformed as transformed
+             from description_candidates where id = ?`,
+          )
+          .get(candidateId),
+      ).toEqual({ sourceTextHash: textHash, transformed: 0 });
+      expect(raw.pragma("foreign_key_check")).toEqual([]);
+    } finally {
+      raw.close();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/db/catalog/enrichment/descriptions/fixtures.ts
+++ b/src/db/catalog/enrichment/descriptions/fixtures.ts
@@ -1,0 +1,422 @@
+import type Database from "better-sqlite3";
+import postgres from "postgres";
+import {
+  canonicalJson,
+  deterministicCatalogId,
+  hashCanonicalJson,
+} from "../../identity";
+import { ENRICHMENT_SAMPLE_MANIFEST } from "../sample-manifest";
+import type {
+  DescriptionCandidateInput,
+  EditorialDescriptionInput,
+  LicensedDescriptionInput,
+  ModelDescriptionInput,
+} from "./types";
+import { DESCRIPTION_POLICY_VERSION } from "./types";
+
+const CREATED_AT = Date.UTC(2026, 6, 29, 9, 0, 0);
+export const DESCRIPTION_FIXTURE_SOURCE_POLICY_VERSION =
+  "description-candidate-fixture-policy-v1";
+const EVIDENCE_POLICY_VERSION = "description-parent-evidence-policy-v1";
+
+export const DESCRIPTION_FIXTURE_SOURCE_ID = deterministicCatalogId(
+  "metadata_source",
+  "description-test",
+  "candidate",
+);
+export const DESCRIPTION_EVIDENCE_SOURCE_ID = deterministicCatalogId(
+  "metadata_source",
+  "description-test",
+  "evidence",
+);
+
+const sourceRecordId = (workId: string, kind: "candidate" | "evidence") =>
+  deterministicCatalogId(
+    "source_record",
+    "description-test",
+    `${kind}:${workId}`,
+  );
+
+const parentObservationId = (workId: string, fieldKey: string) =>
+  deterministicCatalogId(
+    "field_observation",
+    "description-test",
+    `${workId}:${fieldKey}`,
+  );
+
+export const descriptionFixtureIds = (workId: string) => ({
+  candidateSourceRecordId: sourceRecordId(workId, "candidate"),
+  evidenceSourceRecordId: sourceRecordId(workId, "evidence"),
+  parents: [
+    parentObservationId(workId, "work.preferred_title"),
+    parentObservationId(workId, "work.first_publication_date"),
+    parentObservationId(workId, "work.categories"),
+  ] as const,
+});
+
+export const DESCRIPTION_FIXTURE_TEXT = [
+  "This recorded evaluation fixture follows a central figure whose ordinary",
+  "plans change after a difficult responsibility arrives without warning.",
+  "The setting brings together family pressure, public expectations, and",
+  "questions about where loyalty should rest. As the situation develops, the",
+  "character must understand unfamiliar people while deciding which inherited",
+  "assumptions remain useful. The account focuses on choices, relationships,",
+  "and the consequences of entering a larger conflict. Its perspective stays",
+  "close to the character's uncertainty, giving the story a clear human",
+  "center without describing its outcome or making claims about quality.",
+].join(" ");
+
+export const DESCRIPTION_FIXTURE_ALTERNATE_TEXT = [
+  "This deterministic review fixture begins with a person returning to a",
+  "community shaped by memory, duty, and unresolved questions. A new problem",
+  "forces several relationships into the open and makes earlier choices",
+  "matter again. The narrative observes how trust changes when private",
+  "knowledge becomes difficult to contain. Rather than explaining the final",
+  "result, this summary stays with the opening pressure and the competing",
+  "responsibilities it creates. The setting and the character's history give",
+  "the conflict a specific frame while the language remains factual, measured,",
+  "and suitable for a bounded catalog-enrichment test.",
+].join(" ");
+
+const claimsFor = (workId: string) => {
+  const ids = descriptionFixtureIds(workId).parents;
+  return [
+    {
+      text: "The record has a verified work identity.",
+      parentObservationIds: [ids[0]],
+    },
+    {
+      text: "The work has publication context.",
+      parentObservationIds: [ids[1]],
+    },
+    {
+      text: "The work has a reviewed category.",
+      parentObservationIds: [ids[2]],
+    },
+  ] as const;
+};
+
+const common = (
+  workId: string,
+  text: string,
+  createdAt: number,
+): Omit<
+  DescriptionCandidateInput,
+  "descriptionClass" | "license" | "editorial" | "model"
+> => ({
+  workId,
+  text,
+  sourceRecordId: descriptionFixtureIds(workId).candidateSourceRecordId,
+  sourceRevision: "description-candidate-fixture-revision-v1",
+  sourcePolicyVersion: DESCRIPTION_FIXTURE_SOURCE_POLICY_VERSION,
+  descriptionPolicyVersion: DESCRIPTION_POLICY_VERSION,
+  claims: claimsFor(workId),
+  comparisonTexts: [],
+  createdAt,
+});
+
+export const modelDescriptionFixture = (
+  workId: string = ENRICHMENT_SAMPLE_MANIFEST.works[0].workId,
+  overrides: Partial<ModelDescriptionInput> = {},
+): ModelDescriptionInput => ({
+  ...common(workId, DESCRIPTION_FIXTURE_TEXT, CREATED_AT),
+  descriptionClass: "model_assisted_candidate",
+  model: {
+    modelId: "provider-neutral.recorded-fixture",
+    modelVersion: "fixture-model-v1",
+    promptVersion: "fixture-prompt-v1",
+    generatedAt: CREATED_AT - 1_000,
+    generationDurationMs: 125,
+    inputTokens: 320,
+    outputTokens: 112,
+    costMicrousd: 4_200,
+  },
+  ...overrides,
+});
+
+export const editorialDescriptionFixture = (
+  workId: string = ENRICHMENT_SAMPLE_MANIFEST.works[1].workId,
+  overrides: Partial<EditorialDescriptionInput> = {},
+): EditorialDescriptionInput => ({
+  ...common(workId, DESCRIPTION_FIXTURE_TEXT, CREATED_AT + 10),
+  descriptionClass: "bukie_editorial",
+  editorial: {
+    editorRef: "user:editor-fixture",
+    reason: "Original neutral summary based on approved fixture evidence",
+    revision: "editorial-fixture-v1",
+  },
+  ...overrides,
+});
+
+export const licensedDescriptionFixture = (
+  workId: string = ENRICHMENT_SAMPLE_MANIFEST.works[2].workId,
+  overrides: Partial<LicensedDescriptionInput> = {},
+): LicensedDescriptionInput => ({
+  ...common(workId, DESCRIPTION_FIXTURE_TEXT, CREATED_AT + 20),
+  descriptionClass: "licensed_verbatim",
+  license: {
+    name: "Recorded fixture license",
+    url: "https://example.invalid/recorded-fixture-license",
+    attributionText: "Recorded fixture source",
+    derivativesPermitted: false,
+    sourceText: DESCRIPTION_FIXTURE_TEXT,
+    transformed: false,
+  },
+  ...overrides,
+});
+
+export const seedDescriptionFixturesSqlite = (
+  raw: InstanceType<typeof Database>,
+): void => {
+  const evidencePolicy = canonicalJson({
+    display: true,
+    proposedEvidenceOnly: false,
+    sourcePolicyVersion: EVIDENCE_POLICY_VERSION,
+    fieldPermission: {
+      allowedFields: [
+        "work.preferred_title",
+        "work.first_publication_date",
+        "work.categories",
+      ],
+    },
+  });
+  const candidatePolicy = canonicalJson({
+    display: true,
+    proposedEvidenceOnly: true,
+    sourcePolicyVersion: DESCRIPTION_FIXTURE_SOURCE_POLICY_VERSION,
+    attribution: {
+      required: true,
+    },
+    textPermission: {
+      allowedFields: ["work.description"],
+      fetch: true,
+      transform: false,
+    },
+  });
+  const source = raw.prepare(
+    `insert into metadata_sources (
+       id, key, name, terms_url, attribution_url, reviewed_at, approval_state,
+       metadata_policy, asset_policy, payload_policy, refresh_interval_ms
+     ) values (?, ?, ?, null, null, ?, 'approved', ?, '{}', 'selected_fields', null)`,
+  );
+  source.run(
+    DESCRIPTION_EVIDENCE_SOURCE_ID,
+    "description_fixture_evidence",
+    "Description fixture parent evidence",
+    CREATED_AT,
+    evidencePolicy,
+  );
+  source.run(
+    DESCRIPTION_FIXTURE_SOURCE_ID,
+    "description_fixture_candidates",
+    "Description fixture candidate source",
+    CREATED_AT,
+    candidatePolicy,
+  );
+  const sourceRecord = raw.prepare(
+    `insert into source_records (
+       id, source_id, record_key, source_revision, source_modified_at,
+       retrieved_at, payload_json, payload_hash, importer_version,
+       source_row_hash, state
+     ) values (?, ?, ?, ?, null, ?, null, null, 'description-fixture-v1', ?, 'active')`,
+  );
+  const link = raw.prepare(
+    `insert into source_record_links (
+       source_record_id, entity_type, entity_id, match_kind,
+       mapping_confidence, state, actor_ref, reason, created_at
+     ) values (?, 'work', ?, 'curated', 1, 'active', 'system:description-fixture', ?, ?)`,
+  );
+  const observation = raw.prepare(
+    `insert into field_observations (
+       id, source_record_id, entity_type, entity_id, field_key, value_json,
+       comparison_hash, provenance_kind, source_path, source_modified_at,
+       retrieved_at, mapping_confidence, state, actor_ref, reason,
+       derivation_name, derivation_version, parent_ids_json
+     ) values (
+       ?, ?, 'work', ?, ?, ?, ?, 'curated', ?, null, ?, 1, 'active',
+       'system:description-fixture', 'Approved deterministic parent evidence',
+       null, null, null
+     )`,
+  );
+  for (const [index, work] of ENRICHMENT_SAMPLE_MANIFEST.works.entries()) {
+    const ids = descriptionFixtureIds(work.workId);
+    sourceRecord.run(
+      ids.evidenceSourceRecordId,
+      DESCRIPTION_EVIDENCE_SOURCE_ID,
+      `evidence:${work.workId}`,
+      "description-parent-evidence-revision-v1",
+      CREATED_AT + index,
+      hashCanonicalJson({ kind: "evidence", workId: work.workId }),
+    );
+    sourceRecord.run(
+      ids.candidateSourceRecordId,
+      DESCRIPTION_FIXTURE_SOURCE_ID,
+      `candidate:${work.workId}`,
+      "description-candidate-fixture-revision-v1",
+      CREATED_AT + index,
+      hashCanonicalJson({ kind: "candidate", workId: work.workId }),
+    );
+    link.run(
+      ids.evidenceSourceRecordId,
+      work.workId,
+      "Active identity-verified parent evidence fixture",
+      CREATED_AT + index,
+    );
+    link.run(
+      ids.candidateSourceRecordId,
+      work.workId,
+      "Active description candidate fixture source",
+      CREATED_AT + index,
+    );
+    const values: Array<[string, unknown]> = [
+      ["work.preferred_title", work.title],
+      ["work.first_publication_date", String(1900 + index)],
+      ["work.categories", [`fixture-category-${index}`]],
+    ];
+    for (const [fieldKey, value] of values) {
+      observation.run(
+        parentObservationId(work.workId, fieldKey),
+        ids.evidenceSourceRecordId,
+        work.workId,
+        fieldKey,
+        canonicalJson(value),
+        hashCanonicalJson(value),
+        fieldKey,
+        CREATED_AT + index,
+      );
+    }
+  }
+};
+
+export const seedDescriptionFixturesPostgres = async (
+  url: string,
+): Promise<void> => {
+  const client = postgres(url, { max: 1 });
+  const evidencePolicy = {
+    display: true,
+    proposedEvidenceOnly: false,
+    sourcePolicyVersion: EVIDENCE_POLICY_VERSION,
+    fieldPermission: {
+      allowedFields: [
+        "work.preferred_title",
+        "work.first_publication_date",
+        "work.categories",
+      ],
+    },
+  };
+  const candidatePolicy = {
+    display: true,
+    proposedEvidenceOnly: true,
+    sourcePolicyVersion: DESCRIPTION_FIXTURE_SOURCE_POLICY_VERSION,
+    attribution: {
+      required: true,
+    },
+    textPermission: {
+      allowedFields: ["work.description"],
+      fetch: true,
+      transform: false,
+    },
+  };
+  try {
+    await client.begin(async (sql) => {
+      await sql.unsafe(
+        `insert into metadata_sources (
+           id, key, name, terms_url, attribution_url, reviewed_at,
+           approval_state, metadata_policy, asset_policy, payload_policy,
+           refresh_interval_ms
+         ) values
+           ($1, $2, $3, null, null, $4, 'approved', $5::jsonb, '{}'::jsonb,
+            'selected_fields', null),
+           ($6, $7, $8, null, null, $4, 'approved', $9::jsonb, '{}'::jsonb,
+            'selected_fields', null)`,
+        [
+          DESCRIPTION_EVIDENCE_SOURCE_ID,
+          "description_fixture_evidence",
+          "Description fixture parent evidence",
+          CREATED_AT,
+          JSON.stringify(evidencePolicy),
+          DESCRIPTION_FIXTURE_SOURCE_ID,
+          "description_fixture_candidates",
+          "Description fixture candidate source",
+          JSON.stringify(candidatePolicy),
+        ],
+      );
+      for (const [index, work] of ENRICHMENT_SAMPLE_MANIFEST.works.entries()) {
+        const ids = descriptionFixtureIds(work.workId);
+        await sql.unsafe(
+          `insert into source_records (
+             id, source_id, record_key, source_revision, source_modified_at,
+             retrieved_at, payload_json, payload_hash, importer_version,
+             source_row_hash, state
+           ) values
+             ($1, $2, $3, $4, null, $5, null, null,
+              'description-fixture-v1', $6, 'active'),
+             ($7, $8, $9, $10, null, $5, null, null,
+              'description-fixture-v1', $11, 'active')`,
+          [
+            ids.evidenceSourceRecordId,
+            DESCRIPTION_EVIDENCE_SOURCE_ID,
+            `evidence:${work.workId}`,
+            "description-parent-evidence-revision-v1",
+            CREATED_AT + index,
+            hashCanonicalJson({ kind: "evidence", workId: work.workId }),
+            ids.candidateSourceRecordId,
+            DESCRIPTION_FIXTURE_SOURCE_ID,
+            `candidate:${work.workId}`,
+            "description-candidate-fixture-revision-v1",
+            hashCanonicalJson({ kind: "candidate", workId: work.workId }),
+          ],
+        );
+        await sql.unsafe(
+          `insert into source_record_links (
+             source_record_id, entity_type, entity_id, match_kind,
+             mapping_confidence, state, actor_ref, reason, created_at
+           ) values
+             ($1, 'work', $2, 'curated', 1, 'active',
+              'system:description-fixture',
+              'Active identity-verified parent evidence fixture', $3),
+             ($4, 'work', $2, 'curated', 1, 'active',
+              'system:description-fixture',
+              'Active description candidate fixture source', $3)`,
+          [
+            ids.evidenceSourceRecordId,
+            work.workId,
+            CREATED_AT + index,
+            ids.candidateSourceRecordId,
+          ],
+        );
+        const values: Array<[string, unknown]> = [
+          ["work.preferred_title", work.title],
+          ["work.first_publication_date", String(1900 + index)],
+          ["work.categories", [`fixture-category-${index}`]],
+        ];
+        for (const [fieldKey, value] of values) {
+          await sql.unsafe(
+            `insert into field_observations (
+               id, source_record_id, entity_type, entity_id, field_key,
+               value_json, comparison_hash, provenance_kind, source_path,
+               source_modified_at, retrieved_at, mapping_confidence, state,
+               actor_ref, reason, derivation_name, derivation_version,
+               parent_ids_json
+             ) values (
+               $1, $2, 'work', $3, $4, $5::jsonb, $6, 'curated', $4, null,
+               $7, 1, 'active', 'system:description-fixture',
+               'Approved deterministic parent evidence', null, null, null
+             )`,
+            [
+              parentObservationId(work.workId, fieldKey),
+              ids.evidenceSourceRecordId,
+              work.workId,
+              fieldKey,
+              JSON.stringify(value),
+              hashCanonicalJson(value),
+              CREATED_AT + index,
+            ],
+          );
+        }
+      }
+    });
+  } finally {
+    await client.end({ timeout: 5_000 });
+  }
+};

--- a/src/db/catalog/enrichment/descriptions/fixtures.ts
+++ b/src/db/catalog/enrichment/descriptions/fixtures.ts
@@ -54,46 +54,55 @@ export const descriptionFixtureIds = (workId: string) => ({
   ] as const,
 });
 
-export const DESCRIPTION_FIXTURE_TEXT = [
-  "This recorded evaluation fixture follows a central figure whose ordinary",
-  "plans change after a difficult responsibility arrives without warning.",
-  "The setting brings together family pressure, public expectations, and",
-  "questions about where loyalty should rest. As the situation develops, the",
-  "character must understand unfamiliar people while deciding which inherited",
-  "assumptions remain useful. The account focuses on choices, relationships,",
-  "and the consequences of entering a larger conflict. Its perspective stays",
-  "close to the character's uncertainty, giving the story a clear human",
-  "center without describing its outcome or making claims about quality.",
-].join(" ");
+const workFixture = (workId: string) => {
+  const index = ENRICHMENT_SAMPLE_MANIFEST.works.findIndex(
+    (work) => work.workId === workId,
+  );
+  const work = ENRICHMENT_SAMPLE_MANIFEST.works[index];
+  if (!work) throw new Error(`Description fixture work not found: ${workId}`);
+  return {
+    category: `fixture-category-${index}`,
+    firstPublication: String(1900 + index),
+    title: work.title,
+  };
+};
 
-export const DESCRIPTION_FIXTURE_ALTERNATE_TEXT = [
-  "This deterministic review fixture begins with a person returning to a",
-  "community shaped by memory, duty, and unresolved questions. A new problem",
-  "forces several relationships into the open and makes earlier choices",
-  "matter again. The narrative observes how trust changes when private",
-  "knowledge becomes difficult to contain. Rather than explaining the final",
-  "result, this summary stays with the opening pressure and the competing",
-  "responsibilities it creates. The setting and the character's history give",
-  "the conflict a specific frame while the language remains factual, measured,",
-  "and suitable for a bounded catalog-enrichment test.",
-].join(" ");
-
-const claimsFor = (workId: string) => {
-  const ids = descriptionFixtureIds(workId).parents;
+export const descriptionFixtureText = (workId: string): string => {
+  const fixture = workFixture(workId);
   return [
-    {
-      text: "The record has a verified work identity.",
-      parentObservationIds: [ids[0]],
-    },
-    {
-      text: "The work has publication context.",
-      parentObservationIds: [ids[1]],
-    },
-    {
-      text: "The work has a reviewed category.",
-      parentObservationIds: [ids[2]],
-    },
-  ] as const;
+    `The catalog identifies this work as ${fixture.title}, using its approved work record as the sole basis for the title and identity stated here.`,
+    `Its recorded first-publication context is ${fixture.firstPublication}; this fixture does not infer a more precise date, edition, publisher, setting, plot, character, or outcome.`,
+    `The approved category record places the work in ${fixture.category}; no review, recommendation, popularity claim, retailer wording, publisher prose, or external synopsis is reused here.`,
+    "These bounded statements are intentionally neutral and preserve the distinction between structured catalog evidence and prose that requires separate rights and editorial review.",
+  ].join(" ");
+};
+
+export const descriptionFixtureAlternateText = (workId: string): string => {
+  const fixture = workFixture(workId);
+  return [
+    `The approved catalog record names this work ${fixture.title}, and the work ID keeps that title separate from the facts of any one edition.`,
+    `The work record gives ${fixture.firstPublication} as its first-publication context, with no added month, day, press, format, language, page count, plot event, or ending.`,
+    `The approved category is ${fixture.category}; this text adds no rating, sales claim, praise, shop copy, source copy, outside plot summary, or claim about quality.`,
+    "It stays within the few facts recorded for this test and does not guess at details that the evidence does not support.",
+  ].join(" ");
+};
+
+const firstFixtureWorkId = ENRICHMENT_SAMPLE_MANIFEST.works[0].workId;
+export const DESCRIPTION_FIXTURE_TEXT =
+  descriptionFixtureText(firstFixtureWorkId);
+export const DESCRIPTION_FIXTURE_ALTERNATE_TEXT =
+  descriptionFixtureAlternateText(firstFixtureWorkId);
+
+const claimsFor = (workId: string, text: string) => {
+  const ids = descriptionFixtureIds(workId).parents;
+  const claimTexts = (text.match(/[^.!?]+(?:[.!?]+|$)/gu) ?? [])
+    .map((claim) => claim.trim())
+    .filter(Boolean);
+  return claimTexts.map((claim, index) => ({
+    text: claim,
+    parentObservationIds:
+      index < ids.length ? [ids[index]] : [ids[0], ids[1], ids[2]],
+  }));
 };
 
 const common = (
@@ -110,7 +119,7 @@ const common = (
   sourceRevision: "description-candidate-fixture-revision-v1",
   sourcePolicyVersion: DESCRIPTION_FIXTURE_SOURCE_POLICY_VERSION,
   descriptionPolicyVersion: DESCRIPTION_POLICY_VERSION,
-  claims: claimsFor(workId),
+  claims: claimsFor(workId, text),
   comparisonTexts: [],
   createdAt,
 });
@@ -119,7 +128,7 @@ export const modelDescriptionFixture = (
   workId: string = ENRICHMENT_SAMPLE_MANIFEST.works[0].workId,
   overrides: Partial<ModelDescriptionInput> = {},
 ): ModelDescriptionInput => ({
-  ...common(workId, DESCRIPTION_FIXTURE_TEXT, CREATED_AT),
+  ...common(workId, descriptionFixtureText(workId), CREATED_AT),
   descriptionClass: "model_assisted_candidate",
   model: {
     modelId: "provider-neutral.recorded-fixture",
@@ -138,7 +147,7 @@ export const editorialDescriptionFixture = (
   workId: string = ENRICHMENT_SAMPLE_MANIFEST.works[1].workId,
   overrides: Partial<EditorialDescriptionInput> = {},
 ): EditorialDescriptionInput => ({
-  ...common(workId, DESCRIPTION_FIXTURE_TEXT, CREATED_AT + 10),
+  ...common(workId, descriptionFixtureText(workId), CREATED_AT + 10),
   descriptionClass: "bukie_editorial",
   editorial: {
     editorRef: "user:editor-fixture",
@@ -152,14 +161,14 @@ export const licensedDescriptionFixture = (
   workId: string = ENRICHMENT_SAMPLE_MANIFEST.works[2].workId,
   overrides: Partial<LicensedDescriptionInput> = {},
 ): LicensedDescriptionInput => ({
-  ...common(workId, DESCRIPTION_FIXTURE_TEXT, CREATED_AT + 20),
+  ...common(workId, descriptionFixtureText(workId), CREATED_AT + 20),
   descriptionClass: "licensed_verbatim",
   license: {
     name: "Recorded fixture license",
     url: "https://example.invalid/recorded-fixture-license",
     attributionText: "Recorded fixture source",
     derivativesPermitted: false,
-    sourceText: DESCRIPTION_FIXTURE_TEXT,
+    sourceText: descriptionFixtureText(workId),
     transformed: false,
   },
   ...overrides,

--- a/src/db/catalog/enrichment/descriptions/repository.pg.test.ts
+++ b/src/db/catalog/enrichment/descriptions/repository.pg.test.ts
@@ -185,7 +185,6 @@ describe.skipIf(!isolatedUrl)(
       const overflow = await createDescriptionCandidatePostgres({
         url: target.url,
         candidate: licensedDescriptionFixture(undefined, {
-          text: DESCRIPTION_FIXTURE_TEXT,
           createdAt: NOW + 4,
           sensitiveContent: true,
         }),
@@ -445,7 +444,13 @@ describe.skipIf(!isolatedUrl)(
         await derivativeClient.unsafe(
           `update metadata_sources
            set metadata_policy = jsonb_set(
-             metadata_policy, '{textPermission,transform}', 'true'::jsonb
+             case
+               when jsonb_typeof(metadata_policy) = 'string'
+                 then (metadata_policy #>> '{}')::jsonb
+               else metadata_policy
+             end,
+             '{textPermission,transform}',
+             'true'::jsonb
            )
            where id = $1`,
           [DESCRIPTION_FIXTURE_SOURCE_ID],

--- a/src/db/catalog/enrichment/descriptions/repository.pg.test.ts
+++ b/src/db/catalog/enrichment/descriptions/repository.pg.test.ts
@@ -56,6 +56,29 @@ describe.skipIf(!isolatedUrl)(
       expect(model.queue).toBe("queued");
       expect(retry.changed).toBe(false);
       expect(retry.queue).toBe("deduplicated");
+      expect(retry.validation.warningCodes).toEqual(
+        model.validation.warningCodes,
+      );
+      const unsupported = await createDescriptionCandidatePostgres({
+        url: target.url,
+        candidate: modelDescriptionFixture(undefined, {
+          claims: [
+            {
+              text: "Unsupported fixture claim",
+              parentObservationIds: ["missing"],
+            },
+          ],
+          createdAt: NOW + 7,
+        }),
+        queueCapacity: 3,
+      });
+      expect(unsupported.state).toBe("rejected");
+      expect(unsupported.validation.rejectionCodes).toEqual(
+        expect.arrayContaining([
+          "claim_unsupported",
+          "specificity_insufficient",
+        ]),
+      );
       await expect(
         reviewDescriptionCandidatePostgres({
           url: target.url,
@@ -176,8 +199,8 @@ describe.skipIf(!isolatedUrl)(
         scopeWorks: 5,
       });
       expect(metrics).toMatchObject({
-        candidates: 4,
-        rejected: 1,
+        candidates: 5,
+        rejected: 2,
         eligible: 0,
         withdrawn: 1,
         invalidated: 1,
@@ -185,15 +208,15 @@ describe.skipIf(!isolatedUrl)(
         byClass: {
           licensed_verbatim: 2,
           bukie_editorial: 1,
-          model_assisted_candidate: 1,
+          model_assisted_candidate: 2,
         },
       });
       expect(metrics.tokens).toEqual({
-        input: 320,
-        output: 112,
-        total: 432,
+        input: 640,
+        output: 224,
+        total: 864,
       });
-      expect(metrics.estimate500.costMicrousd).toBe(420_000);
+      expect(metrics.estimate500.costMicrousd).toBe(840_000);
     }, 120_000);
   },
 );

--- a/src/db/catalog/enrichment/descriptions/repository.pg.test.ts
+++ b/src/db/catalog/enrichment/descriptions/repository.pg.test.ts
@@ -1,0 +1,199 @@
+import postgres from "postgres";
+import { describe, expect, it } from "vitest";
+import { buildCatalogImportGraph } from "../../importer";
+import { rebuildCatalogPostgres } from "../../postgres-rebuild";
+import { resolveRebuildTarget } from "../../rebuild-safety";
+import { SAMPLE_BASELINE_IMPORT_RECORDS } from "../fixtures";
+import {
+  DESCRIPTION_FIXTURE_ALTERNATE_TEXT,
+  DESCRIPTION_FIXTURE_TEXT,
+  editorialDescriptionFixture,
+  licensedDescriptionFixture,
+  modelDescriptionFixture,
+  seedDescriptionFixturesPostgres,
+} from "./fixtures";
+import {
+  createDescriptionCandidatePostgres,
+  descriptionMetricsPostgres,
+  reviewDescriptionCandidatePostgres,
+  transitionDescriptionCandidatePostgres,
+} from "./repository.pg";
+import { DESCRIPTION_POLICY_VERSION } from "./types";
+
+const isolatedUrl = process.env.CATALOG_TEST_POSTGRES_URL;
+const NOW = Date.UTC(2026, 6, 29, 12, 0, 0);
+
+describe.skipIf(!isolatedUrl)(
+  "Postgres evidence-gated description lifecycle",
+  () => {
+    it("matches SQLite lifecycle, queue, retry, rollback, and metrics behavior", async () => {
+      const target = resolveRebuildTarget({
+        rawTarget: `postgres:${isolatedUrl}`,
+        confirmDisposable: true,
+        env: { NODE_ENV: "test" },
+      });
+      if (target.driver !== "postgres") {
+        throw new Error("Expected an isolated Postgres target");
+      }
+      await rebuildCatalogPostgres({
+        url: target.url,
+        graph: buildCatalogImportGraph(SAMPLE_BASELINE_IMPORT_RECORDS),
+      });
+      await seedDescriptionFixturesPostgres(target.url);
+
+      const modelInput = modelDescriptionFixture();
+      const model = await createDescriptionCandidatePostgres({
+        url: target.url,
+        candidate: modelInput,
+        queueCapacity: 3,
+      });
+      const retry = await createDescriptionCandidatePostgres({
+        url: target.url,
+        candidate: modelInput,
+        queueCapacity: 3,
+      });
+      expect(model.state).toBe("review_required");
+      expect(model.queue).toBe("queued");
+      expect(retry.changed).toBe(false);
+      expect(retry.queue).toBe("deduplicated");
+      await expect(
+        reviewDescriptionCandidatePostgres({
+          url: target.url,
+          candidateId: model.candidateId,
+          reviewerRef: "user:pg-reviewer",
+          decision: "approve",
+          reason: "Postgres evidence review",
+          acknowledgedWarningCodes: model.validation.warningCodes,
+          reviewedAt: NOW,
+          failAfter: "queue",
+        }),
+      ).rejects.toThrow("Forced Postgres description review");
+      const client = postgres(target.url, { max: 1 });
+      try {
+        const rows = await client.unsafe(
+          `select d.state, q.state as "queueState"
+           from description_decision_heads h
+           join description_decisions d on d.id = h.decision_id
+           join description_review_queue q on q.candidate_id = h.candidate_id
+           where h.candidate_id = $1`,
+          [model.candidateId],
+        );
+        expect(rows[0]).toMatchObject({
+          state: "review_required",
+          queueState: "queued",
+        });
+      } finally {
+        await client.end({ timeout: 5_000 });
+      }
+      await reviewDescriptionCandidatePostgres({
+        url: target.url,
+        candidateId: model.candidateId,
+        reviewerRef: "user:pg-reviewer",
+        decision: "approve",
+        reason: "Postgres evidence review",
+        acknowledgedWarningCodes: model.validation.warningCodes,
+        reviewedAt: NOW + 1,
+      });
+
+      const editorial = await createDescriptionCandidatePostgres({
+        url: target.url,
+        candidate: editorialDescriptionFixture(),
+        queueCapacity: 3,
+      });
+      await expect(
+        reviewDescriptionCandidatePostgres({
+          url: target.url,
+          candidateId: editorial.candidateId,
+          reviewerRef: "user:editor-fixture",
+          decision: "approve",
+          reason: "Self review",
+          acknowledgedWarningCodes: editorial.validation.warningCodes,
+          reviewedAt: NOW + 2,
+        }),
+      ).rejects.toThrow("reviewer must differ from editor");
+      await reviewDescriptionCandidatePostgres({
+        url: target.url,
+        candidateId: editorial.candidateId,
+        reviewerRef: "user:pg-editorial-reviewer",
+        decision: "approve",
+        reason: "Editorial evidence and revision reviewed",
+        acknowledgedWarningCodes: editorial.validation.warningCodes,
+        reviewedAt: NOW + 3,
+      });
+
+      const licensedRejected = await createDescriptionCandidatePostgres({
+        url: target.url,
+        candidate: licensedDescriptionFixture(undefined, {
+          text: DESCRIPTION_FIXTURE_ALTERNATE_TEXT,
+          license: {
+            name: "Recorded fixture license",
+            url: "https://example.invalid/recorded-fixture-license",
+            attributionText: "Recorded fixture source",
+            derivativesPermitted: true,
+            sourceText: DESCRIPTION_FIXTURE_TEXT,
+            transformed: true,
+          },
+        }),
+        queueCapacity: 3,
+      });
+      expect(licensedRejected.state).toBe("rejected");
+      expect(licensedRejected.validation.rejectionCodes).toContain(
+        "licensed_derivative_not_permitted",
+      );
+
+      const overflow = await createDescriptionCandidatePostgres({
+        url: target.url,
+        candidate: licensedDescriptionFixture(undefined, {
+          text: DESCRIPTION_FIXTURE_TEXT,
+          createdAt: NOW + 4,
+          sensitiveContent: true,
+        }),
+        queueCapacity: 0,
+      });
+      expect(overflow.state).toBe("paused");
+      expect(overflow.queue).toBe("overflow_paused");
+
+      await transitionDescriptionCandidatePostgres({
+        url: target.url,
+        candidateId: model.candidateId,
+        state: "withdrawn",
+        actorRef: "user:pg-reviewer",
+        reason: "Postgres withdrawal proof",
+        policyVersion: DESCRIPTION_POLICY_VERSION,
+        at: NOW + 5,
+      });
+      await transitionDescriptionCandidatePostgres({
+        url: target.url,
+        candidateId: editorial.candidateId,
+        state: "invalidated",
+        actorRef: "system:pg-policy",
+        reason: "Postgres policy invalidation proof",
+        policyVersion: "description-gates-pg-v2",
+        at: NOW + 6,
+      });
+      const metrics = await descriptionMetricsPostgres({
+        url: target.url,
+        scopeWorks: 5,
+      });
+      expect(metrics).toMatchObject({
+        candidates: 4,
+        rejected: 1,
+        eligible: 0,
+        withdrawn: 1,
+        invalidated: 1,
+        paused: 1,
+        byClass: {
+          licensed_verbatim: 2,
+          bukie_editorial: 1,
+          model_assisted_candidate: 1,
+        },
+      });
+      expect(metrics.tokens).toEqual({
+        input: 320,
+        output: 112,
+        total: 432,
+      });
+      expect(metrics.estimate500.costMicrousd).toBe(420_000);
+    }, 120_000);
+  },
+);

--- a/src/db/catalog/enrichment/descriptions/repository.pg.test.ts
+++ b/src/db/catalog/enrichment/descriptions/repository.pg.test.ts
@@ -4,9 +4,13 @@ import { buildCatalogImportGraph } from "../../importer";
 import { rebuildCatalogPostgres } from "../../postgres-rebuild";
 import { resolveRebuildTarget } from "../../rebuild-safety";
 import { SAMPLE_BASELINE_IMPORT_RECORDS } from "../fixtures";
+import { ENRICHMENT_SAMPLE_MANIFEST } from "../sample-manifest";
 import {
   DESCRIPTION_FIXTURE_ALTERNATE_TEXT,
+  DESCRIPTION_FIXTURE_SOURCE_ID,
   DESCRIPTION_FIXTURE_TEXT,
+  descriptionFixtureAlternateText,
+  descriptionFixtureIds,
   editorialDescriptionFixture,
   licensedDescriptionFixture,
   modelDescriptionFixture,
@@ -15,13 +19,23 @@ import {
 import {
   createDescriptionCandidatePostgres,
   descriptionMetricsPostgres,
+  getDescriptionProposalPostgres,
+  reconcileDescriptionCandidatePostgres,
+  requestDescriptionRereviewPostgres,
+  retryDescriptionQueuePostgres,
   reviewDescriptionCandidatePostgres,
+  rollbackDescriptionProjectionPostgres,
   transitionDescriptionCandidatePostgres,
 } from "./repository.pg";
 import { DESCRIPTION_POLICY_VERSION } from "./types";
 
 const isolatedUrl = process.env.CATALOG_TEST_POSTGRES_URL;
 const NOW = Date.UTC(2026, 6, 29, 12, 0, 0);
+const MODEL_REVIEW_POLICY = {
+  descriptionPolicyVersion: DESCRIPTION_POLICY_VERSION,
+  currentModelVersion: "fixture-model-v1",
+  currentPromptVersion: "fixture-prompt-v1",
+} as const;
 
 describe.skipIf(!isolatedUrl)(
   "Postgres evidence-gated description lifecycle",
@@ -81,6 +95,7 @@ describe.skipIf(!isolatedUrl)(
       );
       await expect(
         reviewDescriptionCandidatePostgres({
+          ...MODEL_REVIEW_POLICY,
           url: target.url,
           candidateId: model.candidateId,
           reviewerRef: "user:pg-reviewer",
@@ -109,6 +124,7 @@ describe.skipIf(!isolatedUrl)(
         await client.end({ timeout: 5_000 });
       }
       await reviewDescriptionCandidatePostgres({
+        ...MODEL_REVIEW_POLICY,
         url: target.url,
         candidateId: model.candidateId,
         reviewerRef: "user:pg-reviewer",
@@ -125,6 +141,7 @@ describe.skipIf(!isolatedUrl)(
       });
       await expect(
         reviewDescriptionCandidatePostgres({
+          descriptionPolicyVersion: DESCRIPTION_POLICY_VERSION,
           url: target.url,
           candidateId: editorial.candidateId,
           reviewerRef: "user:editor-fixture",
@@ -135,6 +152,7 @@ describe.skipIf(!isolatedUrl)(
         }),
       ).rejects.toThrow("reviewer must differ from editor");
       await reviewDescriptionCandidatePostgres({
+        descriptionPolicyVersion: DESCRIPTION_POLICY_VERSION,
         url: target.url,
         candidateId: editorial.candidateId,
         reviewerRef: "user:pg-editorial-reviewer",
@@ -217,6 +235,279 @@ describe.skipIf(!isolatedUrl)(
         total: 864,
       });
       expect(metrics.estimate500.costMicrousd).toBe(840_000);
+    }, 120_000);
+
+    it("matches SQLite re-review, live-policy, queue, rollback, and read behavior", async () => {
+      const target = resolveRebuildTarget({
+        rawTarget: `postgres:${isolatedUrl}`,
+        confirmDisposable: true,
+        env: { NODE_ENV: "test" },
+      });
+      if (target.driver !== "postgres") {
+        throw new Error("Expected an isolated Postgres target");
+      }
+      await rebuildCatalogPostgres({
+        url: target.url,
+        graph: buildCatalogImportGraph(SAMPLE_BASELINE_IMPORT_RECORDS),
+      });
+      await seedDescriptionFixturesPostgres(target.url);
+
+      const rejected = await createDescriptionCandidatePostgres({
+        url: target.url,
+        candidate: modelDescriptionFixture(undefined, {
+          claims: [
+            {
+              text: "Unsupported fixture claim.",
+              parentObservationIds: ["missing"],
+            },
+          ],
+        }),
+        queueCapacity: 3,
+      });
+      await expect(
+        requestDescriptionRereviewPostgres({
+          url: target.url,
+          candidateId: rejected.candidateId,
+          policyVersion: "description-gates-pg-v2",
+          currentModelVersion: "fixture-model-v1",
+          currentPromptVersion: "fixture-prompt-v1",
+          queueCapacity: 3,
+          requestedAt: NOW,
+        }),
+      ).rejects.toThrow("hard rejection");
+
+      const modelInput = modelDescriptionFixture(
+        ENRICHMENT_SAMPLE_MANIFEST.works[1].workId,
+      );
+      const model = await createDescriptionCandidatePostgres({
+        url: target.url,
+        candidate: modelInput,
+        queueCapacity: 3,
+      });
+      const client = postgres(target.url, { max: 1 });
+      try {
+        await client.unsafe(
+          "update metadata_sources set approval_state = 'suspended' where id = $1",
+          [DESCRIPTION_FIXTURE_SOURCE_ID],
+        );
+      } finally {
+        await client.end({ timeout: 5_000 });
+      }
+      await expect(
+        reviewDescriptionCandidatePostgres({
+          ...MODEL_REVIEW_POLICY,
+          url: target.url,
+          candidateId: model.candidateId,
+          reviewerRef: "user:pg-stale-reviewer",
+          decision: "approve",
+          reason: "Stale evidence must not pass",
+          acknowledgedWarningCodes: model.validation.warningCodes,
+          reviewedAt: NOW + 1,
+        }),
+      ).rejects.toThrow("current evidence or policy is ineligible");
+      const restoreClient = postgres(target.url, { max: 1 });
+      try {
+        await restoreClient.unsafe(
+          "update metadata_sources set approval_state = 'approved' where id = $1",
+          [DESCRIPTION_FIXTURE_SOURCE_ID],
+        );
+      } finally {
+        await restoreClient.end({ timeout: 5_000 });
+      }
+      await reviewDescriptionCandidatePostgres({
+        ...MODEL_REVIEW_POLICY,
+        url: target.url,
+        candidateId: model.candidateId,
+        reviewerRef: "user:pg-live-reviewer",
+        decision: "approve",
+        reason: "Current evidence reviewed",
+        acknowledgedWarningCodes: model.validation.warningCodes,
+        reviewedAt: NOW + 2,
+      });
+      expect(
+        await getDescriptionProposalPostgres({
+          url: target.url,
+          workId: modelInput.workId,
+          descriptionPolicyVersion: DESCRIPTION_POLICY_VERSION,
+          currentModelVersion: modelInput.model.modelVersion,
+          currentPromptVersion: modelInput.model.promptVersion,
+        }),
+      ).toBeDefined();
+      expect(
+        await reconcileDescriptionCandidatePostgres({
+          url: target.url,
+          candidateId: model.candidateId,
+          descriptionPolicyVersion: "description-gates-pg-v2",
+          currentModelVersion: modelInput.model.modelVersion,
+          currentPromptVersion: modelInput.model.promptVersion,
+          queueCapacity: 3,
+          reconciledAt: NOW + 3,
+        }),
+      ).toBe("rereview_required");
+
+      const overflowInput = licensedDescriptionFixture(
+        ENRICHMENT_SAMPLE_MANIFEST.works[4].workId,
+        { sensitiveContent: true },
+      );
+      const overflow = await createDescriptionCandidatePostgres({
+        url: target.url,
+        candidate: overflowInput,
+        queueCapacity: 0,
+      });
+      expect(overflow.state).toBe("paused");
+      expect(
+        await retryDescriptionQueuePostgres({
+          url: target.url,
+          candidateId: overflow.candidateId,
+          queueCapacity: 3,
+          now: NOW + 4,
+        }),
+      ).toBe("queued");
+
+      const rollbackWorkId = ENRICHMENT_SAMPLE_MANIFEST.works[2].workId;
+      const firstInput = licensedDescriptionFixture(rollbackWorkId, {
+        sensitiveContent: true,
+      });
+      const first = await createDescriptionCandidatePostgres({
+        url: target.url,
+        candidate: firstInput,
+        queueCapacity: 3,
+      });
+      await reviewDescriptionCandidatePostgres({
+        descriptionPolicyVersion: DESCRIPTION_POLICY_VERSION,
+        url: target.url,
+        candidateId: first.candidateId,
+        reviewerRef: "user:pg-first-reviewer",
+        decision: "approve",
+        reason: "First rollback fixture reviewed",
+        acknowledgedWarningCodes: first.validation.warningCodes,
+        reviewedAt: NOW + 5,
+      });
+      const projectionClient = postgres(target.url, { max: 1 });
+      let firstProjectionId: string;
+      try {
+        const rows = await projectionClient.unsafe(
+          "select projection_id as id from description_projection_heads where work_id = $1",
+          [rollbackWorkId],
+        );
+        firstProjectionId = String(rows[0].id);
+      } finally {
+        await projectionClient.end({ timeout: 5_000 });
+      }
+      const secondText = descriptionFixtureAlternateText(rollbackWorkId);
+      const second = await createDescriptionCandidatePostgres({
+        url: target.url,
+        candidate: licensedDescriptionFixture(rollbackWorkId, {
+          text: secondText,
+          sensitiveContent: true,
+          license: {
+            name: "Recorded fixture license",
+            url: "https://example.invalid/recorded-fixture-license",
+            attributionText: "Recorded fixture source",
+            derivativesPermitted: false,
+            sourceText: secondText,
+            transformed: false,
+          },
+        }),
+        queueCapacity: 3,
+      });
+      await reviewDescriptionCandidatePostgres({
+        descriptionPolicyVersion: DESCRIPTION_POLICY_VERSION,
+        url: target.url,
+        candidateId: second.candidateId,
+        reviewerRef: "user:pg-second-reviewer",
+        decision: "approve",
+        reason: "Second rollback fixture reviewed",
+        acknowledgedWarningCodes: second.validation.warningCodes,
+        reviewedAt: NOW + 6,
+      });
+      await rollbackDescriptionProjectionPostgres({
+        url: target.url,
+        workId: rollbackWorkId,
+        targetProjectionId: firstProjectionId,
+        actorRef: "user:pg-rollback-reviewer",
+        reason: "rollback_approved",
+        policyVersion: DESCRIPTION_POLICY_VERSION,
+        rolledBackAt: NOW + 7,
+      });
+      expect(
+        (
+          await getDescriptionProposalPostgres({
+            url: target.url,
+            workId: rollbackWorkId,
+            descriptionPolicyVersion: DESCRIPTION_POLICY_VERSION,
+          })
+        )?.candidateId,
+      ).toBe(first.candidateId);
+
+      const derivativeClient = postgres(target.url, { max: 1 });
+      try {
+        await derivativeClient.unsafe(
+          `update metadata_sources
+           set metadata_policy = jsonb_set(
+             metadata_policy, '{textPermission,transform}', 'true'::jsonb
+           )
+           where id = $1`,
+          [DESCRIPTION_FIXTURE_SOURCE_ID],
+        );
+      } finally {
+        await derivativeClient.end({ timeout: 5_000 });
+      }
+      const derivativeWorkId = ENRICHMENT_SAMPLE_MANIFEST.works[3].workId;
+      const derivative = await createDescriptionCandidatePostgres({
+        url: target.url,
+        candidate: licensedDescriptionFixture(derivativeWorkId, {
+          text: descriptionFixtureAlternateText(derivativeWorkId),
+          license: {
+            name: "Recorded derivative fixture license",
+            url: "https://example.invalid/recorded-derivative-license",
+            attributionText: "Recorded derivative fixture source",
+            derivativesPermitted: true,
+            sourceText: DESCRIPTION_FIXTURE_TEXT,
+            transformed: true,
+          },
+        }),
+        queueCapacity: 3,
+      });
+      expect(derivative.validation.rejectionCodes).not.toContain(
+        "licensed_derivative_not_permitted",
+      );
+
+      const reviewedBefore = (
+        await descriptionMetricsPostgres({ url: target.url, scopeWorks: 5 })
+      ).reviewed;
+      await transitionDescriptionCandidatePostgres({
+        url: target.url,
+        candidateId: overflow.candidateId,
+        state: "withdrawn",
+        actorRef: "system:pg-withdrawal",
+        reason: "Unreviewed withdrawal",
+        policyVersion: DESCRIPTION_POLICY_VERSION,
+        at: NOW + 8,
+      });
+      expect(
+        (await descriptionMetricsPostgres({ url: target.url, scopeWorks: 5 }))
+          .reviewed,
+      ).toBe(reviewedBefore);
+
+      const revokeClient = postgres(target.url, { max: 1 });
+      try {
+        await revokeClient.unsafe(
+          "update field_observations set state = 'withdrawn' where id = $1",
+          [descriptionFixtureIds(modelInput.workId).parents[0]],
+        );
+      } finally {
+        await revokeClient.end({ timeout: 5_000 });
+      }
+      expect(
+        await getDescriptionProposalPostgres({
+          url: target.url,
+          workId: modelInput.workId,
+          descriptionPolicyVersion: "description-gates-pg-v2",
+          currentModelVersion: modelInput.model.modelVersion,
+          currentPromptVersion: modelInput.model.promptVersion,
+        }),
+      ).toBeUndefined();
     }, 120_000);
   },
 );

--- a/src/db/catalog/enrichment/descriptions/repository.pg.ts
+++ b/src/db/catalog/enrichment/descriptions/repository.pg.ts
@@ -64,11 +64,19 @@ type CandidateRow = {
     | "bukie_editorial"
     | "model_assisted_candidate";
   textContent: string;
+  sourceRevision: string;
+  sourcePolicyVersion: string;
+  descriptionPolicyVersion: string;
+  attributionText: string | null;
+  licensedSourceTextHash: string | null;
+  licensedTextTransformed: boolean | null;
   editorRef: string | null;
   modelVersion: string | null;
   promptVersion: string | null;
   qualityScore: number | null;
 };
+
+type PgSql = Pick<ReturnType<typeof postgres>, "unsafe">;
 
 const uniqueSorted = <T extends string>(values: readonly T[]): T[] =>
   [...new Set(values)].sort();
@@ -130,6 +138,27 @@ const sourceAllowsCandidate = (
   );
 };
 
+const sourceAllowsStoredCandidate = (
+  source: SourceRow | undefined,
+  candidate: CandidateRow,
+): boolean => {
+  if (
+    !source ||
+    source.sourceApproval !== "approved" ||
+    source.sourceRecordState !== "active" ||
+    source.sourceLinkState !== "active"
+  ) {
+    return false;
+  }
+  const policy = policyObject(source.metadataPolicy);
+  return Boolean(
+    policy.sourcePolicyVersion === candidate.sourcePolicyVersion &&
+      policy.textPermission?.fetch === true &&
+      Array.isArray(policy.textPermission.allowedFields) &&
+      policy.textPermission.allowedFields.includes("work.description"),
+  );
+};
+
 const parentEvidence = (
   rows: readonly ParentRow[],
 ): DescriptionParentEvidence[] =>
@@ -170,6 +199,18 @@ const candidateFromRow = (row: Record<string, unknown>): CandidateRow => ({
   observationId: String(row.observationId),
   descriptionClass: row.descriptionClass as CandidateRow["descriptionClass"],
   textContent: String(row.textContent),
+  sourceRevision: String(row.sourceRevision),
+  sourcePolicyVersion: String(row.sourcePolicyVersion),
+  descriptionPolicyVersion: String(row.descriptionPolicyVersion),
+  attributionText: row.attributionText ? String(row.attributionText) : null,
+  licensedSourceTextHash: row.licensedSourceTextHash
+    ? String(row.licensedSourceTextHash)
+    : null,
+  licensedTextTransformed:
+    row.licensedTextTransformed === null ||
+    row.licensedTextTransformed === undefined
+      ? null
+      : Boolean(row.licensedTextTransformed),
   editorRef: row.editorRef ? String(row.editorRef) : null,
   modelVersion: row.modelVersion ? String(row.modelVersion) : null,
   promptVersion: row.promptVersion ? String(row.promptVersion) : null,
@@ -178,6 +219,129 @@ const candidateFromRow = (row: Record<string, unknown>): CandidateRow => ({
       ? null
       : Number(row.qualityScore),
 });
+
+const storedCandidateEvidenceIsUsablePostgres = async (
+  sql: PgSql,
+  candidate: CandidateRow,
+  input: {
+    currentModelVersion?: string;
+    currentPromptVersion?: string;
+  },
+): Promise<boolean> => {
+  const sourceRows = await sql.unsafe(
+    `select
+       sr.source_revision as "sourceRevision",
+       sr.state as "sourceRecordState",
+       s.approval_state as "sourceApproval",
+       s.metadata_policy as "metadataPolicy",
+       sl.state as "sourceLinkState",
+       o.state as "candidateObservationState"
+     from description_candidates c
+     join field_observations o on o.id = c.observation_id
+     join source_records sr on sr.id = o.source_record_id
+     join metadata_sources s on s.id = sr.source_id
+     left join source_record_links sl
+       on sl.source_record_id = sr.id
+      and sl.entity_type = 'work'
+      and sl.entity_id = c.work_id
+     where c.id = $1`,
+    [candidate.id],
+  );
+  const source = sourceRows[0] as unknown as
+    | (SourceRow & { candidateObservationState: string })
+    | undefined;
+  if (
+    source?.candidateObservationState !== "active" ||
+    source.sourceRevision !== candidate.sourceRevision ||
+    !sourceAllowsStoredCandidate(source, candidate)
+  ) {
+    return false;
+  }
+  const policy = policyObject(source.metadataPolicy);
+  if (
+    candidate.descriptionClass === "licensed_verbatim" &&
+    ((candidate.licensedTextTransformed &&
+      policy.textPermission?.transform !== true) ||
+      (policy.attribution?.required === true &&
+        !candidate.attributionText?.trim()))
+  ) {
+    return false;
+  }
+  if (
+    candidate.descriptionClass === "model_assisted_candidate" &&
+    (!input.currentModelVersion ||
+      !input.currentPromptVersion ||
+      candidate.modelVersion !== input.currentModelVersion ||
+      candidate.promptVersion !== input.currentPromptVersion)
+  ) {
+    return false;
+  }
+  if (candidate.descriptionClass !== "licensed_verbatim") {
+    const coverageRows = await sql.unsafe(
+      `select
+         count(*)::int as claims,
+         count(*) filter (where exists (
+           select 1 from description_claim_evidence evidence
+           where evidence.claim_id = claims.id
+         ))::int as covered
+       from description_claims claims
+       where claims.candidate_id = $1`,
+      [candidate.id],
+    );
+    if (
+      Number(coverageRows[0]?.claims ?? 0) === 0 ||
+      Number(coverageRows[0]?.covered ?? 0) !==
+        Number(coverageRows[0]?.claims ?? 0)
+    ) {
+      return false;
+    }
+  }
+  const parentRows = await sql.unsafe(
+    `select distinct
+       o.id as "id",
+       o.entity_type as "entityType",
+       o.entity_id as "entityId",
+       case
+         when o.entity_type = 'work' then o.entity_id
+         when o.entity_type = 'edition' then e.work_id
+         else null
+       end as "workId",
+       o.field_key as "fieldKey",
+       o.value_json as "valueJson",
+       o.state as "observationState",
+       o.provenance_kind as "provenanceKind",
+       sr.state as "sourceRecordState",
+       s.approval_state as "sourceApproval",
+       sl.state as "sourceLinkState",
+       s.metadata_policy as "metadataPolicy",
+       r.state as "resolutionState"
+     from description_claims c
+     join description_claim_evidence ce on ce.claim_id = c.id
+     join field_observations o on o.id = ce.observation_id
+     join source_records sr on sr.id = o.source_record_id
+     join metadata_sources s on s.id = sr.source_id
+     left join editions e
+       on o.entity_type = 'edition' and e.id = o.entity_id
+     left join source_record_links sl
+       on sl.source_record_id = sr.id
+      and sl.entity_type = o.entity_type
+      and sl.entity_id = o.entity_id
+     left join field_resolution_heads h
+       on h.entity_type = o.entity_type
+      and h.entity_id = o.entity_id
+      and h.field_key = o.field_key
+     left join field_resolutions r on r.id = h.resolution_id
+     where c.candidate_id = $1
+     order by o.id`,
+    [candidate.id],
+  );
+  return !parentEvidence(parentRows as unknown as ParentRow[]).some(
+    (parent) =>
+      !parent.eligible ||
+      parent.unresolvedConflict ||
+      parent.workId !== candidate.workId,
+  );
+};
 
 export const createDescriptionCandidatePostgres = async (input: {
   url: string;
@@ -386,7 +550,8 @@ export const createDescriptionCandidatePostgres = async (input: {
            id, work_id, observation_id, description_class, text_content,
            text_hash, source_revision, source_policy_version,
            description_policy_version, license_name, license_url,
-           attribution_text, derivatives_permitted, editor_ref,
+           attribution_text, derivatives_permitted, licensed_source_text_hash,
+           licensed_text_transformed, editor_ref,
            editorial_reason, editorial_revision, model_id, model_version,
            prompt_version, generation_input_hash, generated_at,
            generation_duration_ms, input_tokens, output_tokens, cost_microusd,
@@ -394,7 +559,7 @@ export const createDescriptionCandidatePostgres = async (input: {
          ) values (
            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14,
            $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26,
-           $27, $28, $29
+           $27, $28, $29, $30, $31
          )`,
         [
           candidateId,
@@ -417,6 +582,12 @@ export const createDescriptionCandidatePostgres = async (input: {
             : null,
           input.candidate.descriptionClass === "licensed_verbatim"
             ? input.candidate.license.derivativesPermitted
+            : null,
+          input.candidate.descriptionClass === "licensed_verbatim"
+            ? hashCanonicalJson(input.candidate.license.sourceText)
+            : null,
+          input.candidate.descriptionClass === "licensed_verbatim"
+            ? input.candidate.license.transformed
             : null,
           input.candidate.descriptionClass === "bukie_editorial"
             ? input.candidate.editorial.editorRef
@@ -625,6 +796,269 @@ export const createDescriptionCandidatePostgres = async (input: {
   }
 };
 
+const loadCurrentCandidatePostgres = async (
+  sql: PgSql,
+  candidateId: string,
+  lock = false,
+): Promise<
+  | {
+      candidate: CandidateRow;
+      decision: DecisionRow;
+    }
+  | undefined
+> => {
+  const rows = await sql.unsafe(
+    `select
+       c.id as "id",
+       c.work_id as "workId",
+       c.observation_id as "observationId",
+       c.description_class as "descriptionClass",
+       c.text_content as "textContent",
+       c.source_revision as "sourceRevision",
+       c.source_policy_version as "sourcePolicyVersion",
+       c.description_policy_version as "descriptionPolicyVersion",
+       c.attribution_text as "attributionText",
+       c.licensed_source_text_hash as "licensedSourceTextHash",
+       c.licensed_text_transformed as "licensedTextTransformed",
+       c.editor_ref as "editorRef",
+       c.model_version as "modelVersion",
+       c.prompt_version as "promptVersion",
+       c.quality_score as "qualityScore",
+       d.id as "decisionId",
+       d.state as "state",
+       d.rejection_codes_json as "rejectionCodes",
+       d.warning_codes_json as "warningCodes",
+       d.reviewer_ref as "reviewerRef",
+       d.review_reason as "reviewReason",
+       d.policy_version as "policyVersion"
+     from description_candidates c
+     join description_decision_heads h on h.candidate_id = c.id
+     join description_decisions d on d.id = h.decision_id
+     where c.id = $1
+     ${lock ? "for update of c, h" : ""}`,
+    [candidateId],
+  );
+  if (!rows[0]) return undefined;
+  const row = rows[0] as Record<string, unknown>;
+  return {
+    candidate: candidateFromRow(row),
+    decision: decisionFromRow({ ...row, id: row.decisionId }),
+  };
+};
+
+const writeDecisionPostgres = async (
+  sql: PgSql,
+  input: {
+    candidateId: string;
+    current: DecisionRow;
+    state: DescriptionDecisionState;
+    rejectionCodes: readonly DescriptionRejectionCode[];
+    warningCodes: readonly DescriptionWarningCode[];
+    reviewerRef?: string | null;
+    reviewReason?: string | null;
+    policyVersion: string;
+    decidedAt: number;
+  },
+): Promise<{ id: string; changed: boolean }> => {
+  const rejectionCodes = uniqueSorted(input.rejectionCodes);
+  const warningCodes = uniqueSorted(input.warningCodes);
+  if (
+    input.current.state === input.state &&
+    input.current.policyVersion === input.policyVersion &&
+    input.current.reviewerRef === (input.reviewerRef ?? null) &&
+    input.current.reviewReason === (input.reviewReason ?? null) &&
+    JSON.stringify(input.current.rejectionCodes) ===
+      JSON.stringify(rejectionCodes) &&
+    JSON.stringify(input.current.warningCodes) === JSON.stringify(warningCodes)
+  ) {
+    return { id: input.current.id, changed: false };
+  }
+  const id = descriptionDecisionIdentity({
+    candidateId: input.candidateId,
+    previousDecisionId: input.current.id,
+    state: input.state,
+    rejectionCodes,
+    warningCodes,
+    reviewerRef: input.reviewerRef ?? null,
+    reviewReason: input.reviewReason ?? null,
+    policyVersion: input.policyVersion,
+  });
+  await sql.unsafe(
+    `insert into description_decisions (
+       id, candidate_id, state, rejection_codes_json, warning_codes_json,
+       reviewer_ref, review_reason, previous_decision_id, policy_version,
+       decided_at
+     ) values ($1, $2, $3, $4::jsonb, $5::jsonb, $6, $7, $8, $9, $10)`,
+    [
+      id,
+      input.candidateId,
+      input.state,
+      JSON.stringify(rejectionCodes),
+      JSON.stringify(warningCodes),
+      input.reviewerRef ?? null,
+      input.reviewReason ?? null,
+      input.current.id,
+      input.policyVersion,
+      input.decidedAt,
+    ],
+  );
+  await sql.unsafe(
+    `update description_decision_heads set decision_id = $1
+     where candidate_id = $2`,
+    [id, input.candidateId],
+  );
+  return { id, changed: true };
+};
+
+const queueCandidatePostgres = async (
+  sql: PgSql,
+  input: {
+    candidateId: string;
+    reasonCodes: readonly DescriptionWarningCode[];
+    capacity: number;
+    now: number;
+  },
+): Promise<DescriptionCandidateResult["queue"]> => {
+  await sql.unsafe("select pg_advisory_xact_lock(133)");
+  const existingRows = await sql.unsafe(
+    "select state from description_review_queue where candidate_id = $1",
+    [input.candidateId],
+  );
+  if (
+    existingRows[0]?.state === "queued" ||
+    existingRows[0]?.state === "claimed"
+  ) {
+    return "deduplicated";
+  }
+  const countRows = await sql.unsafe(
+    `select count(*)::int as count
+     from description_review_queue
+     where state in ('queued', 'claimed')`,
+  );
+  if (
+    Number(countRows[0]?.count ?? 0) >= Math.max(0, Math.trunc(input.capacity))
+  ) {
+    return "overflow_paused";
+  }
+  const reasons = uniqueSorted(input.reasonCodes);
+  const priority = reasons.reduce(
+    (total, code) =>
+      total +
+      (code.includes("sensitive") || code.includes("ambiguous") ? 100 : 10),
+    0,
+  );
+  await sql.unsafe(
+    `insert into description_review_queue (
+       candidate_id, state, priority, reason_codes_json, queued_at,
+       updated_at, reviewer_ref
+     ) values ($1, 'queued', $2, $3::jsonb, $4, $4, null)
+     on conflict(candidate_id) do update set
+       state = 'queued',
+       priority = excluded.priority,
+       reason_codes_json = excluded.reason_codes_json,
+       queued_at = excluded.queued_at,
+       updated_at = excluded.updated_at,
+       reviewer_ref = null`,
+    [input.candidateId, priority, JSON.stringify(reasons), input.now],
+  );
+  return "queued";
+};
+
+const removeProjectionIfSelectedPostgres = async (
+  sql: PgSql,
+  input: {
+    candidate: CandidateRow;
+    state: "withdrawn" | "invalidated";
+    reasonCode: string;
+    actorRef: string;
+    policyVersion: string;
+    at: number;
+  },
+): Promise<void> => {
+  const projectionRows = await sql.unsafe(
+    `select p.id as id, p.candidate_id as "candidateId"
+     from description_projection_heads h
+     join description_projections p on p.id = h.projection_id
+     where h.work_id = $1`,
+    [input.candidate.workId],
+  );
+  if (projectionRows[0]?.candidateId !== input.candidate.id) return;
+  const projectionId = descriptionProjectionIdentity({
+    workId: input.candidate.workId,
+    candidateId: null,
+    previousProjectionId: String(projectionRows[0].id),
+    state: input.state,
+    reasonCode: input.reasonCode,
+    policyVersion: input.policyVersion,
+  });
+  await sql.unsafe(
+    `insert into description_projections (
+       id, work_id, candidate_id, state, previous_projection_id,
+       reason_code, actor_ref, policy_version, projected_at
+     ) values ($1, $2, null, $3, $4, $5, $6, $7, $8)`,
+    [
+      projectionId,
+      input.candidate.workId,
+      input.state,
+      projectionRows[0].id,
+      input.reasonCode,
+      input.actorRef,
+      input.policyVersion,
+      input.at,
+    ],
+  );
+  await sql.unsafe(
+    `update description_projection_heads set projection_id = $1
+     where work_id = $2`,
+    [projectionId, input.candidate.workId],
+  );
+};
+
+export const retryDescriptionQueuePostgres = async (input: {
+  url: string;
+  candidateId: string;
+  queueCapacity: number;
+  now: number;
+}): Promise<DescriptionCandidateResult["queue"]> => {
+  const client = postgres(input.url, { max: 1 });
+  try {
+    return await client.begin(async (sql) => {
+      const current = await loadCurrentCandidatePostgres(
+        sql,
+        input.candidateId,
+        true,
+      );
+      if (!current) throw new Error("Description candidate not found");
+      if (
+        current.decision.state !== "paused" &&
+        current.decision.state !== "review_required"
+      ) {
+        return "not_required";
+      }
+      const queue = await queueCandidatePostgres(sql, {
+        candidateId: input.candidateId,
+        reasonCodes: current.decision.warningCodes,
+        capacity: input.queueCapacity,
+        now: input.now,
+      });
+      if (queue !== "overflow_paused") {
+        await writeDecisionPostgres(sql, {
+          candidateId: input.candidateId,
+          current: current.decision,
+          state: "review_required",
+          rejectionCodes: current.decision.rejectionCodes,
+          warningCodes: current.decision.warningCodes,
+          policyVersion: current.decision.policyVersion,
+          decidedAt: input.now,
+        });
+      }
+      return queue;
+    });
+  } finally {
+    await client.end({ timeout: 5_000 });
+  }
+};
+
 export const reviewDescriptionCandidatePostgres = async (input: {
   url: string;
   candidateId: string;
@@ -632,6 +1066,9 @@ export const reviewDescriptionCandidatePostgres = async (input: {
   decision: "approve" | "reject";
   reason: string;
   acknowledgedWarningCodes?: readonly DescriptionWarningCode[];
+  descriptionPolicyVersion: string;
+  currentModelVersion?: string;
+  currentPromptVersion?: string;
   reviewedAt: number;
   failAfter?: "decision" | "queue" | "projection";
 }): Promise<{
@@ -649,6 +1086,12 @@ export const reviewDescriptionCandidatePostgres = async (input: {
            c.observation_id as "observationId",
            c.description_class as "descriptionClass",
            c.text_content as "textContent",
+           c.source_revision as "sourceRevision",
+           c.source_policy_version as "sourcePolicyVersion",
+           c.description_policy_version as "descriptionPolicyVersion",
+           c.attribution_text as "attributionText",
+           c.licensed_source_text_hash as "licensedSourceTextHash",
+           c.licensed_text_transformed as "licensedTextTransformed",
            c.editor_ref as "editorRef",
            c.model_version as "modelVersion",
            c.prompt_version as "promptVersion",
@@ -675,6 +1118,19 @@ export const reviewDescriptionCandidatePostgres = async (input: {
       });
       const state: "eligible" | "rejected" =
         input.decision === "approve" ? "eligible" : "rejected";
+      if (
+        input.decision === "approve" &&
+        (current.policyVersion !== input.descriptionPolicyVersion ||
+          !(await storedCandidateEvidenceIsUsablePostgres(
+            sql,
+            candidate,
+            input,
+          )))
+      ) {
+        throw new Error(
+          "Description review refused: current evidence or policy is ineligible",
+        );
+      }
       if (
         current.state === state &&
         current.reviewerRef === input.reviewerRef &&
@@ -946,6 +1402,428 @@ export const transitionDescriptionCandidatePostgres = async (input: {
   }
 };
 
+export const requestDescriptionRereviewPostgres = async (input: {
+  url: string;
+  candidateId: string;
+  policyVersion: string;
+  currentModelVersion?: string;
+  currentPromptVersion?: string;
+  queueCapacity: number;
+  requestedAt: number;
+}): Promise<{
+  state: "review_required" | "paused";
+  queue: DescriptionCandidateResult["queue"];
+}> => {
+  const client = postgres(input.url, { max: 1 });
+  try {
+    return await client.begin(async (sql) => {
+      const current = await loadCurrentCandidatePostgres(
+        sql,
+        input.candidateId,
+        true,
+      );
+      if (!current) throw new Error("Description candidate not found");
+      if (
+        current.decision.state === "rejected" ||
+        current.decision.state === "withdrawn" ||
+        current.decision.rejectionCodes.length > 0
+      ) {
+        throw new Error(
+          "Description re-review refused: hard rejection or withdrawal is not reviewable",
+        );
+      }
+      if (
+        !(await storedCandidateEvidenceIsUsablePostgres(
+          sql,
+          current.candidate,
+          input,
+        ))
+      ) {
+        throw new Error(
+          "Description re-review refused: current evidence or model policy is ineligible",
+        );
+      }
+      const warningCodes = uniqueSorted([
+        ...current.decision.warningCodes,
+        "policy_version_review" as const,
+      ]);
+      const queue = await queueCandidatePostgres(sql, {
+        candidateId: input.candidateId,
+        reasonCodes: warningCodes,
+        capacity: input.queueCapacity,
+        now: input.requestedAt,
+      });
+      const state: "review_required" | "paused" =
+        queue === "overflow_paused" ? "paused" : "review_required";
+      await writeDecisionPostgres(sql, {
+        candidateId: input.candidateId,
+        current: current.decision,
+        state,
+        rejectionCodes: current.decision.rejectionCodes,
+        warningCodes,
+        policyVersion: input.policyVersion,
+        decidedAt: input.requestedAt,
+      });
+      await removeProjectionIfSelectedPostgres(sql, {
+        candidate: current.candidate,
+        state: "invalidated",
+        reasonCode: "candidate_rereview_required",
+        actorRef: "system:description-policy",
+        policyVersion: input.policyVersion,
+        at: input.requestedAt,
+      });
+      return { state, queue };
+    });
+  } finally {
+    await client.end({ timeout: 5_000 });
+  }
+};
+
+export const getDescriptionProposalPostgres = async (input: {
+  url: string;
+  workId: string;
+  descriptionPolicyVersion: string;
+  currentModelVersion?: string;
+  currentPromptVersion?: string;
+}): Promise<
+  | {
+      candidateId: string;
+      text: string;
+      descriptionClass: CandidateRow["descriptionClass"];
+      qualityScore: number;
+      publicDisplayEligible: false;
+    }
+  | undefined
+> => {
+  const client = postgres(input.url, { max: 1 });
+  try {
+    const projectionRows = await client.unsafe(
+      `select p.candidate_id as "candidateId", p.state
+       from description_projection_heads h
+       join description_projections p on p.id = h.projection_id
+       where h.work_id = $1`,
+      [input.workId],
+    );
+    const projection = projectionRows[0];
+    if (
+      !projection?.candidateId ||
+      (projection.state !== "selected" && projection.state !== "rolled_back")
+    ) {
+      return undefined;
+    }
+    const current = await loadCurrentCandidatePostgres(
+      client,
+      String(projection.candidateId),
+    );
+    if (
+      !current ||
+      current.decision.state !== "eligible" ||
+      current.decision.policyVersion !== input.descriptionPolicyVersion ||
+      !(await storedCandidateEvidenceIsUsablePostgres(
+        client,
+        current.candidate,
+        input,
+      ))
+    ) {
+      return undefined;
+    }
+    return {
+      candidateId: current.candidate.id,
+      text: current.candidate.textContent,
+      descriptionClass: current.candidate.descriptionClass,
+      qualityScore: current.candidate.qualityScore ?? 0,
+      publicDisplayEligible: false,
+    };
+  } finally {
+    await client.end({ timeout: 5_000 });
+  }
+};
+
+export const rollbackDescriptionProjectionPostgres = async (input: {
+  url: string;
+  workId: string;
+  targetProjectionId: string;
+  actorRef: string;
+  reason: string;
+  policyVersion: string;
+  currentModelVersion?: string;
+  currentPromptVersion?: string;
+  rolledBackAt: number;
+  failAfter?: "event" | "head";
+}): Promise<{ projectionId: string; changed: boolean }> => {
+  const client = postgres(input.url, { max: 1 });
+  try {
+    return await client.begin(async (sql) => {
+      const headRows = await sql.unsafe(
+        `select h.projection_id as "projectionId"
+         from description_projection_heads h
+         where h.work_id = $1
+         for update of h`,
+        [input.workId],
+      );
+      const targetRows = await sql.unsafe(
+        `select id, candidate_id as "candidateId", state
+         from description_projections
+         where id = $1 and work_id = $2`,
+        [input.targetProjectionId, input.workId],
+      );
+      const target = targetRows[0];
+      if (
+        !target?.candidateId ||
+        (target.state !== "selected" && target.state !== "rolled_back")
+      ) {
+        throw new Error(
+          "Description rollback refused: target is not selectable",
+        );
+      }
+      const current = await loadCurrentCandidatePostgres(
+        sql,
+        String(target.candidateId),
+        true,
+      );
+      if (
+        !current ||
+        current.decision.state !== "eligible" ||
+        current.decision.policyVersion !== input.policyVersion ||
+        !(await storedCandidateEvidenceIsUsablePostgres(
+          sql,
+          current.candidate,
+          input,
+        ))
+      ) {
+        throw new Error(
+          "Description rollback refused: target candidate is not currently eligible",
+        );
+      }
+      const previousProjectionId = headRows[0]
+        ? String(headRows[0].projectionId)
+        : null;
+      const projectionId = descriptionProjectionIdentity({
+        workId: input.workId,
+        candidateId: current.candidate.id,
+        previousProjectionId,
+        state: "rolled_back",
+        reasonCode: input.reason,
+        policyVersion: input.policyVersion,
+      });
+      await sql.unsafe(
+        `insert into description_projections (
+           id, work_id, candidate_id, state, previous_projection_id,
+           reason_code, actor_ref, policy_version, projected_at
+         ) values ($1, $2, $3, 'rolled_back', $4, $5, $6, $7, $8)`,
+        [
+          projectionId,
+          input.workId,
+          current.candidate.id,
+          previousProjectionId,
+          input.reason,
+          input.actorRef,
+          input.policyVersion,
+          input.rolledBackAt,
+        ],
+      );
+      if (input.failAfter === "event") {
+        throw new Error(
+          "Forced Postgres description rollback failure after event",
+        );
+      }
+      await sql.unsafe(
+        `insert into description_projection_heads (work_id, projection_id)
+         values ($1, $2)
+         on conflict(work_id)
+         do update set projection_id = excluded.projection_id`,
+        [input.workId, projectionId],
+      );
+      if (input.failAfter === "head") {
+        throw new Error(
+          "Forced Postgres description rollback failure after head",
+        );
+      }
+      return {
+        projectionId,
+        changed: previousProjectionId !== projectionId,
+      };
+    });
+  } finally {
+    await client.end({ timeout: 5_000 });
+  }
+};
+
+export const reconcileDescriptionCandidatePostgres = async (input: {
+  url: string;
+  candidateId: string;
+  descriptionPolicyVersion: string;
+  currentModelVersion?: string;
+  currentPromptVersion?: string;
+  queueCapacity: number;
+  reconciledAt: number;
+}): Promise<
+  | "unchanged"
+  | "withdrawn"
+  | "invalidated_source_policy"
+  | "invalidated_model"
+  | "invalidated_prompt"
+  | "rereview_required"
+  | "rereview_paused"
+> => {
+  const client = postgres(input.url, { max: 1 });
+  try {
+    return await client.begin(async (sql) => {
+      const current = await loadCurrentCandidatePostgres(
+        sql,
+        input.candidateId,
+        true,
+      );
+      if (!current) throw new Error("Description candidate not found");
+      const lifecycleRows = await sql.unsafe(
+        `select o.state as "observationState",
+                sr.state as "sourceRecordState"
+         from field_observations o
+         join source_records sr on sr.id = o.source_record_id
+         where o.id = $1`,
+        [current.candidate.observationId],
+      );
+      const lifecycle = lifecycleRows[0];
+      const transition = async (
+        state: "withdrawn" | "invalidated",
+        reason: string,
+        policyVersion: string,
+      ): Promise<void> => {
+        await writeDecisionPostgres(sql, {
+          candidateId: input.candidateId,
+          current: current.decision,
+          state,
+          rejectionCodes: current.decision.rejectionCodes,
+          warningCodes: current.decision.warningCodes,
+          reviewerRef: "system:description-reconciliation",
+          reviewReason: reason,
+          policyVersion,
+          decidedAt: input.reconciledAt,
+        });
+        if (state === "withdrawn") {
+          await sql.unsafe(
+            "update field_observations set state = 'withdrawn' where id = $1",
+            [current.candidate.observationId],
+          );
+        }
+        await sql.unsafe(
+          `update description_review_queue
+           set state = 'cancelled', updated_at = $1
+           where candidate_id = $2 and state in ('queued', 'claimed')`,
+          [input.reconciledAt, input.candidateId],
+        );
+        await removeProjectionIfSelectedPostgres(sql, {
+          candidate: current.candidate,
+          state,
+          reasonCode: reason,
+          actorRef: "system:description-reconciliation",
+          policyVersion,
+          at: input.reconciledAt,
+        });
+      };
+      if (
+        lifecycle?.observationState === "withdrawn" ||
+        lifecycle?.sourceRecordState === "withdrawn" ||
+        lifecycle?.sourceRecordState === "deleted"
+      ) {
+        await transition(
+          "withdrawn",
+          "source_withdrawn",
+          current.decision.policyVersion,
+        );
+        return "withdrawn";
+      }
+      if (
+        !(await storedCandidateEvidenceIsUsablePostgres(
+          sql,
+          current.candidate,
+          {
+            currentModelVersion:
+              current.candidate.modelVersion ?? input.currentModelVersion,
+            currentPromptVersion:
+              current.candidate.promptVersion ?? input.currentPromptVersion,
+          },
+        ))
+      ) {
+        await transition(
+          "invalidated",
+          "source_or_parent_policy_revoked",
+          input.descriptionPolicyVersion,
+        );
+        return "invalidated_source_policy";
+      }
+      if (
+        current.candidate.descriptionClass === "model_assisted_candidate" &&
+        input.currentModelVersion &&
+        current.candidate.modelVersion !== input.currentModelVersion
+      ) {
+        await transition(
+          "invalidated",
+          "model_version_invalidated",
+          input.descriptionPolicyVersion,
+        );
+        return "invalidated_model";
+      }
+      if (
+        current.candidate.descriptionClass === "model_assisted_candidate" &&
+        input.currentPromptVersion &&
+        current.candidate.promptVersion !== input.currentPromptVersion
+      ) {
+        await transition(
+          "invalidated",
+          "prompt_version_invalidated",
+          input.descriptionPolicyVersion,
+        );
+        return "invalidated_prompt";
+      }
+      if (current.decision.policyVersion !== input.descriptionPolicyVersion) {
+        if (
+          current.decision.state === "rejected" ||
+          current.decision.state === "withdrawn" ||
+          current.decision.rejectionCodes.length > 0
+        ) {
+          throw new Error(
+            "Description re-review refused: hard rejection or withdrawal is not reviewable",
+          );
+        }
+        const warningCodes = uniqueSorted([
+          ...current.decision.warningCodes,
+          "policy_version_review" as const,
+        ]);
+        const queue = await queueCandidatePostgres(sql, {
+          candidateId: input.candidateId,
+          reasonCodes: warningCodes,
+          capacity: input.queueCapacity,
+          now: input.reconciledAt,
+        });
+        const state: "review_required" | "paused" =
+          queue === "overflow_paused" ? "paused" : "review_required";
+        await writeDecisionPostgres(sql, {
+          candidateId: input.candidateId,
+          current: current.decision,
+          state,
+          rejectionCodes: current.decision.rejectionCodes,
+          warningCodes,
+          policyVersion: input.descriptionPolicyVersion,
+          decidedAt: input.reconciledAt,
+        });
+        await removeProjectionIfSelectedPostgres(sql, {
+          candidate: current.candidate,
+          state: "invalidated",
+          reasonCode: "candidate_rereview_required",
+          actorRef: "system:description-policy",
+          policyVersion: input.descriptionPolicyVersion,
+          at: input.reconciledAt,
+        });
+        return state === "paused" ? "rereview_paused" : "rereview_required";
+      }
+      return "unchanged";
+    });
+  } finally {
+    await client.end({ timeout: 5_000 });
+  }
+};
+
 const scaled = (value: number, scopeWorks: number): number =>
   scopeWorks <= 0 ? 0 : Math.round((value * 500) / scopeWorks);
 
@@ -961,7 +1839,12 @@ export const descriptionMetricsPostgres = async (input: {
            count(*)::int as candidates,
            count(distinct c.work_id)::int as "candidateWorks",
            count(*) filter (where d.state = 'rejected')::int as rejected,
-           count(*) filter (where d.reviewer_ref is not null)::int as reviewed,
+           count(*) filter (where exists (
+             select 1 from description_decisions reviewed
+             where reviewed.candidate_id = c.id
+               and reviewed.reviewer_ref is not null
+               and reviewed.state in ('eligible', 'rejected')
+           ))::int as reviewed,
            count(*) filter (where d.state = 'eligible')::int as eligible,
            count(distinct c.work_id) filter (where d.state = 'eligible')::int as "eligibleWorks",
            count(*) filter (where d.state = 'withdrawn')::int as withdrawn,

--- a/src/db/catalog/enrichment/descriptions/repository.pg.ts
+++ b/src/db/catalog/enrichment/descriptions/repository.pg.ts
@@ -73,6 +73,17 @@ type CandidateRow = {
 const uniqueSorted = <T extends string>(values: readonly T[]): T[] =>
   [...new Set(values)].sort();
 
+const jsonStringArray = <T extends string>(value: unknown): T[] => {
+  if (Array.isArray(value)) return value as T[];
+  if (typeof value !== "string") return [];
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return Array.isArray(parsed) ? (parsed as T[]) : [];
+  } catch {
+    return [];
+  }
+};
+
 const policyObject = (
   value: unknown,
 ): {
@@ -146,8 +157,8 @@ const parentEvidence = (
 const decisionFromRow = (row: Record<string, unknown>): DecisionRow => ({
   id: String(row.id),
   state: row.state as DescriptionDecisionState,
-  rejectionCodes: row.rejectionCodes as DescriptionRejectionCode[],
-  warningCodes: row.warningCodes as DescriptionWarningCode[],
+  rejectionCodes: jsonStringArray<DescriptionRejectionCode>(row.rejectionCodes),
+  warningCodes: jsonStringArray<DescriptionWarningCode>(row.warningCodes),
   reviewerRef: row.reviewerRef ? String(row.reviewerRef) : null,
   reviewReason: row.reviewReason ? String(row.reviewReason) : null,
   policyVersion: String(row.policyVersion),
@@ -204,8 +215,12 @@ export const createDescriptionCandidatePostgres = async (input: {
           decisionId: String(row.decisionId),
           state,
           validation: {
-            rejectionCodes: row.rejectionCodes as DescriptionRejectionCode[],
-            warningCodes: row.warningCodes as DescriptionWarningCode[],
+            rejectionCodes: jsonStringArray<DescriptionRejectionCode>(
+              row.rejectionCodes,
+            ),
+            warningCodes: jsonStringArray<DescriptionWarningCode>(
+              row.warningCodes,
+            ),
             requiresHumanReview:
               state === "review_required" || state === "paused",
             wordCount: String(row.textContent)
@@ -285,6 +300,9 @@ export const createDescriptionCandidatePostgres = async (input: {
                order by o.id`,
               [parentIds],
             );
+      const loadedParentIds = new Set(
+        (parentRows as unknown as ParentRow[]).map((row) => row.id),
+      );
       const validation = validateDescriptionCandidate({
         candidate: input.candidate,
         parents: parentEvidence(parentRows as unknown as ParentRow[]),
@@ -456,7 +474,7 @@ export const createDescriptionCandidatePostgres = async (input: {
           [claimId, candidateId, position, claim.text, claimHash],
         );
         for (const parentId of uniqueSorted(claim.parentObservationIds)) {
-          if (!parentIds.includes(parentId)) continue;
+          if (!loadedParentIds.has(parentId)) continue;
           await sql.unsafe(
             `insert into description_claim_evidence (claim_id, observation_id)
              values ($1, $2)`,

--- a/src/db/catalog/enrichment/descriptions/repository.pg.ts
+++ b/src/db/catalog/enrichment/descriptions/repository.pg.ts
@@ -1,0 +1,1033 @@
+import postgres from "postgres";
+import { deterministicCatalogId, hashCanonicalJson } from "../../identity";
+import { sourcePolicyAllowsFieldDisplay } from "../../policy-eligibility";
+import type { DescriptionDecisionState } from "../../values";
+import {
+  descriptionCandidateIdentity,
+  descriptionDecisionIdentity,
+  descriptionObservationIdentity,
+  descriptionProjectionIdentity,
+} from "./repository";
+import type {
+  DescriptionCandidateInput,
+  DescriptionCandidateResult,
+  DescriptionMetrics,
+  DescriptionParentEvidence,
+  DescriptionRejectionCode,
+  DescriptionWarningCode,
+} from "./types";
+import {
+  descriptionGenerationInputHash,
+  validateDescriptionCandidate,
+} from "./validation";
+
+type SourceRow = {
+  sourceRevision: string | null;
+  sourceRecordState: string;
+  sourceApproval: string;
+  metadataPolicy: unknown;
+  sourceLinkState: string | null;
+};
+
+type ParentRow = {
+  id: string;
+  entityType: string;
+  entityId: string;
+  workId: string | null;
+  fieldKey: string;
+  valueJson: unknown;
+  observationState: string;
+  provenanceKind: string;
+  sourceRecordState: string;
+  sourceApproval: string;
+  sourceLinkState: string | null;
+  metadataPolicy: unknown;
+  resolutionState: string | null;
+};
+
+type DecisionRow = {
+  id: string;
+  state: DescriptionDecisionState;
+  rejectionCodes: DescriptionRejectionCode[];
+  warningCodes: DescriptionWarningCode[];
+  reviewerRef: string | null;
+  reviewReason: string | null;
+  policyVersion: string;
+};
+
+type CandidateRow = {
+  id: string;
+  workId: string;
+  observationId: string;
+  descriptionClass:
+    | "licensed_verbatim"
+    | "bukie_editorial"
+    | "model_assisted_candidate";
+  textContent: string;
+  editorRef: string | null;
+  modelVersion: string | null;
+  promptVersion: string | null;
+  qualityScore: number | null;
+};
+
+const uniqueSorted = <T extends string>(values: readonly T[]): T[] =>
+  [...new Set(values)].sort();
+
+const policyObject = (
+  value: unknown,
+): {
+  sourcePolicyVersion?: unknown;
+  textPermission?: {
+    allowedFields?: unknown;
+    fetch?: unknown;
+    transform?: unknown;
+  };
+  attribution?: {
+    required?: unknown;
+  };
+} => {
+  if (typeof value === "string") {
+    try {
+      return policyObject(JSON.parse(value));
+    } catch {
+      return {};
+    }
+  }
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value
+    : {};
+};
+
+const sourceAllowsCandidate = (
+  source: SourceRow | undefined,
+  candidate: DescriptionCandidateInput,
+): boolean => {
+  if (
+    !source ||
+    source.sourceApproval !== "approved" ||
+    source.sourceRecordState !== "active" ||
+    source.sourceLinkState !== "active"
+  ) {
+    return false;
+  }
+  const policy = policyObject(source.metadataPolicy);
+  return Boolean(
+    policy.sourcePolicyVersion === candidate.sourcePolicyVersion &&
+      policy.textPermission?.fetch === true &&
+      Array.isArray(policy.textPermission.allowedFields) &&
+      policy.textPermission.allowedFields.includes("work.description"),
+  );
+};
+
+const parentEvidence = (
+  rows: readonly ParentRow[],
+): DescriptionParentEvidence[] =>
+  rows.map((row) => ({
+    id: row.id,
+    entityType: row.entityType,
+    entityId: row.entityId,
+    workId: row.workId,
+    fieldKey: row.fieldKey,
+    value: row.valueJson,
+    sourceText: typeof row.valueJson === "string" ? row.valueJson : null,
+    eligible:
+      (row.observationState === "active" || row.observationState === "stale") &&
+      row.provenanceKind !== "synthetic" &&
+      row.sourceRecordState === "active" &&
+      row.sourceApproval === "approved" &&
+      row.sourceLinkState === "active" &&
+      sourcePolicyAllowsFieldDisplay(
+        row.metadataPolicy as Record<string, unknown>,
+        row.fieldKey,
+      ),
+    unresolvedConflict: row.resolutionState === "conflicting",
+  }));
+
+const decisionFromRow = (row: Record<string, unknown>): DecisionRow => ({
+  id: String(row.id),
+  state: row.state as DescriptionDecisionState,
+  rejectionCodes: row.rejectionCodes as DescriptionRejectionCode[],
+  warningCodes: row.warningCodes as DescriptionWarningCode[],
+  reviewerRef: row.reviewerRef ? String(row.reviewerRef) : null,
+  reviewReason: row.reviewReason ? String(row.reviewReason) : null,
+  policyVersion: String(row.policyVersion),
+});
+
+const candidateFromRow = (row: Record<string, unknown>): CandidateRow => ({
+  id: String(row.id),
+  workId: String(row.workId),
+  observationId: String(row.observationId),
+  descriptionClass: row.descriptionClass as CandidateRow["descriptionClass"],
+  textContent: String(row.textContent),
+  editorRef: row.editorRef ? String(row.editorRef) : null,
+  modelVersion: row.modelVersion ? String(row.modelVersion) : null,
+  promptVersion: row.promptVersion ? String(row.promptVersion) : null,
+  qualityScore:
+    row.qualityScore === null || row.qualityScore === undefined
+      ? null
+      : Number(row.qualityScore),
+});
+
+export const createDescriptionCandidatePostgres = async (input: {
+  url: string;
+  candidate: DescriptionCandidateInput;
+  queueCapacity: number;
+  failAfter?: "candidate" | "decision" | "projection";
+}): Promise<DescriptionCandidateResult> => {
+  const client = postgres(input.url, { max: 1 });
+  const candidateId = descriptionCandidateIdentity(input.candidate);
+  try {
+    return await client.begin(async (sql) => {
+      const existingRows = await sql.unsafe(
+        `select
+           c.observation_id as "observationId",
+           c.text_content as "textContent",
+           c.quality_score as "qualityScore",
+           d.id as "decisionId",
+           d.state as "state",
+           d.rejection_codes_json as "rejectionCodes",
+           d.warning_codes_json as "warningCodes",
+           q.state as "queueState"
+         from description_candidates c
+         join description_decision_heads h on h.candidate_id = c.id
+         join description_decisions d on d.id = h.decision_id
+         left join description_review_queue q on q.candidate_id = c.id
+         where c.id = $1`,
+        [candidateId],
+      );
+      if (existingRows[0]) {
+        const row = existingRows[0] as Record<string, unknown>;
+        const state = row.state as DescriptionDecisionState;
+        return {
+          candidateId,
+          observationId: String(row.observationId),
+          decisionId: String(row.decisionId),
+          state,
+          validation: {
+            rejectionCodes: row.rejectionCodes as DescriptionRejectionCode[],
+            warningCodes: row.warningCodes as DescriptionWarningCode[],
+            requiresHumanReview:
+              state === "review_required" || state === "paused",
+            wordCount: String(row.textContent)
+              .trim()
+              .split(/\s+/u)
+              .filter(Boolean).length,
+            readabilityScore: 0,
+            qualityScore: Number(row.qualityScore ?? 0),
+          },
+          queue:
+            state === "paused"
+              ? "overflow_paused"
+              : row.queueState === "queued" || row.queueState === "claimed"
+                ? "deduplicated"
+                : "not_required",
+          changed: false,
+        };
+      }
+
+      const sourceRows = await sql.unsafe(
+        `select
+           sr.source_revision as "sourceRevision",
+           sr.state as "sourceRecordState",
+           s.approval_state as "sourceApproval",
+           s.metadata_policy as "metadataPolicy",
+           sl.state as "sourceLinkState"
+         from source_records sr
+         join metadata_sources s on s.id = sr.source_id
+         left join source_record_links sl
+           on sl.source_record_id = sr.id
+          and sl.entity_type = 'work'
+          and sl.entity_id = $1
+         where sr.id = $2`,
+        [input.candidate.workId, input.candidate.sourceRecordId],
+      );
+      const source = sourceRows[0] as unknown as SourceRow | undefined;
+      const parentIds = uniqueSorted(
+        input.candidate.claims.flatMap((claim) => claim.parentObservationIds),
+      );
+      const parentRows =
+        parentIds.length === 0
+          ? []
+          : await sql.unsafe(
+              `select
+                 o.id as "id",
+                 o.entity_type as "entityType",
+                 o.entity_id as "entityId",
+                 case
+                   when o.entity_type = 'work' then o.entity_id
+                   when o.entity_type = 'edition' then e.work_id
+                   else null
+                 end as "workId",
+                 o.field_key as "fieldKey",
+                 o.value_json as "valueJson",
+                 o.state as "observationState",
+                 o.provenance_kind as "provenanceKind",
+                 sr.state as "sourceRecordState",
+                 s.approval_state as "sourceApproval",
+                 sl.state as "sourceLinkState",
+                 s.metadata_policy as "metadataPolicy",
+                 r.state as "resolutionState"
+               from field_observations o
+               join source_records sr on sr.id = o.source_record_id
+               join metadata_sources s on s.id = sr.source_id
+               left join editions e
+                 on o.entity_type = 'edition' and e.id = o.entity_id
+               left join source_record_links sl
+                 on sl.source_record_id = sr.id
+                and sl.entity_type = o.entity_type
+                and sl.entity_id = o.entity_id
+               left join field_resolution_heads h
+                 on h.entity_type = o.entity_type
+                and h.entity_id = o.entity_id
+                and h.field_key = o.field_key
+               left join field_resolutions r on r.id = h.resolution_id
+               where o.id = any($1::text[])
+               order by o.id`,
+              [parentIds],
+            );
+      const validation = validateDescriptionCandidate({
+        candidate: input.candidate,
+        parents: parentEvidence(parentRows as unknown as ParentRow[]),
+      });
+      if (source?.sourceRevision !== input.candidate.sourceRevision) {
+        validation.rejectionCodes.push("source_revision_mismatch");
+      }
+      if (!sourceAllowsCandidate(source, input.candidate)) {
+        validation.rejectionCodes.push("source_policy_ineligible");
+      }
+      if (
+        input.candidate.descriptionClass === "licensed_verbatim" &&
+        input.candidate.license.transformed &&
+        policyObject(source?.metadataPolicy).textPermission?.transform !== true
+      ) {
+        validation.rejectionCodes.push("licensed_derivative_not_permitted");
+      }
+      if (
+        input.candidate.descriptionClass === "licensed_verbatim" &&
+        policyObject(source?.metadataPolicy).attribution?.required === true &&
+        !input.candidate.license.attributionText?.trim()
+      ) {
+        validation.rejectionCodes.push("licensed_provenance_incomplete");
+      }
+      validation.rejectionCodes = uniqueSorted(validation.rejectionCodes);
+      validation.warningCodes = uniqueSorted(validation.warningCodes);
+      validation.requiresHumanReview =
+        validation.rejectionCodes.length === 0 &&
+        validation.warningCodes.length > 0;
+
+      const observationId = descriptionObservationIdentity(candidateId);
+      await sql.unsafe(
+        `insert into field_observations (
+           id, source_record_id, entity_type, entity_id, field_key, value_json,
+           comparison_hash, provenance_kind, source_path, source_modified_at,
+           retrieved_at, mapping_confidence, state, actor_ref, reason,
+           derivation_name, derivation_version, parent_ids_json
+         ) values (
+           $1, $2, 'work', $3, 'work.description', $4::jsonb, $5, $6, $7,
+           null, $8, 1, $9, $10, $11, $12, $13, $14::jsonb
+         )`,
+        [
+          observationId,
+          input.candidate.sourceRecordId,
+          input.candidate.workId,
+          JSON.stringify(input.candidate.text),
+          hashCanonicalJson(input.candidate.text),
+          input.candidate.descriptionClass === "licensed_verbatim"
+            ? "imported"
+            : input.candidate.descriptionClass === "bukie_editorial"
+              ? "curated"
+              : "derived",
+          input.candidate.descriptionClass === "licensed_verbatim"
+            ? "licensed.description"
+            : input.candidate.descriptionClass === "bukie_editorial"
+              ? "editorial.description"
+              : "model.description",
+          input.candidate.createdAt,
+          validation.rejectionCodes.length > 0 ? "invalid" : "active",
+          input.candidate.descriptionClass === "bukie_editorial"
+            ? input.candidate.editorial.editorRef
+            : input.candidate.descriptionClass === "model_assisted_candidate"
+              ? "system:description-generation-fixture"
+              : null,
+          input.candidate.descriptionClass === "bukie_editorial"
+            ? input.candidate.editorial.reason
+            : null,
+          input.candidate.descriptionClass === "model_assisted_candidate"
+            ? "provider-neutral-description-generation"
+            : null,
+          input.candidate.descriptionClass === "model_assisted_candidate"
+            ? `${input.candidate.model.modelVersion}:${input.candidate.model.promptVersion}`
+            : null,
+          input.candidate.descriptionClass === "model_assisted_candidate"
+            ? JSON.stringify(parentIds)
+            : null,
+        ],
+      );
+      await sql.unsafe(
+        `insert into description_candidates (
+           id, work_id, observation_id, description_class, text_content,
+           text_hash, source_revision, source_policy_version,
+           description_policy_version, license_name, license_url,
+           attribution_text, derivatives_permitted, editor_ref,
+           editorial_reason, editorial_revision, model_id, model_version,
+           prompt_version, generation_input_hash, generated_at,
+           generation_duration_ms, input_tokens, output_tokens, cost_microusd,
+           quality_score, ambiguous_identity, sensitive_content, created_at
+         ) values (
+           $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14,
+           $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26,
+           $27, $28, $29
+         )`,
+        [
+          candidateId,
+          input.candidate.workId,
+          observationId,
+          input.candidate.descriptionClass,
+          input.candidate.text,
+          hashCanonicalJson(input.candidate.text),
+          input.candidate.sourceRevision,
+          input.candidate.sourcePolicyVersion,
+          input.candidate.descriptionPolicyVersion,
+          input.candidate.descriptionClass === "licensed_verbatim"
+            ? input.candidate.license.name
+            : null,
+          input.candidate.descriptionClass === "licensed_verbatim"
+            ? input.candidate.license.url
+            : null,
+          input.candidate.descriptionClass === "licensed_verbatim"
+            ? input.candidate.license.attributionText
+            : null,
+          input.candidate.descriptionClass === "licensed_verbatim"
+            ? input.candidate.license.derivativesPermitted
+            : null,
+          input.candidate.descriptionClass === "bukie_editorial"
+            ? input.candidate.editorial.editorRef
+            : null,
+          input.candidate.descriptionClass === "bukie_editorial"
+            ? input.candidate.editorial.reason
+            : null,
+          input.candidate.descriptionClass === "bukie_editorial"
+            ? input.candidate.editorial.revision
+            : null,
+          input.candidate.descriptionClass === "model_assisted_candidate"
+            ? input.candidate.model.modelId
+            : null,
+          input.candidate.descriptionClass === "model_assisted_candidate"
+            ? input.candidate.model.modelVersion
+            : null,
+          input.candidate.descriptionClass === "model_assisted_candidate"
+            ? input.candidate.model.promptVersion
+            : null,
+          input.candidate.descriptionClass === "model_assisted_candidate"
+            ? descriptionGenerationInputHash(input.candidate)
+            : null,
+          input.candidate.descriptionClass === "model_assisted_candidate"
+            ? input.candidate.model.generatedAt
+            : null,
+          input.candidate.descriptionClass === "model_assisted_candidate"
+            ? input.candidate.model.generationDurationMs
+            : null,
+          input.candidate.descriptionClass === "model_assisted_candidate"
+            ? input.candidate.model.inputTokens
+            : null,
+          input.candidate.descriptionClass === "model_assisted_candidate"
+            ? input.candidate.model.outputTokens
+            : null,
+          input.candidate.descriptionClass === "model_assisted_candidate"
+            ? input.candidate.model.costMicrousd
+            : null,
+          validation.qualityScore,
+          input.candidate.ambiguousIdentity ?? false,
+          input.candidate.sensitiveContent ?? false,
+          input.candidate.createdAt,
+        ],
+      );
+      for (const [position, claim] of input.candidate.claims.entries()) {
+        const claimHash = hashCanonicalJson(claim.text);
+        const claimId = deterministicCatalogId(
+          "description_claim",
+          candidateId,
+          hashCanonicalJson({ claimHash, position }),
+        );
+        await sql.unsafe(
+          `insert into description_claims (
+             id, candidate_id, position, claim_text, claim_hash
+           ) values ($1, $2, $3, $4, $5)`,
+          [claimId, candidateId, position, claim.text, claimHash],
+        );
+        for (const parentId of uniqueSorted(claim.parentObservationIds)) {
+          if (!parentIds.includes(parentId)) continue;
+          await sql.unsafe(
+            `insert into description_claim_evidence (claim_id, observation_id)
+             values ($1, $2)`,
+            [claimId, parentId],
+          );
+        }
+      }
+      if (input.failAfter === "candidate") {
+        throw new Error("Forced Postgres description failure after candidate");
+      }
+
+      let state: DescriptionDecisionState =
+        validation.rejectionCodes.length > 0
+          ? "rejected"
+          : validation.requiresHumanReview
+            ? "review_required"
+            : "eligible";
+      let queue: DescriptionCandidateResult["queue"] = "not_required";
+      if (state === "review_required") {
+        await sql.unsafe("select pg_advisory_xact_lock(133)");
+        const countRows = await sql.unsafe(
+          `select count(*)::int as count
+           from description_review_queue
+           where state in ('queued', 'claimed')`,
+        );
+        if (
+          Number(countRows[0]?.count ?? 0) >=
+          Math.max(0, Math.trunc(input.queueCapacity))
+        ) {
+          state = "paused";
+          queue = "overflow_paused";
+        } else {
+          const priority = validation.warningCodes.reduce(
+            (total, code) =>
+              total +
+              (code.includes("sensitive") || code.includes("ambiguous")
+                ? 100
+                : 10),
+            0,
+          );
+          await sql.unsafe(
+            `insert into description_review_queue (
+               candidate_id, state, priority, reason_codes_json, queued_at,
+               updated_at, reviewer_ref
+             ) values ($1, 'queued', $2, $3::jsonb, $4, $4, null)`,
+            [
+              candidateId,
+              priority,
+              JSON.stringify(validation.warningCodes),
+              input.candidate.createdAt,
+            ],
+          );
+          queue = "queued";
+        }
+      }
+      const decisionId = descriptionDecisionIdentity({
+        candidateId,
+        previousDecisionId: null,
+        state,
+        rejectionCodes: validation.rejectionCodes,
+        warningCodes: validation.warningCodes,
+        reviewerRef: null,
+        reviewReason: null,
+        policyVersion: input.candidate.descriptionPolicyVersion,
+      });
+      await sql.unsafe(
+        `insert into description_decisions (
+           id, candidate_id, state, rejection_codes_json, warning_codes_json,
+           reviewer_ref, review_reason, previous_decision_id, policy_version,
+           decided_at
+         ) values ($1, $2, $3, $4::jsonb, $5::jsonb, null, null, null, $6, $7)`,
+        [
+          decisionId,
+          candidateId,
+          state,
+          JSON.stringify(validation.rejectionCodes),
+          JSON.stringify(validation.warningCodes),
+          input.candidate.descriptionPolicyVersion,
+          input.candidate.createdAt,
+        ],
+      );
+      await sql.unsafe(
+        `insert into description_decision_heads (candidate_id, decision_id)
+         values ($1, $2)`,
+        [candidateId, decisionId],
+      );
+      if (input.failAfter === "decision") {
+        throw new Error("Forced Postgres description failure after decision");
+      }
+      if (state === "eligible") {
+        const currentProjectionRows = await sql.unsafe(
+          `select p.id as id
+           from description_projection_heads h
+           join description_projections p on p.id = h.projection_id
+           where h.work_id = $1`,
+          [input.candidate.workId],
+        );
+        const previousProjectionId = currentProjectionRows[0]
+          ? String(currentProjectionRows[0].id)
+          : null;
+        const projectionId = descriptionProjectionIdentity({
+          workId: input.candidate.workId,
+          candidateId,
+          previousProjectionId,
+          state: "selected",
+          reasonCode: "automated_licensed_verbatim_eligible",
+          policyVersion: input.candidate.descriptionPolicyVersion,
+        });
+        await sql.unsafe(
+          `insert into description_projections (
+             id, work_id, candidate_id, state, previous_projection_id,
+             reason_code, actor_ref, policy_version, projected_at
+           ) values ($1, $2, $3, 'selected', $4, $5, $6, $7, $8)`,
+          [
+            projectionId,
+            input.candidate.workId,
+            candidateId,
+            previousProjectionId,
+            "automated_licensed_verbatim_eligible",
+            "system:description-gates",
+            input.candidate.descriptionPolicyVersion,
+            input.candidate.createdAt,
+          ],
+        );
+        await sql.unsafe(
+          `insert into description_projection_heads (work_id, projection_id)
+           values ($1, $2)
+           on conflict(work_id)
+           do update set projection_id = excluded.projection_id`,
+          [input.candidate.workId, projectionId],
+        );
+      }
+      if (input.failAfter === "projection") {
+        throw new Error("Forced Postgres description failure after projection");
+      }
+      return {
+        candidateId,
+        observationId,
+        decisionId,
+        state,
+        validation,
+        queue,
+        changed: true,
+      };
+    });
+  } finally {
+    await client.end({ timeout: 5_000 });
+  }
+};
+
+export const reviewDescriptionCandidatePostgres = async (input: {
+  url: string;
+  candidateId: string;
+  reviewerRef: string;
+  decision: "approve" | "reject";
+  reason: string;
+  acknowledgedWarningCodes?: readonly DescriptionWarningCode[];
+  reviewedAt: number;
+  failAfter?: "decision" | "queue" | "projection";
+}): Promise<{
+  decisionId: string;
+  state: "eligible" | "rejected";
+  changed: boolean;
+}> => {
+  const client = postgres(input.url, { max: 1 });
+  try {
+    return await client.begin(async (sql) => {
+      const rows = await sql.unsafe(
+        `select
+           c.id as "id",
+           c.work_id as "workId",
+           c.observation_id as "observationId",
+           c.description_class as "descriptionClass",
+           c.text_content as "textContent",
+           c.editor_ref as "editorRef",
+           c.model_version as "modelVersion",
+           c.prompt_version as "promptVersion",
+           c.quality_score as "qualityScore",
+           d.id as "decisionId",
+           d.state as "state",
+           d.rejection_codes_json as "rejectionCodes",
+           d.warning_codes_json as "warningCodes",
+           d.reviewer_ref as "reviewerRef",
+           d.review_reason as "reviewReason",
+           d.policy_version as "policyVersion"
+         from description_candidates c
+         join description_decision_heads h on h.candidate_id = c.id
+         join description_decisions d on d.id = h.decision_id
+         where c.id = $1
+         for update of c, h`,
+        [input.candidateId],
+      );
+      if (!rows[0]) throw new Error("Description candidate not found");
+      const candidate = candidateFromRow(rows[0] as Record<string, unknown>);
+      const current = decisionFromRow({
+        ...(rows[0] as Record<string, unknown>),
+        id: rows[0].decisionId,
+      });
+      const state: "eligible" | "rejected" =
+        input.decision === "approve" ? "eligible" : "rejected";
+      if (
+        current.state === state &&
+        current.reviewerRef === input.reviewerRef &&
+        current.reviewReason === input.reason
+      ) {
+        return { decisionId: current.id, state, changed: false };
+      }
+      if (current.state !== "review_required") {
+        throw new Error(
+          `Description review refused: candidate is ${current.state}`,
+        );
+      }
+      if (
+        candidate.descriptionClass === "bukie_editorial" &&
+        candidate.editorRef === input.reviewerRef
+      ) {
+        throw new Error(
+          "Description review refused: editorial reviewer must differ from editor",
+        );
+      }
+      if (input.decision === "approve") {
+        const acknowledged = new Set(input.acknowledgedWarningCodes ?? []);
+        const missing = current.warningCodes.filter(
+          (code) => !acknowledged.has(code),
+        );
+        if (missing.length > 0) {
+          throw new Error(
+            `Description review refused: warnings not acknowledged: ${missing.join(",")}`,
+          );
+        }
+      }
+      const rejectionCodes =
+        input.decision === "reject"
+          ? uniqueSorted([
+              ...current.rejectionCodes,
+              "human_review_rejected" as const,
+            ])
+          : [];
+      const decisionId = descriptionDecisionIdentity({
+        candidateId: input.candidateId,
+        previousDecisionId: current.id,
+        state,
+        rejectionCodes,
+        warningCodes: current.warningCodes,
+        reviewerRef: input.reviewerRef,
+        reviewReason: input.reason,
+        policyVersion: current.policyVersion,
+      });
+      await sql.unsafe(
+        `insert into description_decisions (
+           id, candidate_id, state, rejection_codes_json, warning_codes_json,
+           reviewer_ref, review_reason, previous_decision_id, policy_version,
+           decided_at
+         ) values ($1, $2, $3, $4::jsonb, $5::jsonb, $6, $7, $8, $9, $10)`,
+        [
+          decisionId,
+          input.candidateId,
+          state,
+          JSON.stringify(rejectionCodes),
+          JSON.stringify(current.warningCodes),
+          input.reviewerRef,
+          input.reason,
+          current.id,
+          current.policyVersion,
+          input.reviewedAt,
+        ],
+      );
+      await sql.unsafe(
+        `update description_decision_heads set decision_id = $1
+         where candidate_id = $2`,
+        [decisionId, input.candidateId],
+      );
+      if (input.failAfter === "decision") {
+        throw new Error("Forced Postgres description review after decision");
+      }
+      await sql.unsafe(
+        `update description_review_queue
+         set state = 'completed', updated_at = $1, reviewer_ref = $2
+         where candidate_id = $3`,
+        [input.reviewedAt, input.reviewerRef, input.candidateId],
+      );
+      if (input.failAfter === "queue") {
+        throw new Error("Forced Postgres description review after queue");
+      }
+      if (state === "eligible") {
+        const currentProjectionRows = await sql.unsafe(
+          `select p.id as id
+           from description_projection_heads h
+           join description_projections p on p.id = h.projection_id
+           where h.work_id = $1`,
+          [candidate.workId],
+        );
+        const previousProjectionId = currentProjectionRows[0]
+          ? String(currentProjectionRows[0].id)
+          : null;
+        const projectionId = descriptionProjectionIdentity({
+          workId: candidate.workId,
+          candidateId: candidate.id,
+          previousProjectionId,
+          state: "selected",
+          reasonCode: "human_review_approved",
+          policyVersion: current.policyVersion,
+        });
+        await sql.unsafe(
+          `insert into description_projections (
+             id, work_id, candidate_id, state, previous_projection_id,
+             reason_code, actor_ref, policy_version, projected_at
+           ) values ($1, $2, $3, 'selected', $4, $5, $6, $7, $8)`,
+          [
+            projectionId,
+            candidate.workId,
+            candidate.id,
+            previousProjectionId,
+            "human_review_approved",
+            input.reviewerRef,
+            current.policyVersion,
+            input.reviewedAt,
+          ],
+        );
+        await sql.unsafe(
+          `insert into description_projection_heads (work_id, projection_id)
+           values ($1, $2)
+           on conflict(work_id)
+           do update set projection_id = excluded.projection_id`,
+          [candidate.workId, projectionId],
+        );
+      }
+      if (input.failAfter === "projection") {
+        throw new Error("Forced Postgres description review after projection");
+      }
+      return { decisionId, state, changed: true };
+    });
+  } finally {
+    await client.end({ timeout: 5_000 });
+  }
+};
+
+export const transitionDescriptionCandidatePostgres = async (input: {
+  url: string;
+  candidateId: string;
+  state: "withdrawn" | "invalidated";
+  actorRef: string;
+  reason: string;
+  policyVersion: string;
+  at: number;
+}): Promise<{ decisionId: string; changed: boolean }> => {
+  const client = postgres(input.url, { max: 1 });
+  try {
+    return await client.begin(async (sql) => {
+      const rows = await sql.unsafe(
+        `select
+           c.id as "id",
+           c.work_id as "workId",
+           c.observation_id as "observationId",
+           d.id as "decisionId",
+           d.state as "state",
+           d.rejection_codes_json as "rejectionCodes",
+           d.warning_codes_json as "warningCodes",
+           d.reviewer_ref as "reviewerRef",
+           d.review_reason as "reviewReason",
+           d.policy_version as "policyVersion"
+         from description_candidates c
+         join description_decision_heads h on h.candidate_id = c.id
+         join description_decisions d on d.id = h.decision_id
+         where c.id = $1
+         for update of c, h`,
+        [input.candidateId],
+      );
+      if (!rows[0]) throw new Error("Description candidate not found");
+      const row = rows[0] as Record<string, unknown>;
+      const current = decisionFromRow({
+        ...row,
+        id: row.decisionId,
+      });
+      if (
+        current.state === input.state &&
+        current.policyVersion === input.policyVersion
+      ) {
+        return { decisionId: current.id, changed: false };
+      }
+      const decisionId = descriptionDecisionIdentity({
+        candidateId: input.candidateId,
+        previousDecisionId: current.id,
+        state: input.state,
+        rejectionCodes: current.rejectionCodes,
+        warningCodes: current.warningCodes,
+        reviewerRef: input.actorRef,
+        reviewReason: input.reason,
+        policyVersion: input.policyVersion,
+      });
+      await sql.unsafe(
+        `insert into description_decisions (
+           id, candidate_id, state, rejection_codes_json, warning_codes_json,
+           reviewer_ref, review_reason, previous_decision_id, policy_version,
+           decided_at
+         ) values ($1, $2, $3, $4::jsonb, $5::jsonb, $6, $7, $8, $9, $10)`,
+        [
+          decisionId,
+          input.candidateId,
+          input.state,
+          JSON.stringify(current.rejectionCodes),
+          JSON.stringify(current.warningCodes),
+          input.actorRef,
+          input.reason,
+          current.id,
+          input.policyVersion,
+          input.at,
+        ],
+      );
+      await sql.unsafe(
+        `update description_decision_heads set decision_id = $1
+         where candidate_id = $2`,
+        [decisionId, input.candidateId],
+      );
+      if (input.state === "withdrawn") {
+        await sql.unsafe(
+          "update field_observations set state = 'withdrawn' where id = $1",
+          [String(row.observationId)],
+        );
+      }
+      await sql.unsafe(
+        `update description_review_queue
+         set state = 'cancelled', updated_at = $1
+         where candidate_id = $2 and state in ('queued', 'claimed')`,
+        [input.at, input.candidateId],
+      );
+      const projectionRows = await sql.unsafe(
+        `select p.id as id, p.candidate_id as "candidateId"
+         from description_projection_heads h
+         join description_projections p on p.id = h.projection_id
+         where h.work_id = $1`,
+        [String(row.workId)],
+      );
+      if (projectionRows[0]?.candidateId === input.candidateId) {
+        const projectionId = descriptionProjectionIdentity({
+          workId: String(row.workId),
+          candidateId: null,
+          previousProjectionId: String(projectionRows[0].id),
+          state: input.state,
+          reasonCode: input.reason,
+          policyVersion: input.policyVersion,
+        });
+        await sql.unsafe(
+          `insert into description_projections (
+             id, work_id, candidate_id, state, previous_projection_id,
+             reason_code, actor_ref, policy_version, projected_at
+           ) values ($1, $2, null, $3, $4, $5, $6, $7, $8)`,
+          [
+            projectionId,
+            String(row.workId),
+            input.state,
+            projectionRows[0].id,
+            input.reason,
+            input.actorRef,
+            input.policyVersion,
+            input.at,
+          ],
+        );
+        await sql.unsafe(
+          `update description_projection_heads set projection_id = $1
+           where work_id = $2`,
+          [projectionId, String(row.workId)],
+        );
+      }
+      return { decisionId, changed: true };
+    });
+  } finally {
+    await client.end({ timeout: 5_000 });
+  }
+};
+
+const scaled = (value: number, scopeWorks: number): number =>
+  scopeWorks <= 0 ? 0 : Math.round((value * 500) / scopeWorks);
+
+export const descriptionMetricsPostgres = async (input: {
+  url: string;
+  scopeWorks: number;
+}): Promise<DescriptionMetrics> => {
+  const client = postgres(input.url, { max: 1 });
+  try {
+    const [countsRows, queueRows, classRows] = await Promise.all([
+      client.unsafe(
+        `select
+           count(*)::int as candidates,
+           count(distinct c.work_id)::int as "candidateWorks",
+           count(*) filter (where d.state = 'rejected')::int as rejected,
+           count(*) filter (where d.reviewer_ref is not null)::int as reviewed,
+           count(*) filter (where d.state = 'eligible')::int as eligible,
+           count(distinct c.work_id) filter (where d.state = 'eligible')::int as "eligibleWorks",
+           count(*) filter (where d.state = 'withdrawn')::int as withdrawn,
+           count(*) filter (where d.state = 'invalidated')::int as invalidated,
+           count(*) filter (where d.state = 'paused')::int as paused,
+           coalesce(sum(c.input_tokens), 0)::bigint as "inputTokens",
+           coalesce(sum(c.output_tokens), 0)::bigint as "outputTokens",
+           coalesce(sum(c.cost_microusd), 0)::bigint as "costMicrousd"
+         from description_candidates c
+         join description_decision_heads h on h.candidate_id = c.id
+         join description_decisions d on d.id = h.decision_id`,
+      ),
+      client.unsafe(
+        `select state, count(*)::int as count
+         from description_review_queue group by state`,
+      ),
+      client.unsafe(
+        `select description_class as class, count(*)::int as count
+         from description_candidates group by description_class`,
+      ),
+    ]);
+    const counts = countsRows[0] as Record<string, unknown>;
+    const queue = {
+      queued: 0,
+      claimed: 0,
+      completed: 0,
+      cancelled: 0,
+    };
+    for (const row of queueRows) {
+      queue[row.state as keyof typeof queue] = Number(row.count);
+    }
+    const byClass = {
+      licensed_verbatim: 0,
+      bukie_editorial: 0,
+      model_assisted_candidate: 0,
+    };
+    for (const row of classRows) {
+      byClass[row.class as keyof typeof byClass] = Number(row.count);
+    }
+    const candidates = Number(counts.candidates ?? 0);
+    const eligible = Number(counts.eligible ?? 0);
+    const candidateWorks = Number(counts.candidateWorks ?? 0);
+    const eligibleWorks = Number(counts.eligibleWorks ?? 0);
+    const inputTokens = Number(counts.inputTokens ?? 0);
+    const outputTokens = Number(counts.outputTokens ?? 0);
+    const costMicrousd = Number(counts.costMicrousd ?? 0);
+    return {
+      scopeWorks: input.scopeWorks,
+      candidates,
+      rejected: Number(counts.rejected ?? 0),
+      reviewed: Number(counts.reviewed ?? 0),
+      eligible,
+      withdrawn: Number(counts.withdrawn ?? 0),
+      invalidated: Number(counts.invalidated ?? 0),
+      paused: Number(counts.paused ?? 0),
+      queue,
+      coverage: {
+        candidateWorks,
+        eligibleWorks,
+        candidateBasisPoints:
+          input.scopeWorks <= 0
+            ? 0
+            : Math.round((candidateWorks * 10_000) / input.scopeWorks),
+        eligibleBasisPoints:
+          input.scopeWorks <= 0
+            ? 0
+            : Math.round((eligibleWorks * 10_000) / input.scopeWorks),
+      },
+      tokens: {
+        input: inputTokens,
+        output: outputTokens,
+        total: inputTokens + outputTokens,
+      },
+      costMicrousd,
+      estimate500: {
+        candidates: scaled(candidates, input.scopeWorks),
+        eligible: scaled(eligible, input.scopeWorks),
+        inputTokens: scaled(inputTokens, input.scopeWorks),
+        outputTokens: scaled(outputTokens, input.scopeWorks),
+        costMicrousd: scaled(costMicrousd, input.scopeWorks),
+      },
+      byClass,
+    };
+  } finally {
+    await client.end({ timeout: 5_000 });
+  }
+};

--- a/src/db/catalog/enrichment/descriptions/repository.test.ts
+++ b/src/db/catalog/enrichment/descriptions/repository.test.ts
@@ -1,0 +1,759 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildCatalogImportGraph } from "../../importer";
+import { createCatalogRepository } from "../../repository";
+import { openCatalogSqlite, rebuildCatalogSqlite } from "../../sqlite-rebuild";
+import { SAMPLE_BASELINE_IMPORT_RECORDS } from "../fixtures";
+import { ENRICHMENT_SAMPLE_MANIFEST } from "../sample-manifest";
+import {
+  DESCRIPTION_FIXTURE_ALTERNATE_TEXT,
+  DESCRIPTION_FIXTURE_SOURCE_ID,
+  DESCRIPTION_FIXTURE_TEXT,
+  descriptionFixtureIds,
+  editorialDescriptionFixture,
+  licensedDescriptionFixture,
+  modelDescriptionFixture,
+  seedDescriptionFixturesSqlite,
+} from "./fixtures";
+import {
+  createDescriptionCandidateSqlite,
+  descriptionMetricsSqlite,
+  getDescriptionProposalSqlite,
+  invalidateDescriptionCandidateSqlite,
+  reconcileDescriptionCandidateSqlite,
+  requestDescriptionRereviewSqlite,
+  retryDescriptionQueueSqlite,
+  reviewDescriptionCandidateSqlite,
+  rollbackDescriptionProjectionSqlite,
+  withdrawDescriptionCandidateSqlite,
+} from "./repository";
+import { DESCRIPTION_POLICY_VERSION } from "./types";
+
+const NOW = Date.UTC(2026, 6, 29, 10, 0, 0);
+
+const acknowledge = (
+  result: ReturnType<typeof createDescriptionCandidateSqlite>,
+) => result.validation.warningCodes;
+
+describe("SQLite evidence-gated description repository", () => {
+  let directory: string;
+  let raw: ReturnType<typeof openCatalogSqlite>["raw"];
+
+  beforeEach(() => {
+    directory = mkdtempSync(path.join(tmpdir(), "bukie-descriptions-test-"));
+    const sqlitePath = path.join(directory, "descriptions.sqlite");
+    rebuildCatalogSqlite({
+      sqlitePath,
+      graph: buildCatalogImportGraph(SAMPLE_BASELINE_IMPORT_RECORDS),
+    });
+    raw = openCatalogSqlite(sqlitePath).raw;
+    seedDescriptionFixturesSqlite(raw);
+  });
+
+  afterEach(() => {
+    raw.close();
+    rmSync(directory, { recursive: true, force: true });
+  });
+
+  it("keeps an initial model result queued until an explicit human approval", () => {
+    const candidate = modelDescriptionFixture();
+    const first = createDescriptionCandidateSqlite(raw, {
+      candidate,
+      queueCapacity: 3,
+    });
+    const retry = createDescriptionCandidateSqlite(raw, {
+      candidate,
+      queueCapacity: 3,
+    });
+
+    expect(first.state).toBe("review_required");
+    expect(first.queue).toBe("queued");
+    expect(first.validation.warningCodes).toContain("initial_model_review");
+    expect(retry.changed).toBe(false);
+    expect(retry.queue).toBe("deduplicated");
+    raw
+      .prepare(
+        "update description_candidates set quality_score = 100 where id = ?",
+      )
+      .run(first.candidateId);
+    expect(
+      getDescriptionProposalSqlite(raw, {
+        workId: candidate.workId,
+        descriptionPolicyVersion: DESCRIPTION_POLICY_VERSION,
+        currentModelVersion: candidate.model.modelVersion,
+        currentPromptVersion: candidate.model.promptVersion,
+      }),
+    ).toBeUndefined();
+    expect(() =>
+      reviewDescriptionCandidateSqlite(raw, {
+        candidateId: first.candidateId,
+        reviewerRef: "user:reviewer-fixture",
+        decision: "approve",
+        reason: "Evidence and warnings reviewed",
+        acknowledgedWarningCodes: [],
+        reviewedAt: NOW,
+      }),
+    ).toThrow("warnings not acknowledged");
+
+    const reviewed = reviewDescriptionCandidateSqlite(raw, {
+      candidateId: first.candidateId,
+      reviewerRef: "user:reviewer-fixture",
+      decision: "approve",
+      reason: "Evidence and warnings reviewed",
+      acknowledgedWarningCodes: acknowledge(first),
+      reviewedAt: NOW,
+    });
+    const repeatedReview = reviewDescriptionCandidateSqlite(raw, {
+      candidateId: first.candidateId,
+      reviewerRef: "user:reviewer-fixture",
+      decision: "approve",
+      reason: "Evidence and warnings reviewed",
+      acknowledgedWarningCodes: acknowledge(first),
+      reviewedAt: NOW,
+    });
+    const proposal = getDescriptionProposalSqlite(raw, {
+      workId: candidate.workId,
+      descriptionPolicyVersion: DESCRIPTION_POLICY_VERSION,
+      currentModelVersion: candidate.model.modelVersion,
+      currentPromptVersion: candidate.model.promptVersion,
+    });
+
+    expect(reviewed.state).toBe("eligible");
+    expect(repeatedReview.changed).toBe(false);
+    expect(proposal).toMatchObject({
+      candidateId: first.candidateId,
+      text: candidate.text,
+      descriptionClass: "model_assisted_candidate",
+      qualityScore: 100,
+      publicDisplayEligible: false,
+    });
+  });
+
+  it("records complete licensed and editorial provenance and reviewer decisions", () => {
+    const licensed = createDescriptionCandidateSqlite(raw, {
+      candidate: licensedDescriptionFixture(),
+      queueCapacity: 3,
+    });
+    if (licensed.state === "review_required") {
+      reviewDescriptionCandidateSqlite(raw, {
+        candidateId: licensed.candidateId,
+        reviewerRef: "user:licensed-reviewer",
+        decision: "approve",
+        reason: "License and attribution verified",
+        acknowledgedWarningCodes: acknowledge(licensed),
+        reviewedAt: NOW,
+      });
+    }
+    const editorial = createDescriptionCandidateSqlite(raw, {
+      candidate: editorialDescriptionFixture(),
+      queueCapacity: 3,
+    });
+    expect(() =>
+      reviewDescriptionCandidateSqlite(raw, {
+        candidateId: editorial.candidateId,
+        reviewerRef: "user:editor-fixture",
+        decision: "approve",
+        reason: "Self review is not permitted",
+        acknowledgedWarningCodes: acknowledge(editorial),
+        reviewedAt: NOW,
+      }),
+    ).toThrow("reviewer must differ from editor");
+    reviewDescriptionCandidateSqlite(raw, {
+      candidateId: editorial.candidateId,
+      reviewerRef: "user:editorial-reviewer",
+      decision: "approve",
+      reason: "Evidence, wording, and revision verified",
+      acknowledgedWarningCodes: acknowledge(editorial),
+      reviewedAt: NOW + 1,
+    });
+
+    const rows = raw
+      .prepare(
+        `select
+           c.description_class as class,
+           c.license_name as licenseName,
+           c.attribution_text as attribution,
+           c.editor_ref as editorRef,
+           c.editorial_reason as editorialReason,
+           c.editorial_revision as editorialRevision,
+           d.reviewer_ref as reviewerRef,
+           d.review_reason as reviewReason
+         from description_candidates c
+         join description_decision_heads h on h.candidate_id = c.id
+         join description_decisions d on d.id = h.decision_id
+         order by c.description_class`,
+      )
+      .all() as Array<Record<string, string | null>>;
+
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          class: "licensed_verbatim",
+          licenseName: "Recorded fixture license",
+          attribution: "Recorded fixture source",
+        }),
+        expect.objectContaining({
+          class: "bukie_editorial",
+          editorRef: "user:editor-fixture",
+          editorialReason:
+            "Original neutral summary based on approved fixture evidence",
+          editorialRevision: "editorial-fixture-v1",
+          reviewerRef: "user:editorial-reviewer",
+          reviewReason: "Evidence, wording, and revision verified",
+        }),
+      ]),
+    );
+  });
+
+  it("rejects licensed transformations unless both license and source policy permit derivatives", () => {
+    const candidate = licensedDescriptionFixture(undefined, {
+      text: DESCRIPTION_FIXTURE_ALTERNATE_TEXT,
+      license: {
+        name: "Recorded fixture license",
+        url: "https://example.invalid/recorded-fixture-license",
+        attributionText: "Recorded fixture source",
+        derivativesPermitted: true,
+        sourceText: DESCRIPTION_FIXTURE_TEXT,
+        transformed: true,
+      },
+    });
+    const result = createDescriptionCandidateSqlite(raw, {
+      candidate,
+      queueCapacity: 3,
+    });
+
+    expect(result.state).toBe("rejected");
+    expect(result.validation.rejectionCodes).toContain(
+      "licensed_derivative_not_permitted",
+    );
+    const missingAttribution = createDescriptionCandidateSqlite(raw, {
+      candidate: licensedDescriptionFixture(undefined, {
+        createdAt: NOW + 1,
+        license: {
+          name: "Recorded fixture license",
+          url: "https://example.invalid/recorded-fixture-license",
+          attributionText: null,
+          derivativesPermitted: false,
+          sourceText: DESCRIPTION_FIXTURE_TEXT,
+          transformed: false,
+        },
+      }),
+      queueCapacity: 3,
+    });
+    expect(missingAttribution.validation.rejectionCodes).toContain(
+      "licensed_provenance_incomplete",
+    );
+  });
+
+  it("rejects unsupported, identity-inconsistent, conflicting, and sparse evidence", () => {
+    const unsupported = createDescriptionCandidateSqlite(raw, {
+      candidate: modelDescriptionFixture(undefined, {
+        claims: [
+          {
+            text: "Unsupported fixture claim",
+            parentObservationIds: ["missing"],
+          },
+        ],
+        createdAt: NOW + 10,
+      }),
+      queueCapacity: 3,
+    });
+    const otherWork = ENRICHMENT_SAMPLE_MANIFEST.works[1].workId;
+    const mismatch = createDescriptionCandidateSqlite(raw, {
+      candidate: modelDescriptionFixture(undefined, {
+        claims: [
+          {
+            text: "Wrong work identity",
+            parentObservationIds: [descriptionFixtureIds(otherWork).parents[0]],
+          },
+          {
+            text: "Wrong work context",
+            parentObservationIds: [descriptionFixtureIds(otherWork).parents[1]],
+          },
+        ],
+        createdAt: NOW + 11,
+      }),
+      queueCapacity: 3,
+    });
+    const parentId = descriptionFixtureIds(
+      ENRICHMENT_SAMPLE_MANIFEST.works[0].workId,
+    ).parents[1];
+    const conflictId = "00000000-0000-5000-8000-000000000133";
+    raw
+      .prepare(
+        `insert into field_resolutions (
+           id, entity_type, entity_id, field_key, selected_observation_id,
+           state, reason, previous_resolution_id, actor_ref, resolver_version,
+           resolved_at
+         ) values (?, 'work', ?, 'work.first_publication_date', null,
+           'conflicting', 'Fixture conflict', null, 'system:test', 'fixture-v1', ?)`,
+      )
+      .run(conflictId, ENRICHMENT_SAMPLE_MANIFEST.works[0].workId, NOW);
+    raw
+      .prepare(
+        `insert into field_resolution_heads (
+           entity_type, entity_id, field_key, resolution_id
+         ) values ('work', ?, 'work.first_publication_date', ?)
+         on conflict(entity_type, entity_id, field_key)
+         do update set resolution_id = excluded.resolution_id`,
+      )
+      .run(ENRICHMENT_SAMPLE_MANIFEST.works[0].workId, conflictId);
+    const conflict = createDescriptionCandidateSqlite(raw, {
+      candidate: modelDescriptionFixture(undefined, {
+        text: DESCRIPTION_FIXTURE_ALTERNATE_TEXT,
+        createdAt: NOW + 12,
+      }),
+      queueCapacity: 3,
+    });
+
+    expect(unsupported.validation.rejectionCodes).toEqual(
+      expect.arrayContaining(["claim_unsupported", "specificity_insufficient"]),
+    );
+    expect(mismatch.validation.rejectionCodes).toContain("identity_mismatch");
+    expect(conflict.validation.rejectionCodes).toContain(
+      "evidence_conflict_unresolved",
+    );
+    expect(parentId).toBeTruthy();
+  });
+
+  it("pauses queue overflow, deduplicates retries, and resumes only when capacity exists", () => {
+    const result = createDescriptionCandidateSqlite(raw, {
+      candidate: modelDescriptionFixture(),
+      queueCapacity: 0,
+    });
+    const activeBefore = raw
+      .prepare(
+        `select count(*) as count from description_review_queue
+         where state in ('queued', 'claimed')`,
+      )
+      .get() as { count: number };
+
+    expect(result.state).toBe("paused");
+    expect(result.queue).toBe("overflow_paused");
+    expect(activeBefore.count).toBe(0);
+    expect(
+      retryDescriptionQueueSqlite(raw, {
+        candidateId: result.candidateId,
+        queueCapacity: 0,
+        now: NOW,
+      }),
+    ).toBe("overflow_paused");
+    expect(
+      retryDescriptionQueueSqlite(raw, {
+        candidateId: result.candidateId,
+        queueCapacity: 1,
+        now: NOW + 1,
+      }),
+    ).toBe("queued");
+    expect(
+      retryDescriptionQueueSqlite(raw, {
+        candidateId: result.candidateId,
+        queueCapacity: 1,
+        now: NOW + 2,
+      }),
+    ).toBe("deduplicated");
+  });
+
+  it("fails closed on transactional candidate, review, and rollback failures", () => {
+    const candidate = modelDescriptionFixture();
+    expect(() =>
+      createDescriptionCandidateSqlite(raw, {
+        candidate,
+        queueCapacity: 3,
+        failAfter: "decision",
+      }),
+    ).toThrow("Forced description failure");
+    expect(
+      (
+        raw
+          .prepare("select count(*) as count from description_candidates")
+          .get() as { count: number }
+      ).count,
+    ).toBe(0);
+    const created = createDescriptionCandidateSqlite(raw, {
+      candidate,
+      queueCapacity: 3,
+    });
+    expect(() =>
+      reviewDescriptionCandidateSqlite(raw, {
+        candidateId: created.candidateId,
+        reviewerRef: "user:reviewer",
+        decision: "approve",
+        reason: "Reviewed fixture",
+        acknowledgedWarningCodes: acknowledge(created),
+        reviewedAt: NOW,
+        failAfter: "queue",
+      }),
+    ).toThrow("Forced description review failure");
+    const queue = raw
+      .prepare(
+        "select state from description_review_queue where candidate_id = ?",
+      )
+      .get(created.candidateId) as { state: string };
+    expect(queue.state).toBe("queued");
+  });
+
+  it("withdraws, invalidates, re-reviews, and applies policy revocation at read time", () => {
+    const candidate = modelDescriptionFixture();
+    const created = createDescriptionCandidateSqlite(raw, {
+      candidate,
+      queueCapacity: 3,
+    });
+    reviewDescriptionCandidateSqlite(raw, {
+      candidateId: created.candidateId,
+      reviewerRef: "user:reviewer",
+      decision: "approve",
+      reason: "Approved fixture",
+      acknowledgedWarningCodes: acknowledge(created),
+      reviewedAt: NOW,
+    });
+    const read = () =>
+      getDescriptionProposalSqlite(raw, {
+        workId: candidate.workId,
+        descriptionPolicyVersion: DESCRIPTION_POLICY_VERSION,
+        currentModelVersion: candidate.model.modelVersion,
+        currentPromptVersion: candidate.model.promptVersion,
+      });
+    expect(read()).toBeDefined();
+    raw
+      .prepare(
+        "update metadata_sources set approval_state = 'suspended' where id = ?",
+      )
+      .run(DESCRIPTION_FIXTURE_SOURCE_ID);
+    expect(read()).toBeUndefined();
+    expect(
+      reconcileDescriptionCandidateSqlite(raw, {
+        candidateId: created.candidateId,
+        descriptionPolicyVersion: DESCRIPTION_POLICY_VERSION,
+        currentModelVersion: candidate.model.modelVersion,
+        currentPromptVersion: candidate.model.promptVersion,
+        queueCapacity: 3,
+        reconciledAt: NOW + 1,
+      }),
+    ).toBe("invalidated_source_policy");
+    raw
+      .prepare(
+        "update metadata_sources set approval_state = 'approved' where id = ?",
+      )
+      .run(DESCRIPTION_FIXTURE_SOURCE_ID);
+    const rereview = requestDescriptionRereviewSqlite(raw, {
+      candidateId: created.candidateId,
+      policyVersion: "description-gates-v2",
+      queueCapacity: 3,
+      requestedAt: NOW + 2,
+    });
+    expect(rereview.state).toBe("review_required");
+    expect(read()).toBeUndefined();
+    const rereviewWarnings = JSON.parse(
+      (
+        raw
+          .prepare(
+            `select d.warning_codes_json as warnings
+             from description_decision_heads h
+             join description_decisions d on d.id = h.decision_id
+             where h.candidate_id = ?`,
+          )
+          .get(created.candidateId) as { warnings: string }
+      ).warnings,
+    );
+    reviewDescriptionCandidateSqlite(raw, {
+      candidateId: created.candidateId,
+      reviewerRef: "user:reviewer-v2",
+      decision: "approve",
+      reason: "New policy version reviewed",
+      acknowledgedWarningCodes: rereviewWarnings,
+      reviewedAt: NOW + 3,
+    });
+    expect(
+      getDescriptionProposalSqlite(raw, {
+        workId: candidate.workId,
+        descriptionPolicyVersion: "description-gates-v2",
+        currentModelVersion: "fixture-model-v2",
+        currentPromptVersion: candidate.model.promptVersion,
+      }),
+    ).toBeUndefined();
+    expect(
+      reconcileDescriptionCandidateSqlite(raw, {
+        candidateId: created.candidateId,
+        descriptionPolicyVersion: "description-gates-v2",
+        currentModelVersion: "fixture-model-v2",
+        currentPromptVersion: candidate.model.promptVersion,
+        queueCapacity: 3,
+        reconciledAt: NOW + 4,
+      }),
+    ).toBe("invalidated_model");
+    const invalidated = invalidateDescriptionCandidateSqlite(raw, {
+      candidateId: created.candidateId,
+      reason: "Model version retired",
+      policyVersion: "description-gates-v2",
+      invalidatedAt: NOW + 4,
+    });
+    expect(invalidated.changed).toBe(false);
+    const withdrawn = withdrawDescriptionCandidateSqlite(raw, {
+      candidateId: created.candidateId,
+      actorRef: "user:reviewer-v2",
+      reason: "Source text withdrawn",
+      withdrawnAt: NOW + 5,
+    });
+    expect(withdrawn.changed).toBe(true);
+  });
+
+  it("rolls internal dry-run projections back without touching public work projections", () => {
+    const workId = ENRICHMENT_SAMPLE_MANIFEST.works[2].workId;
+    const firstInput = licensedDescriptionFixture(workId, {
+      sensitiveContent: true,
+    });
+    const first = createDescriptionCandidateSqlite(raw, {
+      candidate: firstInput,
+      queueCapacity: 3,
+    });
+    reviewDescriptionCandidateSqlite(raw, {
+      candidateId: first.candidateId,
+      reviewerRef: "user:first-reviewer",
+      decision: "approve",
+      reason: "First fixture approved",
+      acknowledgedWarningCodes: acknowledge(first),
+      reviewedAt: NOW,
+    });
+    const firstProjection = (
+      raw
+        .prepare(
+          `select projection_id as id
+           from description_projection_heads where work_id = ?`,
+        )
+        .get(workId) as { id: string }
+    ).id;
+    const secondInput = licensedDescriptionFixture(workId, {
+      text: DESCRIPTION_FIXTURE_ALTERNATE_TEXT,
+      createdAt: NOW + 1,
+      sensitiveContent: true,
+      license: {
+        name: "Recorded fixture license",
+        url: "https://example.invalid/recorded-fixture-license",
+        attributionText: "Recorded fixture source",
+        derivativesPermitted: false,
+        sourceText: DESCRIPTION_FIXTURE_ALTERNATE_TEXT,
+        transformed: false,
+      },
+    });
+    const second = createDescriptionCandidateSqlite(raw, {
+      candidate: secondInput,
+      queueCapacity: 3,
+    });
+    reviewDescriptionCandidateSqlite(raw, {
+      candidateId: second.candidateId,
+      reviewerRef: "user:second-reviewer",
+      decision: "approve",
+      reason: "Second fixture approved",
+      acknowledgedWarningCodes: acknowledge(second),
+      reviewedAt: NOW + 2,
+    });
+    const headBeforeFailure = (
+      raw
+        .prepare(
+          `select projection_id as id
+           from description_projection_heads where work_id = ?`,
+        )
+        .get(workId) as { id: string }
+    ).id;
+    expect(() =>
+      rollbackDescriptionProjectionSqlite(raw, {
+        workId,
+        targetProjectionId: firstProjection,
+        actorRef: "user:rollback-reviewer",
+        reason: "rollback_test",
+        policyVersion: DESCRIPTION_POLICY_VERSION,
+        rolledBackAt: NOW + 3,
+        failAfter: "event",
+      }),
+    ).toThrow("Forced description rollback failure");
+    expect(
+      (
+        raw
+          .prepare(
+            `select projection_id as id
+             from description_projection_heads where work_id = ?`,
+          )
+          .get(workId) as { id: string }
+      ).id,
+    ).toBe(headBeforeFailure);
+    rollbackDescriptionProjectionSqlite(raw, {
+      workId,
+      targetProjectionId: firstProjection,
+      actorRef: "user:rollback-reviewer",
+      reason: "rollback_approved",
+      policyVersion: DESCRIPTION_POLICY_VERSION,
+      rolledBackAt: NOW + 4,
+    });
+    expect(
+      getDescriptionProposalSqlite(raw, {
+        workId,
+        descriptionPolicyVersion: DESCRIPTION_POLICY_VERSION,
+      })?.candidateId,
+    ).toBe(first.candidateId);
+    const publicWork = raw
+      .prepare("select description from works where id = ?")
+      .get(workId) as { description: string | null };
+    expect(publicWork.description).toBeNull();
+  });
+
+  it("reports deterministic five-work coverage, queue, token, and 500-work estimates", () => {
+    const results = ENRICHMENT_SAMPLE_MANIFEST.works.map((work, index) =>
+      createDescriptionCandidateSqlite(raw, {
+        candidate: modelDescriptionFixture(work.workId, {
+          createdAt: NOW + index,
+        }),
+        queueCapacity: 10,
+      }),
+    );
+    for (let index = 0; index < 2; index += 1) {
+      reviewDescriptionCandidateSqlite(raw, {
+        candidateId: results[index].candidateId,
+        reviewerRef: `user:metrics-reviewer-${index}`,
+        decision: "approve",
+        reason: "Metrics fixture approved",
+        acknowledgedWarningCodes: acknowledge(results[index]),
+        reviewedAt: NOW + 10 + index,
+      });
+    }
+    reviewDescriptionCandidateSqlite(raw, {
+      candidateId: results[2].candidateId,
+      reviewerRef: "user:metrics-reviewer-2",
+      decision: "reject",
+      reason: "Metrics fixture rejected",
+      reviewedAt: NOW + 12,
+    });
+    withdrawDescriptionCandidateSqlite(raw, {
+      candidateId: results[0].candidateId,
+      actorRef: "user:metrics-reviewer-0",
+      reason: "Metrics fixture withdrawal",
+      withdrawnAt: NOW + 13,
+    });
+
+    expect(descriptionMetricsSqlite(raw, 5)).toEqual({
+      scopeWorks: 5,
+      candidates: 5,
+      rejected: 1,
+      reviewed: 3,
+      eligible: 1,
+      withdrawn: 1,
+      invalidated: 0,
+      paused: 0,
+      queue: {
+        queued: 2,
+        claimed: 0,
+        completed: 3,
+        cancelled: 0,
+      },
+      coverage: {
+        candidateWorks: 5,
+        eligibleWorks: 1,
+        candidateBasisPoints: 10_000,
+        eligibleBasisPoints: 2_000,
+      },
+      tokens: {
+        input: 1_600,
+        output: 560,
+        total: 2_160,
+      },
+      costMicrousd: 21_000,
+      estimate500: {
+        candidates: 500,
+        eligible: 100,
+        inputTokens: 160_000,
+        outputTokens: 56_000,
+        costMicrousd: 2_100_000,
+      },
+      byClass: {
+        licensed_verbatim: 0,
+        bukie_editorial: 0,
+        model_assisted_candidate: 5,
+      },
+    });
+  });
+
+  it("cannot expose proposed or unreviewed descriptions through detail/API repository reads", async () => {
+    const candidate = modelDescriptionFixture();
+    const created = createDescriptionCandidateSqlite(raw, {
+      candidate,
+      queueCapacity: 3,
+    });
+    const previous = raw
+      .prepare(
+        `select resolution_id as id from field_resolution_heads
+         where entity_type = 'work' and entity_id = ?
+           and field_key = 'work.description'`,
+      )
+      .get(candidate.workId) as { id: string };
+    raw
+      .prepare(`update metadata_sources set metadata_policy = ? where id = ?`)
+      .run(
+        JSON.stringify({
+          display: true,
+          proposedEvidenceOnly: false,
+          sourcePolicyVersion: candidate.sourcePolicyVersion,
+          textPermission: {
+            allowedFields: ["work.description"],
+            fetch: true,
+            transform: false,
+          },
+        }),
+        DESCRIPTION_FIXTURE_SOURCE_ID,
+      );
+    raw
+      .prepare("update works set description = ? where id = ?")
+      .run(candidate.text, candidate.workId);
+    const forcedResolutionId = "00000000-0000-5000-8000-000000000134";
+    raw
+      .prepare(
+        `insert into field_resolutions (
+           id, entity_type, entity_id, field_key, selected_observation_id,
+           state, reason, previous_resolution_id, actor_ref, resolver_version,
+           resolved_at
+         ) values (
+           ?, 'work', ?, 'work.description', ?, 'present',
+           'Forced unreviewed exposure test', ?, 'system:test',
+           'forced-description-test-v1', ?
+         )`,
+      )
+      .run(
+        forcedResolutionId,
+        candidate.workId,
+        created.observationId,
+        previous.id,
+        NOW,
+      );
+    raw
+      .prepare(
+        `update field_resolution_heads set resolution_id = ?
+         where entity_type = 'work' and entity_id = ?
+           and field_key = 'work.description'`,
+      )
+      .run(forcedResolutionId, candidate.workId);
+    const repository = createCatalogRepository({
+      dialect: "sqlite",
+      async query<T extends Record<string, unknown>>(
+        statement: string,
+        parameters: unknown[] = [],
+      ) {
+        return raw.prepare(statement).all(...parameters) as T[];
+      },
+    });
+
+    const detail = await repository.getWorkDetail(candidate.workId);
+
+    expect(detail?.description).toBeUndefined();
+    reviewDescriptionCandidateSqlite(raw, {
+      candidateId: created.candidateId,
+      reviewerRef: "user:public-gate-reviewer",
+      decision: "reject",
+      reason: "Forced public gate rejection",
+      reviewedAt: NOW + 1,
+    });
+    expect(
+      (await repository.getWorkDetail(candidate.workId))?.description,
+    ).toBeUndefined();
+  });
+});

--- a/src/db/catalog/enrichment/descriptions/repository.test.ts
+++ b/src/db/catalog/enrichment/descriptions/repository.test.ts
@@ -11,6 +11,7 @@ import {
   DESCRIPTION_FIXTURE_ALTERNATE_TEXT,
   DESCRIPTION_FIXTURE_SOURCE_ID,
   DESCRIPTION_FIXTURE_TEXT,
+  descriptionFixtureAlternateText,
   descriptionFixtureIds,
   editorialDescriptionFixture,
   licensedDescriptionFixture,
@@ -32,6 +33,14 @@ import {
 import { DESCRIPTION_POLICY_VERSION } from "./types";
 
 const NOW = Date.UTC(2026, 6, 29, 10, 0, 0);
+const REVIEW_POLICY = {
+  descriptionPolicyVersion: DESCRIPTION_POLICY_VERSION,
+} as const;
+const MODEL_REVIEW_POLICY = {
+  ...REVIEW_POLICY,
+  currentModelVersion: "fixture-model-v1",
+  currentPromptVersion: "fixture-prompt-v1",
+} as const;
 
 const acknowledge = (
   result: ReturnType<typeof createDescriptionCandidateSqlite>,
@@ -88,6 +97,7 @@ describe("SQLite evidence-gated description repository", () => {
     ).toBeUndefined();
     expect(() =>
       reviewDescriptionCandidateSqlite(raw, {
+        ...MODEL_REVIEW_POLICY,
         candidateId: first.candidateId,
         reviewerRef: "user:reviewer-fixture",
         decision: "approve",
@@ -98,6 +108,7 @@ describe("SQLite evidence-gated description repository", () => {
     ).toThrow("warnings not acknowledged");
 
     const reviewed = reviewDescriptionCandidateSqlite(raw, {
+      ...MODEL_REVIEW_POLICY,
       candidateId: first.candidateId,
       reviewerRef: "user:reviewer-fixture",
       decision: "approve",
@@ -106,6 +117,7 @@ describe("SQLite evidence-gated description repository", () => {
       reviewedAt: NOW,
     });
     const repeatedReview = reviewDescriptionCandidateSqlite(raw, {
+      ...MODEL_REVIEW_POLICY,
       candidateId: first.candidateId,
       reviewerRef: "user:reviewer-fixture",
       decision: "approve",
@@ -138,6 +150,7 @@ describe("SQLite evidence-gated description repository", () => {
     });
     if (licensed.state === "review_required") {
       reviewDescriptionCandidateSqlite(raw, {
+        ...REVIEW_POLICY,
         candidateId: licensed.candidateId,
         reviewerRef: "user:licensed-reviewer",
         decision: "approve",
@@ -152,6 +165,7 @@ describe("SQLite evidence-gated description repository", () => {
     });
     expect(() =>
       reviewDescriptionCandidateSqlite(raw, {
+        ...REVIEW_POLICY,
         candidateId: editorial.candidateId,
         reviewerRef: "user:editor-fixture",
         decision: "approve",
@@ -161,6 +175,7 @@ describe("SQLite evidence-gated description repository", () => {
       }),
     ).toThrow("reviewer must differ from editor");
     reviewDescriptionCandidateSqlite(raw, {
+      ...REVIEW_POLICY,
       candidateId: editorial.candidateId,
       reviewerRef: "user:editorial-reviewer",
       decision: "approve",
@@ -175,6 +190,8 @@ describe("SQLite evidence-gated description repository", () => {
            c.description_class as class,
            c.license_name as licenseName,
            c.attribution_text as attribution,
+           c.licensed_source_text_hash as licensedSourceTextHash,
+           c.licensed_text_transformed as licensedTextTransformed,
            c.editor_ref as editorRef,
            c.editorial_reason as editorialReason,
            c.editorial_revision as editorialRevision,
@@ -193,6 +210,8 @@ describe("SQLite evidence-gated description repository", () => {
           class: "licensed_verbatim",
           licenseName: "Recorded fixture license",
           attribution: "Recorded fixture source",
+          licensedSourceTextHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+          licensedTextTransformed: 0,
         }),
         expect.objectContaining({
           class: "bukie_editorial",
@@ -226,6 +245,34 @@ describe("SQLite evidence-gated description repository", () => {
 
     expect(result.state).toBe("rejected");
     expect(result.validation.rejectionCodes).toContain(
+      "licensed_derivative_not_permitted",
+    );
+    const storedPolicy = raw
+      .prepare(
+        "select metadata_policy as policy from metadata_sources where id = ?",
+      )
+      .get(DESCRIPTION_FIXTURE_SOURCE_ID) as { policy: string };
+    const derivativePolicy = JSON.parse(storedPolicy.policy);
+    derivativePolicy.textPermission.transform = true;
+    raw
+      .prepare("update metadata_sources set metadata_policy = ? where id = ?")
+      .run(JSON.stringify(derivativePolicy), DESCRIPTION_FIXTURE_SOURCE_ID);
+    const derivativeWorkId = ENRICHMENT_SAMPLE_MANIFEST.works[3].workId;
+    const permitted = createDescriptionCandidateSqlite(raw, {
+      candidate: licensedDescriptionFixture(derivativeWorkId, {
+        text: descriptionFixtureAlternateText(derivativeWorkId),
+        license: {
+          name: "Recorded derivative fixture license",
+          url: "https://example.invalid/recorded-derivative-license",
+          attributionText: "Recorded derivative fixture source",
+          derivativesPermitted: true,
+          sourceText: DESCRIPTION_FIXTURE_TEXT,
+          transformed: true,
+        },
+      }),
+      queueCapacity: 3,
+    });
+    expect(permitted.validation.rejectionCodes).not.toContain(
       "licensed_derivative_not_permitted",
     );
     const missingAttribution = createDescriptionCandidateSqlite(raw, {
@@ -316,6 +363,41 @@ describe("SQLite evidence-gated description repository", () => {
       "evidence_conflict_unresolved",
     );
     expect(parentId).toBeTruthy();
+    expect(() =>
+      requestDescriptionRereviewSqlite(raw, {
+        candidateId: unsupported.candidateId,
+        policyVersion: "description-gates-v2",
+        currentModelVersion: "fixture-model-v1",
+        currentPromptVersion: "fixture-prompt-v1",
+        queueCapacity: 3,
+        requestedAt: NOW + 13,
+      }),
+    ).toThrow("hard rejection");
+  });
+
+  it("rechecks live evidence before a reviewer can approve", () => {
+    const candidate = modelDescriptionFixture();
+    const created = createDescriptionCandidateSqlite(raw, {
+      candidate,
+      queueCapacity: 3,
+    });
+    raw
+      .prepare(
+        "update metadata_sources set approval_state = 'suspended' where id = ?",
+      )
+      .run(DESCRIPTION_FIXTURE_SOURCE_ID);
+
+    expect(() =>
+      reviewDescriptionCandidateSqlite(raw, {
+        ...MODEL_REVIEW_POLICY,
+        candidateId: created.candidateId,
+        reviewerRef: "user:stale-evidence-reviewer",
+        decision: "approve",
+        reason: "Stale evidence must not pass",
+        acknowledgedWarningCodes: acknowledge(created),
+        reviewedAt: NOW,
+      }),
+    ).toThrow("current evidence or policy is ineligible");
   });
 
   it("pauses queue overflow, deduplicates retries, and resumes only when capacity exists", () => {
@@ -378,6 +460,7 @@ describe("SQLite evidence-gated description repository", () => {
     });
     expect(() =>
       reviewDescriptionCandidateSqlite(raw, {
+        ...MODEL_REVIEW_POLICY,
         candidateId: created.candidateId,
         reviewerRef: "user:reviewer",
         decision: "approve",
@@ -402,6 +485,7 @@ describe("SQLite evidence-gated description repository", () => {
       queueCapacity: 3,
     });
     reviewDescriptionCandidateSqlite(raw, {
+      ...MODEL_REVIEW_POLICY,
       candidateId: created.candidateId,
       reviewerRef: "user:reviewer",
       decision: "approve",
@@ -441,6 +525,8 @@ describe("SQLite evidence-gated description repository", () => {
     const rereview = requestDescriptionRereviewSqlite(raw, {
       candidateId: created.candidateId,
       policyVersion: "description-gates-v2",
+      currentModelVersion: candidate.model.modelVersion,
+      currentPromptVersion: candidate.model.promptVersion,
       queueCapacity: 3,
       requestedAt: NOW + 2,
     });
@@ -459,6 +545,9 @@ describe("SQLite evidence-gated description repository", () => {
       ).warnings,
     );
     reviewDescriptionCandidateSqlite(raw, {
+      descriptionPolicyVersion: "description-gates-v2",
+      currentModelVersion: "fixture-model-v1",
+      currentPromptVersion: "fixture-prompt-v1",
       candidateId: created.candidateId,
       reviewerRef: "user:reviewer-v2",
       decision: "approve",
@@ -510,6 +599,7 @@ describe("SQLite evidence-gated description repository", () => {
       queueCapacity: 3,
     });
     reviewDescriptionCandidateSqlite(raw, {
+      ...REVIEW_POLICY,
       candidateId: first.candidateId,
       reviewerRef: "user:first-reviewer",
       decision: "approve",
@@ -543,6 +633,7 @@ describe("SQLite evidence-gated description repository", () => {
       queueCapacity: 3,
     });
     reviewDescriptionCandidateSqlite(raw, {
+      ...REVIEW_POLICY,
       candidateId: second.candidateId,
       reviewerRef: "user:second-reviewer",
       decision: "approve",
@@ -610,6 +701,7 @@ describe("SQLite evidence-gated description repository", () => {
     );
     for (let index = 0; index < 2; index += 1) {
       reviewDescriptionCandidateSqlite(raw, {
+        ...MODEL_REVIEW_POLICY,
         candidateId: results[index].candidateId,
         reviewerRef: `user:metrics-reviewer-${index}`,
         decision: "approve",
@@ -619,6 +711,7 @@ describe("SQLite evidence-gated description repository", () => {
       });
     }
     reviewDescriptionCandidateSqlite(raw, {
+      ...MODEL_REVIEW_POLICY,
       candidateId: results[2].candidateId,
       reviewerRef: "user:metrics-reviewer-2",
       decision: "reject",
@@ -674,7 +767,22 @@ describe("SQLite evidence-gated description repository", () => {
     });
   });
 
-  it("cannot expose proposed or unreviewed descriptions through detail/API repository reads", async () => {
+  it("does not count a system withdrawal as a human review", () => {
+    const created = createDescriptionCandidateSqlite(raw, {
+      candidate: modelDescriptionFixture(),
+      queueCapacity: 3,
+    });
+    withdrawDescriptionCandidateSqlite(raw, {
+      candidateId: created.candidateId,
+      actorRef: "system:withdrawal-fixture",
+      reason: "Unreviewed withdrawal",
+      withdrawnAt: NOW,
+    });
+
+    expect(descriptionMetricsSqlite(raw, 5).reviewed).toBe(0);
+  });
+
+  it("keeps all diagnostic candidates out of detail/API reads even after approval", async () => {
     const candidate = modelDescriptionFixture();
     const created = createDescriptionCandidateSqlite(raw, {
       candidate,
@@ -746,12 +854,20 @@ describe("SQLite evidence-gated description repository", () => {
 
     expect(detail?.description).toBeUndefined();
     reviewDescriptionCandidateSqlite(raw, {
+      ...MODEL_REVIEW_POLICY,
       candidateId: created.candidateId,
       reviewerRef: "user:public-gate-reviewer",
-      decision: "reject",
-      reason: "Forced public gate rejection",
+      decision: "approve",
+      reason: "Forced public gate approval",
+      acknowledgedWarningCodes: acknowledge(created),
       reviewedAt: NOW + 1,
     });
+    expect(
+      (await repository.getWorkDetail(candidate.workId))?.description,
+    ).toBeUndefined();
+    raw
+      .prepare("update field_observations set state = 'withdrawn' where id = ?")
+      .run(descriptionFixtureIds(candidate.workId).parents[0]);
     expect(
       (await repository.getWorkDetail(candidate.workId))?.description,
     ).toBeUndefined();

--- a/src/db/catalog/enrichment/descriptions/repository.ts
+++ b/src/db/catalog/enrichment/descriptions/repository.ts
@@ -57,6 +57,9 @@ type CandidateRow = {
   sourceRevision: string;
   sourcePolicyVersion: string;
   descriptionPolicyVersion: string;
+  attributionText: string | null;
+  licensedSourceTextHash: string | null;
+  licensedTextTransformed: boolean | number | null;
   editorRef: string | null;
   modelId: string | null;
   modelVersion: string | null;
@@ -574,6 +577,9 @@ const existingCandidateResult = (
          source_revision as "sourceRevision",
          source_policy_version as "sourcePolicyVersion",
          description_policy_version as "descriptionPolicyVersion",
+         attribution_text as "attributionText",
+         licensed_source_text_hash as "licensedSourceTextHash",
+         licensed_text_transformed as "licensedTextTransformed",
          editor_ref as "editorRef",
          model_id as "modelId",
          model_version as "modelVersion",
@@ -719,14 +725,15 @@ export const createDescriptionCandidateSqlite = (
            id, work_id, observation_id, description_class, text_content,
            text_hash, source_revision, source_policy_version,
            description_policy_version, license_name, license_url,
-           attribution_text, derivatives_permitted, editor_ref,
+           attribution_text, derivatives_permitted, licensed_source_text_hash,
+           licensed_text_transformed, editor_ref,
            editorial_reason, editorial_revision, model_id, model_version,
            prompt_version, generation_input_hash, generated_at,
            generation_duration_ms, input_tokens, output_tokens, cost_microusd,
            quality_score, ambiguous_identity, sensitive_content, created_at
          ) values (
            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-           ?, ?, ?, ?, ?, ?, ?, ?
+           ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
          )`,
       )
       .run(
@@ -750,6 +757,12 @@ export const createDescriptionCandidateSqlite = (
           : null,
         input.candidate.descriptionClass === "licensed_verbatim"
           ? Number(input.candidate.license.derivativesPermitted)
+          : null,
+        input.candidate.descriptionClass === "licensed_verbatim"
+          ? hashCanonicalJson(input.candidate.license.sourceText)
+          : null,
+        input.candidate.descriptionClass === "licensed_verbatim"
+          ? Number(input.candidate.license.transformed)
           : null,
         input.candidate.descriptionClass === "bukie_editorial"
           ? input.candidate.editorial.editorRef
@@ -912,6 +925,99 @@ export const retryDescriptionQueueSqlite = (
   return apply.immediate();
 };
 
+const candidateParentIds = (
+  raw: SqliteDatabase,
+  candidateId: string,
+): string[] =>
+  (
+    raw
+      .prepare(
+        `select distinct e.observation_id as id
+         from description_claims c
+         join description_claim_evidence e on e.claim_id = c.id
+         where c.candidate_id = ?
+         order by e.observation_id`,
+      )
+      .all(candidateId) as Array<{ id: string }>
+  ).map((row) => row.id);
+
+const candidateEvidenceIsCurrentlyUsable = (
+  raw: SqliteDatabase,
+  candidate: CandidateRow,
+  input: {
+    descriptionPolicyVersion: string;
+    currentModelVersion?: string;
+    currentPromptVersion?: string;
+  },
+): boolean => {
+  const observation = raw
+    .prepare(
+      `select source_record_id as "sourceRecordId", state
+       from field_observations where id = ?`,
+    )
+    .get(candidate.observationId) as
+    | { sourceRecordId: string; state: string }
+    | undefined;
+  if (!observation || observation.state !== "active") return false;
+  const source = sourceContext(
+    raw,
+    observation.sourceRecordId,
+    candidate.workId,
+  );
+  if (
+    source?.sourceRevision !== candidate.sourceRevision ||
+    !candidateSourceIsCurrentlyUsable(source, candidate.sourcePolicyVersion)
+  ) {
+    return false;
+  }
+  const policy = source ? sourcePolicy(source.metadataPolicy) : {};
+  if (
+    candidate.descriptionClass === "licensed_verbatim" &&
+    ((Boolean(candidate.licensedTextTransformed) &&
+      policy.textPermission?.transform !== true) ||
+      (policy.attribution?.required === true &&
+        !candidate.attributionText?.trim()))
+  ) {
+    return false;
+  }
+  if (
+    candidate.descriptionClass === "model_assisted_candidate" &&
+    (!input.currentModelVersion ||
+      !input.currentPromptVersion ||
+      candidate.modelVersion !== input.currentModelVersion ||
+      candidate.promptVersion !== input.currentPromptVersion)
+  ) {
+    return false;
+  }
+  if (candidate.descriptionClass !== "licensed_verbatim") {
+    const claimCoverage = raw
+      .prepare(
+        `select
+           count(*) as claims,
+           sum(case when exists (
+             select 1 from description_claim_evidence evidence
+             where evidence.claim_id = claims.id
+           ) then 1 else 0 end) as covered
+         from description_claims claims
+         where claims.candidate_id = ?`,
+      )
+      .get(candidate.id) as { claims: number; covered: number | null };
+    if (
+      Number(claimCoverage.claims) === 0 ||
+      Number(claimCoverage.covered ?? 0) !== Number(claimCoverage.claims)
+    ) {
+      return false;
+    }
+  }
+  const parents = loadParents(raw, candidateParentIds(raw, candidate.id));
+  return !parents.some(
+    (parent) =>
+      !parent.eligible ||
+      parent.unresolvedConflict ||
+      parent.workId !== candidate.workId,
+  );
+};
+
 export const reviewDescriptionCandidateSqlite = (
   raw: SqliteDatabase,
   input: {
@@ -920,6 +1026,9 @@ export const reviewDescriptionCandidateSqlite = (
     decision: "approve" | "reject";
     reason: string;
     acknowledgedWarningCodes?: readonly DescriptionWarningCode[];
+    descriptionPolicyVersion: string;
+    currentModelVersion?: string;
+    currentPromptVersion?: string;
     reviewedAt: number;
     failAfter?: "decision" | "queue" | "projection";
   },
@@ -937,6 +1046,9 @@ export const reviewDescriptionCandidateSqlite = (
            source_revision as "sourceRevision",
            source_policy_version as "sourcePolicyVersion",
            description_policy_version as "descriptionPolicyVersion",
+           attribution_text as "attributionText",
+           licensed_source_text_hash as "licensedSourceTextHash",
+           licensed_text_transformed as "licensedTextTransformed",
            editor_ref as "editorRef",
            model_id as "modelId",
            model_version as "modelVersion",
@@ -950,6 +1062,15 @@ export const reviewDescriptionCandidateSqlite = (
     if (!current) throw new Error("Description candidate decision not found");
     const finalState: "eligible" | "rejected" =
       input.decision === "approve" ? "eligible" : "rejected";
+    if (
+      input.decision === "approve" &&
+      (current.policyVersion !== input.descriptionPolicyVersion ||
+        !candidateEvidenceIsCurrentlyUsable(raw, candidate, input))
+    ) {
+      throw new Error(
+        "Description review refused: current evidence or policy is ineligible",
+      );
+    }
     if (
       current.state === finalState &&
       current.reviewerRef === input.reviewerRef &&
@@ -1072,6 +1193,9 @@ const candidateRow = (
          source_revision as "sourceRevision",
          source_policy_version as "sourcePolicyVersion",
          description_policy_version as "descriptionPolicyVersion",
+         attribution_text as "attributionText",
+         licensed_source_text_hash as "licensedSourceTextHash",
+         licensed_text_transformed as "licensedTextTransformed",
          editor_ref as "editorRef",
          model_id as "modelId",
          model_version as "modelVersion",
@@ -1187,6 +1311,8 @@ export const requestDescriptionRereviewSqlite = (
   input: {
     candidateId: string;
     policyVersion: string;
+    currentModelVersion?: string;
+    currentPromptVersion?: string;
     queueCapacity: number;
     requestedAt: number;
   },
@@ -1196,6 +1322,29 @@ export const requestDescriptionRereviewSqlite = (
     if (!candidate) throw new Error("Description candidate not found");
     const current = currentDecision(raw, input.candidateId);
     if (!current) throw new Error("Description candidate decision not found");
+    const rejectionCodes = parseJson<DescriptionRejectionCode[]>(
+      current.rejectionCodesJson,
+    );
+    if (
+      current.state === "rejected" ||
+      current.state === "withdrawn" ||
+      rejectionCodes.length > 0
+    ) {
+      throw new Error(
+        "Description re-review refused: hard rejection or withdrawal is not reviewable",
+      );
+    }
+    if (
+      !candidateEvidenceIsCurrentlyUsable(raw, candidate, {
+        descriptionPolicyVersion: input.policyVersion,
+        currentModelVersion: input.currentModelVersion,
+        currentPromptVersion: input.currentPromptVersion,
+      })
+    ) {
+      throw new Error(
+        "Description re-review refused: current evidence or model policy is ineligible",
+      );
+    }
     const warningCodes = uniqueSorted([
       ...parseJson<DescriptionWarningCode[]>(current.warningCodesJson),
       "policy_version_review",
@@ -1211,7 +1360,7 @@ export const requestDescriptionRereviewSqlite = (
     writeDecision(raw, {
       candidateId: input.candidateId,
       state,
-      rejectionCodes: [],
+      rejectionCodes,
       warningCodes,
       policyVersion: input.policyVersion,
       decidedAt: input.requestedAt,
@@ -1237,6 +1386,8 @@ export const rollbackDescriptionProjectionSqlite = (
     actorRef: string;
     reason: string;
     policyVersion: string;
+    currentModelVersion?: string;
+    currentPromptVersion?: string;
     rolledBackAt: number;
     failAfter?: "event" | "head";
   },
@@ -1259,9 +1410,19 @@ export const rollbackDescriptionProjectionSqlite = (
       throw new Error("Description rollback refused: target is not selectable");
     }
     const decision = currentDecision(raw, target.candidateId);
-    if (decision?.state !== "eligible") {
+    const candidate = candidateRow(raw, target.candidateId);
+    if (
+      decision?.state !== "eligible" ||
+      decision.policyVersion !== input.policyVersion ||
+      !candidate ||
+      !candidateEvidenceIsCurrentlyUsable(raw, candidate, {
+        descriptionPolicyVersion: input.policyVersion,
+        currentModelVersion: input.currentModelVersion,
+        currentPromptVersion: input.currentPromptVersion,
+      })
+    ) {
       throw new Error(
-        "Description rollback refused: target candidate is not eligible",
+        "Description rollback refused: target candidate is not currently eligible",
       );
     }
     const previous = currentProjection(raw, input.workId);
@@ -1308,22 +1469,6 @@ export const rollbackDescriptionProjectionSqlite = (
   return apply.immediate();
 };
 
-const candidateParentIds = (
-  raw: SqliteDatabase,
-  candidateId: string,
-): string[] =>
-  (
-    raw
-      .prepare(
-        `select distinct e.observation_id as id
-         from description_claims c
-         join description_claim_evidence e on e.claim_id = c.id
-         where c.candidate_id = ?
-         order by e.observation_id`,
-      )
-      .all(candidateId) as Array<{ id: string }>
-  ).map((row) => row.id);
-
 export const getDescriptionProposalSqlite = (
   raw: SqliteDatabase,
   input: {
@@ -1353,46 +1498,8 @@ export const getDescriptionProposalSqlite = (
   if (
     !candidate ||
     decision?.state !== "eligible" ||
-    decision.policyVersion !== input.descriptionPolicyVersion
-  ) {
-    return undefined;
-  }
-  if (
-    candidate.descriptionClass === "model_assisted_candidate" &&
-    ((input.currentModelVersion &&
-      candidate.modelVersion !== input.currentModelVersion) ||
-      (input.currentPromptVersion &&
-        candidate.promptVersion !== input.currentPromptVersion))
-  ) {
-    return undefined;
-  }
-  const observation = raw
-    .prepare(
-      `select source_record_id as "sourceRecordId", state
-       from field_observations where id = ?`,
-    )
-    .get(candidate.observationId) as
-    | { sourceRecordId: string; state: string }
-    | undefined;
-  if (!observation || observation.state !== "active") return undefined;
-  const source = sourceContext(
-    raw,
-    observation.sourceRecordId,
-    candidate.workId,
-  );
-  if (
-    !candidateSourceIsCurrentlyUsable(source, candidate.sourcePolicyVersion)
-  ) {
-    return undefined;
-  }
-  const parents = loadParents(raw, candidateParentIds(raw, candidate.id));
-  if (
-    parents.some(
-      (parent) =>
-        !parent.eligible ||
-        parent.unresolvedConflict ||
-        parent.workId !== candidate.workId,
-    )
+    decision.policyVersion !== input.descriptionPolicyVersion ||
+    !candidateEvidenceIsCurrentlyUsable(raw, candidate, input)
   ) {
     return undefined;
   }
@@ -1449,15 +1556,13 @@ export const reconcileDescriptionCandidateSqlite = (
     });
     return "withdrawn";
   }
-  const parents = loadParents(raw, candidateParentIds(raw, candidate.id));
   if (
-    !candidateSourceIsCurrentlyUsable(source, candidate.sourcePolicyVersion) ||
-    parents.some(
-      (parent) =>
-        !parent.eligible ||
-        parent.unresolvedConflict ||
-        parent.workId !== candidate.workId,
-    )
+    !candidateEvidenceIsCurrentlyUsable(raw, candidate, {
+      descriptionPolicyVersion: input.descriptionPolicyVersion,
+      currentModelVersion: candidate.modelVersion ?? input.currentModelVersion,
+      currentPromptVersion:
+        candidate.promptVersion ?? input.currentPromptVersion,
+    })
   ) {
     invalidateDescriptionCandidateSqlite(raw, {
       candidateId: candidate.id,
@@ -1498,6 +1603,8 @@ export const reconcileDescriptionCandidateSqlite = (
     const rereview = requestDescriptionRereviewSqlite(raw, {
       candidateId: candidate.id,
       policyVersion: input.descriptionPolicyVersion,
+      currentModelVersion: input.currentModelVersion,
+      currentPromptVersion: input.currentPromptVersion,
       queueCapacity: input.queueCapacity,
       requestedAt: input.reconciledAt,
     });
@@ -1521,7 +1628,12 @@ export const descriptionMetricsSqlite = (
          count(*) as candidates,
          count(distinct c.work_id) as candidateWorks,
          sum(case when d.state = 'rejected' then 1 else 0 end) as rejected,
-         sum(case when d.reviewer_ref is not null then 1 else 0 end) as reviewed,
+         sum(case when exists (
+           select 1 from description_decisions reviewed
+           where reviewed.candidate_id = c.id
+             and reviewed.reviewer_ref is not null
+             and reviewed.state in ('eligible', 'rejected')
+         ) then 1 else 0 end) as reviewed,
          sum(case when d.state = 'eligible' then 1 else 0 end) as eligible,
          count(distinct case when d.state = 'eligible' then c.work_id end) as eligibleWorks,
          sum(case when d.state = 'withdrawn' then 1 else 0 end) as withdrawn,

--- a/src/db/catalog/enrichment/descriptions/repository.ts
+++ b/src/db/catalog/enrichment/descriptions/repository.ts
@@ -1,0 +1,1613 @@
+import type Database from "better-sqlite3";
+import {
+  canonicalJson,
+  deterministicCatalogId,
+  hashCanonicalJson,
+} from "../../identity";
+import { sourcePolicyAllowsFieldDisplay } from "../../policy-eligibility";
+import type {
+  DescriptionDecisionState,
+  DescriptionProjectionState,
+} from "../../values";
+import type {
+  DescriptionCandidateInput,
+  DescriptionCandidateResult,
+  DescriptionMetrics,
+  DescriptionParentEvidence,
+  DescriptionRejectionCode,
+  DescriptionValidationResult,
+  DescriptionWarningCode,
+} from "./types";
+import {
+  descriptionGenerationInputHash,
+  validateDescriptionCandidate,
+} from "./validation";
+
+type SqliteDatabase = InstanceType<typeof Database>;
+
+type SourceContextRow = {
+  sourceRecordId: string;
+  sourceRevision: string | null;
+  sourceRecordState: "active" | "withdrawn" | "deleted";
+  sourceApproval: "pending" | "approved" | "suspended" | "retired";
+  metadataPolicy: string;
+  sourceLinkState: "active" | "candidate" | "rejected" | null;
+};
+
+type DecisionRow = {
+  id: string;
+  state: DescriptionDecisionState;
+  rejectionCodesJson: string;
+  warningCodesJson: string;
+  reviewerRef: string | null;
+  reviewReason: string | null;
+  policyVersion: string;
+};
+
+type CandidateRow = {
+  id: string;
+  workId: string;
+  observationId: string;
+  descriptionClass:
+    | "licensed_verbatim"
+    | "bukie_editorial"
+    | "model_assisted_candidate";
+  textContent: string;
+  textHash: string;
+  sourceRevision: string;
+  sourcePolicyVersion: string;
+  descriptionPolicyVersion: string;
+  editorRef: string | null;
+  modelId: string | null;
+  modelVersion: string | null;
+  promptVersion: string | null;
+  qualityScore: number | null;
+};
+
+type ParentRow = {
+  id: string;
+  entityType: string;
+  entityId: string;
+  workId: string | null;
+  fieldKey: string;
+  valueJson: string;
+  observationState: "active" | "stale" | "withdrawn" | "invalid";
+  provenanceKind: "curated" | "imported" | "derived" | "synthetic";
+  sourceRecordState: "active" | "withdrawn" | "deleted";
+  sourceApproval: "pending" | "approved" | "suspended" | "retired";
+  sourceLinkState: "active" | "candidate" | "rejected" | null;
+  metadataPolicy: string;
+  resolutionState:
+    | "present"
+    | "missing"
+    | "conflicting"
+    | "stale"
+    | "withdrawn"
+    | null;
+};
+
+type ProjectionRow = {
+  id: string;
+  candidateId: string | null;
+  state: DescriptionProjectionState;
+};
+
+type QueueOutcome =
+  | "not_required"
+  | "queued"
+  | "deduplicated"
+  | "overflow_paused";
+
+const parseJson = <T>(value: string): T => JSON.parse(value) as T;
+
+const uniqueSorted = <T extends string>(values: readonly T[]): T[] =>
+  [...new Set(values)].sort();
+
+const sourcePolicy = (
+  value: string,
+): {
+  sourcePolicyVersion?: unknown;
+  proposedEvidenceOnly?: unknown;
+  textPermission?: {
+    allowedFields?: unknown;
+    fetch?: unknown;
+    transform?: unknown;
+  };
+  attribution?: {
+    required?: unknown;
+  };
+} => {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed
+      : {};
+  } catch {
+    return {};
+  }
+};
+
+const sourceContext = (
+  raw: SqliteDatabase,
+  sourceRecordId: string,
+  workId: string,
+): SourceContextRow | undefined =>
+  raw
+    .prepare(
+      `select
+         sr.id as "sourceRecordId",
+         sr.source_revision as "sourceRevision",
+         sr.state as "sourceRecordState",
+         s.approval_state as "sourceApproval",
+         s.metadata_policy as "metadataPolicy",
+         sl.state as "sourceLinkState"
+       from source_records sr
+       join metadata_sources s on s.id = sr.source_id
+       left join source_record_links sl
+         on sl.source_record_id = sr.id
+        and sl.entity_type = 'work'
+        and sl.entity_id = ?
+       where sr.id = ?`,
+    )
+    .get(workId, sourceRecordId) as SourceContextRow | undefined;
+
+const sourceAllowsCandidate = (
+  context: SourceContextRow | undefined,
+  input: DescriptionCandidateInput,
+): boolean => {
+  if (
+    !context ||
+    context.sourceApproval !== "approved" ||
+    context.sourceRecordState !== "active" ||
+    context.sourceLinkState !== "active"
+  ) {
+    return false;
+  }
+  const policy = sourcePolicy(context.metadataPolicy);
+  return Boolean(
+    policy.sourcePolicyVersion === input.sourcePolicyVersion &&
+      policy.textPermission?.fetch === true &&
+      Array.isArray(policy.textPermission.allowedFields) &&
+      policy.textPermission.allowedFields.includes("work.description"),
+  );
+};
+
+const candidateSourceIsCurrentlyUsable = (
+  context: SourceContextRow | undefined,
+  expectedPolicyVersion: string,
+): boolean => {
+  if (
+    !context ||
+    context.sourceApproval !== "approved" ||
+    context.sourceRecordState !== "active" ||
+    context.sourceLinkState !== "active"
+  ) {
+    return false;
+  }
+  const policy = sourcePolicy(context.metadataPolicy);
+  return Boolean(
+    policy.sourcePolicyVersion === expectedPolicyVersion &&
+      policy.textPermission?.fetch === true &&
+      Array.isArray(policy.textPermission.allowedFields) &&
+      policy.textPermission.allowedFields.includes("work.description"),
+  );
+};
+
+const loadParents = (
+  raw: SqliteDatabase,
+  ids: readonly string[],
+): DescriptionParentEvidence[] => {
+  const uniqueIds = uniqueSorted(ids);
+  if (uniqueIds.length === 0) return [];
+  const placeholders = uniqueIds.map(() => "?").join(", ");
+  const rows = raw
+    .prepare(
+      `select
+         o.id as "id",
+         o.entity_type as "entityType",
+         o.entity_id as "entityId",
+         case
+           when o.entity_type = 'work' then o.entity_id
+           when o.entity_type = 'edition' then e.work_id
+           else null
+         end as "workId",
+         o.field_key as "fieldKey",
+         o.value_json as "valueJson",
+         o.state as "observationState",
+         o.provenance_kind as "provenanceKind",
+         sr.state as "sourceRecordState",
+         s.approval_state as "sourceApproval",
+         sl.state as "sourceLinkState",
+         s.metadata_policy as "metadataPolicy",
+         r.state as "resolutionState"
+       from field_observations o
+       join source_records sr on sr.id = o.source_record_id
+       join metadata_sources s on s.id = sr.source_id
+       left join editions e
+         on o.entity_type = 'edition' and e.id = o.entity_id
+       left join source_record_links sl
+         on sl.source_record_id = sr.id
+        and sl.entity_type = o.entity_type
+        and sl.entity_id = o.entity_id
+       left join field_resolution_heads h
+         on h.entity_type = o.entity_type
+        and h.entity_id = o.entity_id
+        and h.field_key = o.field_key
+       left join field_resolutions r on r.id = h.resolution_id
+       where o.id in (${placeholders})
+       order by o.id`,
+    )
+    .all(...uniqueIds) as ParentRow[];
+  return rows.map((row) => {
+    const value = parseJson<unknown>(row.valueJson);
+    return {
+      id: row.id,
+      entityType: row.entityType,
+      entityId: row.entityId,
+      workId: row.workId,
+      fieldKey: row.fieldKey,
+      value,
+      sourceText: typeof value === "string" ? value : null,
+      eligible:
+        (row.observationState === "active" ||
+          row.observationState === "stale") &&
+        row.provenanceKind !== "synthetic" &&
+        row.sourceRecordState === "active" &&
+        row.sourceApproval === "approved" &&
+        row.sourceLinkState === "active" &&
+        sourcePolicyAllowsFieldDisplay(row.metadataPolicy, row.fieldKey),
+      unresolvedConflict: row.resolutionState === "conflicting",
+    };
+  });
+};
+
+export const descriptionCandidateIdentity = (
+  input: DescriptionCandidateInput,
+): string =>
+  deterministicCatalogId(
+    "description_candidate",
+    input.workId,
+    hashCanonicalJson({
+      ambiguousIdentity: input.ambiguousIdentity ?? false,
+      claims: input.claims,
+      comparisonTextHashes: input.comparisonTexts
+        .map((text) => hashCanonicalJson(text))
+        .sort(),
+      descriptionClass: input.descriptionClass,
+      descriptionPolicyVersion: input.descriptionPolicyVersion,
+      provenance:
+        input.descriptionClass === "licensed_verbatim"
+          ? input.license
+          : input.descriptionClass === "bukie_editorial"
+            ? input.editorial
+            : input.model,
+      sensitiveContent: input.sensitiveContent ?? false,
+      sourcePolicyVersion: input.sourcePolicyVersion,
+      sourceRecordId: input.sourceRecordId,
+      sourceRevision: input.sourceRevision,
+      textHash: hashCanonicalJson(input.text),
+    }),
+  );
+
+export const descriptionObservationIdentity = (candidateId: string): string =>
+  deterministicCatalogId("field_observation", candidateId, "work.description");
+
+export const descriptionDecisionIdentity = (input: {
+  candidateId: string;
+  previousDecisionId: string | null;
+  state: DescriptionDecisionState;
+  rejectionCodes: readonly string[];
+  warningCodes: readonly string[];
+  reviewerRef: string | null;
+  reviewReason: string | null;
+  policyVersion: string;
+}): string =>
+  deterministicCatalogId(
+    "description_decision",
+    input.candidateId,
+    hashCanonicalJson(input),
+  );
+
+export const descriptionProjectionIdentity = (input: {
+  workId: string;
+  candidateId: string | null;
+  previousProjectionId: string | null;
+  state: DescriptionProjectionState;
+  reasonCode: string;
+  policyVersion: string;
+}): string =>
+  deterministicCatalogId(
+    "description_projection",
+    input.workId,
+    hashCanonicalJson(input),
+  );
+
+const currentDecision = (
+  raw: SqliteDatabase,
+  candidateId: string,
+): DecisionRow | undefined =>
+  raw
+    .prepare(
+      `select
+         d.id as "id",
+         d.state as "state",
+         d.rejection_codes_json as "rejectionCodesJson",
+         d.warning_codes_json as "warningCodesJson",
+         d.reviewer_ref as "reviewerRef",
+         d.review_reason as "reviewReason",
+         d.policy_version as "policyVersion"
+       from description_decision_heads h
+       join description_decisions d on d.id = h.decision_id
+       where h.candidate_id = ?`,
+    )
+    .get(candidateId) as DecisionRow | undefined;
+
+const currentProjection = (
+  raw: SqliteDatabase,
+  workId: string,
+): ProjectionRow | undefined =>
+  raw
+    .prepare(
+      `select
+         p.id as "id",
+         p.candidate_id as "candidateId",
+         p.state as "state"
+       from description_projection_heads h
+       join description_projections p on p.id = h.projection_id
+       where h.work_id = ?`,
+    )
+    .get(workId) as ProjectionRow | undefined;
+
+const writeDecision = (
+  raw: SqliteDatabase,
+  input: {
+    candidateId: string;
+    state: DescriptionDecisionState;
+    rejectionCodes: readonly string[];
+    warningCodes: readonly string[];
+    reviewerRef?: string | null;
+    reviewReason?: string | null;
+    policyVersion: string;
+    decidedAt: number;
+  },
+): { id: string; changed: boolean } => {
+  const previous = currentDecision(raw, input.candidateId);
+  const rejectionCodes = uniqueSorted(input.rejectionCodes);
+  const warningCodes = uniqueSorted(input.warningCodes);
+  if (
+    previous?.state === input.state &&
+    previous.policyVersion === input.policyVersion &&
+    previous.reviewerRef === (input.reviewerRef ?? null) &&
+    previous.reviewReason === (input.reviewReason ?? null) &&
+    canonicalJson(parseJson(previous.rejectionCodesJson)) ===
+      canonicalJson(rejectionCodes) &&
+    canonicalJson(parseJson(previous.warningCodesJson)) ===
+      canonicalJson(warningCodes)
+  ) {
+    return { id: previous.id, changed: false };
+  }
+  const id = descriptionDecisionIdentity({
+    candidateId: input.candidateId,
+    previousDecisionId: previous?.id ?? null,
+    state: input.state,
+    rejectionCodes,
+    warningCodes,
+    reviewerRef: input.reviewerRef ?? null,
+    reviewReason: input.reviewReason ?? null,
+    policyVersion: input.policyVersion,
+  });
+  raw
+    .prepare(
+      `insert into description_decisions (
+         id, candidate_id, state, rejection_codes_json, warning_codes_json,
+         reviewer_ref, review_reason, previous_decision_id, policy_version,
+         decided_at
+       ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      id,
+      input.candidateId,
+      input.state,
+      canonicalJson(rejectionCodes),
+      canonicalJson(warningCodes),
+      input.reviewerRef ?? null,
+      input.reviewReason ?? null,
+      previous?.id ?? null,
+      input.policyVersion,
+      input.decidedAt,
+    );
+  raw
+    .prepare(
+      `insert into description_decision_heads (candidate_id, decision_id)
+       values (?, ?)
+       on conflict(candidate_id) do update set decision_id = excluded.decision_id`,
+    )
+    .run(input.candidateId, id);
+  return { id, changed: true };
+};
+
+const writeProjection = (
+  raw: SqliteDatabase,
+  input: {
+    workId: string;
+    candidateId: string | null;
+    state: DescriptionProjectionState;
+    reasonCode: string;
+    actorRef: string;
+    policyVersion: string;
+    projectedAt: number;
+  },
+): { id: string; changed: boolean } => {
+  const previous = currentProjection(raw, input.workId);
+  if (
+    previous?.candidateId === input.candidateId &&
+    previous.state === input.state
+  ) {
+    return { id: previous.id, changed: false };
+  }
+  const id = descriptionProjectionIdentity({
+    workId: input.workId,
+    candidateId: input.candidateId,
+    previousProjectionId: previous?.id ?? null,
+    state: input.state,
+    reasonCode: input.reasonCode,
+    policyVersion: input.policyVersion,
+  });
+  raw
+    .prepare(
+      `insert into description_projections (
+         id, work_id, candidate_id, state, previous_projection_id,
+         reason_code, actor_ref, policy_version, projected_at
+       ) values (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      id,
+      input.workId,
+      input.candidateId,
+      input.state,
+      previous?.id ?? null,
+      input.reasonCode,
+      input.actorRef,
+      input.policyVersion,
+      input.projectedAt,
+    );
+  raw
+    .prepare(
+      `insert into description_projection_heads (work_id, projection_id)
+       values (?, ?)
+       on conflict(work_id) do update set projection_id = excluded.projection_id`,
+    )
+    .run(input.workId, id);
+  return { id, changed: true };
+};
+
+const queueCandidate = (
+  raw: SqliteDatabase,
+  input: {
+    candidateId: string;
+    reasonCodes: readonly string[];
+    capacity: number;
+    now: number;
+  },
+): QueueOutcome => {
+  const existing = raw
+    .prepare(
+      `select state from description_review_queue where candidate_id = ?`,
+    )
+    .get(input.candidateId) as { state: string } | undefined;
+  if (existing?.state === "queued" || existing?.state === "claimed") {
+    return "deduplicated";
+  }
+  const activeCount = Number(
+    (
+      raw
+        .prepare(
+          `select count(*) as count
+           from description_review_queue
+           where state in ('queued', 'claimed')`,
+        )
+        .get() as { count: number }
+    ).count,
+  );
+  if (activeCount >= Math.max(0, Math.trunc(input.capacity))) {
+    return "overflow_paused";
+  }
+  const reasons = uniqueSorted(input.reasonCodes);
+  const priority = reasons.reduce(
+    (total, reason) =>
+      total +
+      (reason.includes("sensitive") || reason.includes("ambiguous") ? 100 : 10),
+    0,
+  );
+  raw
+    .prepare(
+      `insert into description_review_queue (
+         candidate_id, state, priority, reason_codes_json, queued_at,
+         updated_at, reviewer_ref
+       ) values (?, 'queued', ?, ?, ?, ?, null)
+       on conflict(candidate_id) do update set
+         state = 'queued',
+         priority = excluded.priority,
+         reason_codes_json = excluded.reason_codes_json,
+         queued_at = excluded.queued_at,
+         updated_at = excluded.updated_at,
+         reviewer_ref = null`,
+    )
+    .run(
+      input.candidateId,
+      priority,
+      canonicalJson(reasons),
+      input.now,
+      input.now,
+    );
+  return "queued";
+};
+
+const persistedValidation = (
+  candidate: CandidateRow,
+  decision: DecisionRow,
+): DescriptionValidationResult => ({
+  rejectionCodes: parseJson<DescriptionRejectionCode[]>(
+    decision.rejectionCodesJson,
+  ),
+  warningCodes: parseJson<DescriptionWarningCode[]>(decision.warningCodesJson),
+  requiresHumanReview:
+    decision.state === "review_required" || decision.state === "paused",
+  wordCount: candidate.textContent.trim().split(/\s+/u).filter(Boolean).length,
+  readabilityScore: 0,
+  qualityScore: candidate.qualityScore ?? 0,
+});
+
+const existingCandidateResult = (
+  raw: SqliteDatabase,
+  candidateId: string,
+): DescriptionCandidateResult | undefined => {
+  const candidate = raw
+    .prepare(
+      `select
+         id as "id",
+         work_id as "workId",
+         observation_id as "observationId",
+         description_class as "descriptionClass",
+         text_content as "textContent",
+         text_hash as "textHash",
+         source_revision as "sourceRevision",
+         source_policy_version as "sourcePolicyVersion",
+         description_policy_version as "descriptionPolicyVersion",
+         editor_ref as "editorRef",
+         model_id as "modelId",
+         model_version as "modelVersion",
+         prompt_version as "promptVersion",
+         quality_score as "qualityScore"
+       from description_candidates where id = ?`,
+    )
+    .get(candidateId) as CandidateRow | undefined;
+  if (!candidate) return undefined;
+  const decision = currentDecision(raw, candidateId);
+  if (!decision) {
+    throw new Error(
+      `Description candidate ${candidateId} has no decision head`,
+    );
+  }
+  const queueRow = raw
+    .prepare(
+      `select state from description_review_queue where candidate_id = ?`,
+    )
+    .get(candidateId) as { state: string } | undefined;
+  return {
+    candidateId,
+    observationId: candidate.observationId,
+    decisionId: decision.id,
+    state: decision.state,
+    validation: persistedValidation(candidate, decision),
+    queue:
+      decision.state === "paused"
+        ? "overflow_paused"
+        : queueRow?.state === "queued" || queueRow?.state === "claimed"
+          ? "deduplicated"
+          : "not_required",
+    changed: false,
+  };
+};
+
+export const createDescriptionCandidateSqlite = (
+  raw: SqliteDatabase,
+  input: {
+    candidate: DescriptionCandidateInput;
+    queueCapacity: number;
+    failAfter?: "candidate" | "decision" | "projection";
+  },
+): DescriptionCandidateResult => {
+  const candidateId = descriptionCandidateIdentity(input.candidate);
+  const existing = existingCandidateResult(raw, candidateId);
+  if (existing) return existing;
+  const apply = raw.transaction(() => {
+    const source = sourceContext(
+      raw,
+      input.candidate.sourceRecordId,
+      input.candidate.workId,
+    );
+    const parentIds = input.candidate.claims.flatMap(
+      (claim) => claim.parentObservationIds,
+    );
+    const parents = loadParents(raw, parentIds);
+    const validation = validateDescriptionCandidate({
+      candidate: input.candidate,
+      parents,
+    });
+    if (source?.sourceRevision !== input.candidate.sourceRevision) {
+      validation.rejectionCodes.push("source_revision_mismatch");
+    }
+    if (!sourceAllowsCandidate(source, input.candidate)) {
+      validation.rejectionCodes.push("source_policy_ineligible");
+    }
+    if (
+      input.candidate.descriptionClass === "licensed_verbatim" &&
+      input.candidate.license.transformed &&
+      source &&
+      sourcePolicy(source.metadataPolicy).textPermission?.transform !== true
+    ) {
+      validation.rejectionCodes.push("licensed_derivative_not_permitted");
+    }
+    if (
+      input.candidate.descriptionClass === "licensed_verbatim" &&
+      source &&
+      sourcePolicy(source.metadataPolicy).attribution?.required === true &&
+      !input.candidate.license.attributionText?.trim()
+    ) {
+      validation.rejectionCodes.push("licensed_provenance_incomplete");
+    }
+    validation.rejectionCodes = uniqueSorted(validation.rejectionCodes);
+    validation.warningCodes = uniqueSorted(validation.warningCodes);
+    validation.requiresHumanReview =
+      validation.rejectionCodes.length === 0 &&
+      validation.warningCodes.length > 0;
+
+    const observationId = descriptionObservationIdentity(candidateId);
+    const generationInputHash = descriptionGenerationInputHash(input.candidate);
+    raw
+      .prepare(
+        `insert into field_observations (
+           id, source_record_id, entity_type, entity_id, field_key, value_json,
+           comparison_hash, provenance_kind, source_path, source_modified_at,
+           retrieved_at, mapping_confidence, state, actor_ref, reason,
+           derivation_name, derivation_version, parent_ids_json
+         ) values (
+           ?, ?, 'work', ?, 'work.description', ?, ?, ?, ?, null, ?, 1, ?,
+           ?, ?, ?, ?, ?
+         )`,
+      )
+      .run(
+        observationId,
+        input.candidate.sourceRecordId,
+        input.candidate.workId,
+        canonicalJson(input.candidate.text),
+        hashCanonicalJson(input.candidate.text),
+        input.candidate.descriptionClass === "licensed_verbatim"
+          ? "imported"
+          : input.candidate.descriptionClass === "bukie_editorial"
+            ? "curated"
+            : "derived",
+        input.candidate.descriptionClass === "licensed_verbatim"
+          ? "licensed.description"
+          : input.candidate.descriptionClass === "bukie_editorial"
+            ? "editorial.description"
+            : "model.description",
+        input.candidate.createdAt,
+        validation.rejectionCodes.length > 0 ? "invalid" : "active",
+        input.candidate.descriptionClass === "bukie_editorial"
+          ? input.candidate.editorial.editorRef
+          : input.candidate.descriptionClass === "model_assisted_candidate"
+            ? "system:description-generation-fixture"
+            : null,
+        input.candidate.descriptionClass === "bukie_editorial"
+          ? input.candidate.editorial.reason
+          : null,
+        input.candidate.descriptionClass === "model_assisted_candidate"
+          ? "provider-neutral-description-generation"
+          : null,
+        input.candidate.descriptionClass === "model_assisted_candidate"
+          ? `${input.candidate.model.modelVersion}:${input.candidate.model.promptVersion}`
+          : null,
+        input.candidate.descriptionClass === "model_assisted_candidate"
+          ? canonicalJson(uniqueSorted(parentIds))
+          : null,
+      );
+    raw
+      .prepare(
+        `insert into description_candidates (
+           id, work_id, observation_id, description_class, text_content,
+           text_hash, source_revision, source_policy_version,
+           description_policy_version, license_name, license_url,
+           attribution_text, derivatives_permitted, editor_ref,
+           editorial_reason, editorial_revision, model_id, model_version,
+           prompt_version, generation_input_hash, generated_at,
+           generation_duration_ms, input_tokens, output_tokens, cost_microusd,
+           quality_score, ambiguous_identity, sensitive_content, created_at
+         ) values (
+           ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+           ?, ?, ?, ?, ?, ?, ?, ?
+         )`,
+      )
+      .run(
+        candidateId,
+        input.candidate.workId,
+        observationId,
+        input.candidate.descriptionClass,
+        input.candidate.text,
+        hashCanonicalJson(input.candidate.text),
+        input.candidate.sourceRevision,
+        input.candidate.sourcePolicyVersion,
+        input.candidate.descriptionPolicyVersion,
+        input.candidate.descriptionClass === "licensed_verbatim"
+          ? input.candidate.license.name
+          : null,
+        input.candidate.descriptionClass === "licensed_verbatim"
+          ? input.candidate.license.url
+          : null,
+        input.candidate.descriptionClass === "licensed_verbatim"
+          ? input.candidate.license.attributionText
+          : null,
+        input.candidate.descriptionClass === "licensed_verbatim"
+          ? Number(input.candidate.license.derivativesPermitted)
+          : null,
+        input.candidate.descriptionClass === "bukie_editorial"
+          ? input.candidate.editorial.editorRef
+          : null,
+        input.candidate.descriptionClass === "bukie_editorial"
+          ? input.candidate.editorial.reason
+          : null,
+        input.candidate.descriptionClass === "bukie_editorial"
+          ? input.candidate.editorial.revision
+          : null,
+        input.candidate.descriptionClass === "model_assisted_candidate"
+          ? input.candidate.model.modelId
+          : null,
+        input.candidate.descriptionClass === "model_assisted_candidate"
+          ? input.candidate.model.modelVersion
+          : null,
+        input.candidate.descriptionClass === "model_assisted_candidate"
+          ? input.candidate.model.promptVersion
+          : null,
+        input.candidate.descriptionClass === "model_assisted_candidate"
+          ? generationInputHash
+          : null,
+        input.candidate.descriptionClass === "model_assisted_candidate"
+          ? input.candidate.model.generatedAt
+          : null,
+        input.candidate.descriptionClass === "model_assisted_candidate"
+          ? input.candidate.model.generationDurationMs
+          : null,
+        input.candidate.descriptionClass === "model_assisted_candidate"
+          ? input.candidate.model.inputTokens
+          : null,
+        input.candidate.descriptionClass === "model_assisted_candidate"
+          ? input.candidate.model.outputTokens
+          : null,
+        input.candidate.descriptionClass === "model_assisted_candidate"
+          ? input.candidate.model.costMicrousd
+          : null,
+        validation.qualityScore,
+        Number(input.candidate.ambiguousIdentity ?? false),
+        Number(input.candidate.sensitiveContent ?? false),
+        input.candidate.createdAt,
+      );
+    for (const [position, claim] of input.candidate.claims.entries()) {
+      const claimHash = hashCanonicalJson(claim.text);
+      const claimId = deterministicCatalogId(
+        "description_claim",
+        candidateId,
+        hashCanonicalJson({ claimHash, position }),
+      );
+      raw
+        .prepare(
+          `insert into description_claims (
+             id, candidate_id, position, claim_text, claim_hash
+           ) values (?, ?, ?, ?, ?)`,
+        )
+        .run(claimId, candidateId, position, claim.text, claimHash);
+      for (const parentId of uniqueSorted(claim.parentObservationIds)) {
+        if (!parents.some((parent) => parent.id === parentId)) continue;
+        raw
+          .prepare(
+            `insert into description_claim_evidence (claim_id, observation_id)
+             values (?, ?)`,
+          )
+          .run(claimId, parentId);
+      }
+    }
+    if (input.failAfter === "candidate") {
+      throw new Error("Forced description failure after candidate");
+    }
+
+    let state: DescriptionDecisionState =
+      validation.rejectionCodes.length > 0
+        ? "rejected"
+        : validation.requiresHumanReview
+          ? "review_required"
+          : "eligible";
+    let queue: QueueOutcome = "not_required";
+    if (state === "review_required") {
+      queue = queueCandidate(raw, {
+        candidateId,
+        reasonCodes: validation.warningCodes,
+        capacity: input.queueCapacity,
+        now: input.candidate.createdAt,
+      });
+      if (queue === "overflow_paused") state = "paused";
+    }
+    const decision = writeDecision(raw, {
+      candidateId,
+      state,
+      rejectionCodes: validation.rejectionCodes,
+      warningCodes: validation.warningCodes,
+      policyVersion: input.candidate.descriptionPolicyVersion,
+      decidedAt: input.candidate.createdAt,
+    });
+    if (input.failAfter === "decision") {
+      throw new Error("Forced description failure after decision");
+    }
+    if (state === "eligible") {
+      writeProjection(raw, {
+        workId: input.candidate.workId,
+        candidateId,
+        state: "selected",
+        reasonCode: "automated_licensed_verbatim_eligible",
+        actorRef: "system:description-gates",
+        policyVersion: input.candidate.descriptionPolicyVersion,
+        projectedAt: input.candidate.createdAt,
+      });
+    }
+    if (input.failAfter === "projection") {
+      throw new Error("Forced description failure after projection");
+    }
+    return {
+      candidateId,
+      observationId,
+      decisionId: decision.id,
+      state,
+      validation,
+      queue,
+      changed: true,
+    };
+  });
+  return apply.immediate();
+};
+
+export const retryDescriptionQueueSqlite = (
+  raw: SqliteDatabase,
+  input: {
+    candidateId: string;
+    queueCapacity: number;
+    now: number;
+  },
+): QueueOutcome => {
+  const apply = raw.transaction(() => {
+    const decision = currentDecision(raw, input.candidateId);
+    if (!decision) throw new Error("Description candidate decision not found");
+    if (decision.state !== "paused" && decision.state !== "review_required") {
+      return "not_required" as const;
+    }
+    const warningCodes = parseJson<DescriptionWarningCode[]>(
+      decision.warningCodesJson,
+    );
+    const queue = queueCandidate(raw, {
+      candidateId: input.candidateId,
+      reasonCodes: warningCodes,
+      capacity: input.queueCapacity,
+      now: input.now,
+    });
+    if (queue !== "overflow_paused") {
+      writeDecision(raw, {
+        candidateId: input.candidateId,
+        state: "review_required",
+        rejectionCodes: parseJson(decision.rejectionCodesJson),
+        warningCodes,
+        policyVersion: decision.policyVersion,
+        decidedAt: input.now,
+      });
+    }
+    return queue;
+  });
+  return apply.immediate();
+};
+
+export const reviewDescriptionCandidateSqlite = (
+  raw: SqliteDatabase,
+  input: {
+    candidateId: string;
+    reviewerRef: string;
+    decision: "approve" | "reject";
+    reason: string;
+    acknowledgedWarningCodes?: readonly DescriptionWarningCode[];
+    reviewedAt: number;
+    failAfter?: "decision" | "queue" | "projection";
+  },
+): { decisionId: string; state: "eligible" | "rejected"; changed: boolean } => {
+  const apply = raw.transaction(() => {
+    const candidate = raw
+      .prepare(
+        `select
+           id as "id",
+           work_id as "workId",
+           observation_id as "observationId",
+           description_class as "descriptionClass",
+           text_content as "textContent",
+           text_hash as "textHash",
+           source_revision as "sourceRevision",
+           source_policy_version as "sourcePolicyVersion",
+           description_policy_version as "descriptionPolicyVersion",
+           editor_ref as "editorRef",
+           model_id as "modelId",
+           model_version as "modelVersion",
+           prompt_version as "promptVersion",
+           quality_score as "qualityScore"
+         from description_candidates where id = ?`,
+      )
+      .get(input.candidateId) as CandidateRow | undefined;
+    if (!candidate) throw new Error("Description candidate not found");
+    const current = currentDecision(raw, input.candidateId);
+    if (!current) throw new Error("Description candidate decision not found");
+    const finalState: "eligible" | "rejected" =
+      input.decision === "approve" ? "eligible" : "rejected";
+    if (
+      current.state === finalState &&
+      current.reviewerRef === input.reviewerRef &&
+      current.reviewReason === input.reason
+    ) {
+      return { decisionId: current.id, state: finalState, changed: false };
+    }
+    if (current.state !== "review_required") {
+      throw new Error(
+        `Description review refused: candidate is ${current.state}`,
+      );
+    }
+    if (
+      candidate.descriptionClass === "bukie_editorial" &&
+      candidate.editorRef === input.reviewerRef
+    ) {
+      throw new Error(
+        "Description review refused: editorial reviewer must differ from editor",
+      );
+    }
+    const warningCodes = parseJson<DescriptionWarningCode[]>(
+      current.warningCodesJson,
+    );
+    if (input.decision === "approve") {
+      const acknowledged = new Set(input.acknowledgedWarningCodes ?? []);
+      const missing = warningCodes.filter((code) => !acknowledged.has(code));
+      if (missing.length > 0) {
+        throw new Error(
+          `Description review refused: warnings not acknowledged: ${missing.join(",")}`,
+        );
+      }
+    }
+    const next = writeDecision(raw, {
+      candidateId: input.candidateId,
+      state: finalState,
+      rejectionCodes:
+        input.decision === "reject"
+          ? uniqueSorted([
+              ...parseJson<DescriptionRejectionCode[]>(
+                current.rejectionCodesJson,
+              ),
+              "human_review_rejected",
+            ])
+          : [],
+      warningCodes,
+      reviewerRef: input.reviewerRef,
+      reviewReason: input.reason,
+      policyVersion: current.policyVersion,
+      decidedAt: input.reviewedAt,
+    });
+    if (input.failAfter === "decision") {
+      throw new Error("Forced description review failure after decision");
+    }
+    raw
+      .prepare(
+        `update description_review_queue
+         set state = 'completed', updated_at = ?, reviewer_ref = ?
+         where candidate_id = ?`,
+      )
+      .run(input.reviewedAt, input.reviewerRef, input.candidateId);
+    if (input.failAfter === "queue") {
+      throw new Error("Forced description review failure after queue");
+    }
+    if (finalState === "eligible") {
+      writeProjection(raw, {
+        workId: candidate.workId,
+        candidateId: input.candidateId,
+        state: "selected",
+        reasonCode: "human_review_approved",
+        actorRef: input.reviewerRef,
+        policyVersion: current.policyVersion,
+        projectedAt: input.reviewedAt,
+      });
+    }
+    if (input.failAfter === "projection") {
+      throw new Error("Forced description review failure after projection");
+    }
+    return { decisionId: next.id, state: finalState, changed: true };
+  });
+  return apply.immediate();
+};
+
+const removeProjectionIfSelected = (
+  raw: SqliteDatabase,
+  input: {
+    candidate: CandidateRow;
+    state: "withdrawn" | "invalidated";
+    reasonCode: string;
+    actorRef: string;
+    policyVersion: string;
+    at: number;
+  },
+): void => {
+  const projection = currentProjection(raw, input.candidate.workId);
+  if (projection?.candidateId !== input.candidate.id) return;
+  writeProjection(raw, {
+    workId: input.candidate.workId,
+    candidateId: null,
+    state: input.state,
+    reasonCode: input.reasonCode,
+    actorRef: input.actorRef,
+    policyVersion: input.policyVersion,
+    projectedAt: input.at,
+  });
+};
+
+const candidateRow = (
+  raw: SqliteDatabase,
+  candidateId: string,
+): CandidateRow | undefined =>
+  raw
+    .prepare(
+      `select
+         id as "id",
+         work_id as "workId",
+         observation_id as "observationId",
+         description_class as "descriptionClass",
+         text_content as "textContent",
+         text_hash as "textHash",
+         source_revision as "sourceRevision",
+         source_policy_version as "sourcePolicyVersion",
+         description_policy_version as "descriptionPolicyVersion",
+         editor_ref as "editorRef",
+         model_id as "modelId",
+         model_version as "modelVersion",
+         prompt_version as "promptVersion",
+         quality_score as "qualityScore"
+       from description_candidates where id = ?`,
+    )
+    .get(candidateId) as CandidateRow | undefined;
+
+export const withdrawDescriptionCandidateSqlite = (
+  raw: SqliteDatabase,
+  input: {
+    candidateId: string;
+    actorRef: string;
+    reason: string;
+    withdrawnAt: number;
+  },
+): { changed: boolean; decisionId: string } => {
+  const apply = raw.transaction(() => {
+    const candidate = candidateRow(raw, input.candidateId);
+    if (!candidate) throw new Error("Description candidate not found");
+    const current = currentDecision(raw, input.candidateId);
+    if (!current) throw new Error("Description candidate decision not found");
+    if (current.state === "withdrawn") {
+      return { changed: false, decisionId: current.id };
+    }
+    const next = writeDecision(raw, {
+      candidateId: input.candidateId,
+      state: "withdrawn",
+      rejectionCodes: parseJson(current.rejectionCodesJson),
+      warningCodes: parseJson(current.warningCodesJson),
+      reviewerRef: input.actorRef,
+      reviewReason: input.reason,
+      policyVersion: current.policyVersion,
+      decidedAt: input.withdrawnAt,
+    });
+    raw
+      .prepare(`update field_observations set state = 'withdrawn' where id = ?`)
+      .run(candidate.observationId);
+    raw
+      .prepare(
+        `update description_review_queue
+         set state = 'cancelled', updated_at = ?
+         where candidate_id = ? and state in ('queued', 'claimed')`,
+      )
+      .run(input.withdrawnAt, input.candidateId);
+    removeProjectionIfSelected(raw, {
+      candidate,
+      state: "withdrawn",
+      reasonCode: "candidate_withdrawn",
+      actorRef: input.actorRef,
+      policyVersion: current.policyVersion,
+      at: input.withdrawnAt,
+    });
+    return { changed: next.changed, decisionId: next.id };
+  });
+  return apply.immediate();
+};
+
+export const invalidateDescriptionCandidateSqlite = (
+  raw: SqliteDatabase,
+  input: {
+    candidateId: string;
+    actorRef?: string;
+    reason: string;
+    policyVersion: string;
+    invalidatedAt: number;
+  },
+): { changed: boolean; decisionId: string } => {
+  const apply = raw.transaction(() => {
+    const candidate = candidateRow(raw, input.candidateId);
+    if (!candidate) throw new Error("Description candidate not found");
+    const current = currentDecision(raw, input.candidateId);
+    if (!current) throw new Error("Description candidate decision not found");
+    if (
+      current.state === "invalidated" &&
+      current.policyVersion === input.policyVersion
+    ) {
+      return { changed: false, decisionId: current.id };
+    }
+    const next = writeDecision(raw, {
+      candidateId: input.candidateId,
+      state: "invalidated",
+      rejectionCodes: parseJson(current.rejectionCodesJson),
+      warningCodes: parseJson(current.warningCodesJson),
+      reviewerRef: input.actorRef ?? "system:description-policy",
+      reviewReason: input.reason,
+      policyVersion: input.policyVersion,
+      decidedAt: input.invalidatedAt,
+    });
+    raw
+      .prepare(
+        `update description_review_queue
+         set state = 'cancelled', updated_at = ?
+         where candidate_id = ? and state in ('queued', 'claimed')`,
+      )
+      .run(input.invalidatedAt, input.candidateId);
+    removeProjectionIfSelected(raw, {
+      candidate,
+      state: "invalidated",
+      reasonCode: "candidate_policy_invalidated",
+      actorRef: input.actorRef ?? "system:description-policy",
+      policyVersion: input.policyVersion,
+      at: input.invalidatedAt,
+    });
+    return { changed: next.changed, decisionId: next.id };
+  });
+  return apply.immediate();
+};
+
+export const requestDescriptionRereviewSqlite = (
+  raw: SqliteDatabase,
+  input: {
+    candidateId: string;
+    policyVersion: string;
+    queueCapacity: number;
+    requestedAt: number;
+  },
+): { state: "review_required" | "paused"; queue: QueueOutcome } => {
+  const apply = raw.transaction(() => {
+    const candidate = candidateRow(raw, input.candidateId);
+    if (!candidate) throw new Error("Description candidate not found");
+    const current = currentDecision(raw, input.candidateId);
+    if (!current) throw new Error("Description candidate decision not found");
+    const warningCodes = uniqueSorted([
+      ...parseJson<DescriptionWarningCode[]>(current.warningCodesJson),
+      "policy_version_review",
+    ]);
+    const queue = queueCandidate(raw, {
+      candidateId: input.candidateId,
+      reasonCodes: warningCodes,
+      capacity: input.queueCapacity,
+      now: input.requestedAt,
+    });
+    const state: "paused" | "review_required" =
+      queue === "overflow_paused" ? "paused" : "review_required";
+    writeDecision(raw, {
+      candidateId: input.candidateId,
+      state,
+      rejectionCodes: [],
+      warningCodes,
+      policyVersion: input.policyVersion,
+      decidedAt: input.requestedAt,
+    });
+    removeProjectionIfSelected(raw, {
+      candidate,
+      state: "invalidated",
+      reasonCode: "candidate_rereview_required",
+      actorRef: "system:description-policy",
+      policyVersion: input.policyVersion,
+      at: input.requestedAt,
+    });
+    return { state, queue };
+  });
+  return apply.immediate();
+};
+
+export const rollbackDescriptionProjectionSqlite = (
+  raw: SqliteDatabase,
+  input: {
+    workId: string;
+    targetProjectionId: string;
+    actorRef: string;
+    reason: string;
+    policyVersion: string;
+    rolledBackAt: number;
+    failAfter?: "event" | "head";
+  },
+): { projectionId: string; changed: boolean } => {
+  const apply = raw.transaction(() => {
+    const target = raw
+      .prepare(
+        `select
+           id as "id",
+           candidate_id as "candidateId",
+           state as "state"
+         from description_projections
+         where id = ? and work_id = ?`,
+      )
+      .get(input.targetProjectionId, input.workId) as ProjectionRow | undefined;
+    if (
+      !target?.candidateId ||
+      (target.state !== "selected" && target.state !== "rolled_back")
+    ) {
+      throw new Error("Description rollback refused: target is not selectable");
+    }
+    const decision = currentDecision(raw, target.candidateId);
+    if (decision?.state !== "eligible") {
+      throw new Error(
+        "Description rollback refused: target candidate is not eligible",
+      );
+    }
+    const previous = currentProjection(raw, input.workId);
+    const id = descriptionProjectionIdentity({
+      workId: input.workId,
+      candidateId: target.candidateId,
+      previousProjectionId: previous?.id ?? null,
+      state: "rolled_back",
+      reasonCode: input.reason,
+      policyVersion: input.policyVersion,
+    });
+    raw
+      .prepare(
+        `insert into description_projections (
+           id, work_id, candidate_id, state, previous_projection_id,
+           reason_code, actor_ref, policy_version, projected_at
+         ) values (?, ?, ?, 'rolled_back', ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        id,
+        input.workId,
+        target.candidateId,
+        previous?.id ?? null,
+        input.reason,
+        input.actorRef,
+        input.policyVersion,
+        input.rolledBackAt,
+      );
+    if (input.failAfter === "event") {
+      throw new Error("Forced description rollback failure after event");
+    }
+    raw
+      .prepare(
+        `insert into description_projection_heads (work_id, projection_id)
+         values (?, ?)
+         on conflict(work_id) do update set projection_id = excluded.projection_id`,
+      )
+      .run(input.workId, id);
+    if (input.failAfter === "head") {
+      throw new Error("Forced description rollback failure after head");
+    }
+    return { projectionId: id, changed: previous?.id !== id };
+  });
+  return apply.immediate();
+};
+
+const candidateParentIds = (
+  raw: SqliteDatabase,
+  candidateId: string,
+): string[] =>
+  (
+    raw
+      .prepare(
+        `select distinct e.observation_id as id
+         from description_claims c
+         join description_claim_evidence e on e.claim_id = c.id
+         where c.candidate_id = ?
+         order by e.observation_id`,
+      )
+      .all(candidateId) as Array<{ id: string }>
+  ).map((row) => row.id);
+
+export const getDescriptionProposalSqlite = (
+  raw: SqliteDatabase,
+  input: {
+    workId: string;
+    descriptionPolicyVersion: string;
+    currentModelVersion?: string;
+    currentPromptVersion?: string;
+  },
+):
+  | {
+      candidateId: string;
+      text: string;
+      descriptionClass: CandidateRow["descriptionClass"];
+      qualityScore: number;
+      publicDisplayEligible: false;
+    }
+  | undefined => {
+  const projection = currentProjection(raw, input.workId);
+  if (
+    !projection?.candidateId ||
+    (projection.state !== "selected" && projection.state !== "rolled_back")
+  ) {
+    return undefined;
+  }
+  const candidate = candidateRow(raw, projection.candidateId);
+  const decision = currentDecision(raw, projection.candidateId);
+  if (
+    !candidate ||
+    decision?.state !== "eligible" ||
+    decision.policyVersion !== input.descriptionPolicyVersion
+  ) {
+    return undefined;
+  }
+  if (
+    candidate.descriptionClass === "model_assisted_candidate" &&
+    ((input.currentModelVersion &&
+      candidate.modelVersion !== input.currentModelVersion) ||
+      (input.currentPromptVersion &&
+        candidate.promptVersion !== input.currentPromptVersion))
+  ) {
+    return undefined;
+  }
+  const observation = raw
+    .prepare(
+      `select source_record_id as "sourceRecordId", state
+       from field_observations where id = ?`,
+    )
+    .get(candidate.observationId) as
+    | { sourceRecordId: string; state: string }
+    | undefined;
+  if (!observation || observation.state !== "active") return undefined;
+  const source = sourceContext(
+    raw,
+    observation.sourceRecordId,
+    candidate.workId,
+  );
+  if (
+    !candidateSourceIsCurrentlyUsable(source, candidate.sourcePolicyVersion)
+  ) {
+    return undefined;
+  }
+  const parents = loadParents(raw, candidateParentIds(raw, candidate.id));
+  if (
+    parents.some(
+      (parent) =>
+        !parent.eligible ||
+        parent.unresolvedConflict ||
+        parent.workId !== candidate.workId,
+    )
+  ) {
+    return undefined;
+  }
+  return {
+    candidateId: candidate.id,
+    text: candidate.textContent,
+    descriptionClass: candidate.descriptionClass,
+    qualityScore: candidate.qualityScore ?? 0,
+    publicDisplayEligible: false,
+  };
+};
+
+export const reconcileDescriptionCandidateSqlite = (
+  raw: SqliteDatabase,
+  input: {
+    candidateId: string;
+    descriptionPolicyVersion: string;
+    currentModelVersion?: string;
+    currentPromptVersion?: string;
+    queueCapacity: number;
+    reconciledAt: number;
+  },
+):
+  | "unchanged"
+  | "withdrawn"
+  | "invalidated_source_policy"
+  | "invalidated_model"
+  | "invalidated_prompt"
+  | "rereview_required"
+  | "rereview_paused" => {
+  const candidate = candidateRow(raw, input.candidateId);
+  if (!candidate) throw new Error("Description candidate not found");
+  const observation = raw
+    .prepare(
+      `select source_record_id as "sourceRecordId", state
+       from field_observations where id = ?`,
+    )
+    .get(candidate.observationId) as
+    | { sourceRecordId: string; state: string }
+    | undefined;
+  const source = observation
+    ? sourceContext(raw, observation.sourceRecordId, candidate.workId)
+    : undefined;
+  if (
+    observation?.state === "withdrawn" ||
+    source?.sourceRecordState === "withdrawn" ||
+    source?.sourceRecordState === "deleted"
+  ) {
+    withdrawDescriptionCandidateSqlite(raw, {
+      candidateId: candidate.id,
+      actorRef: "system:description-reconciliation",
+      reason: "source_withdrawn",
+      withdrawnAt: input.reconciledAt,
+    });
+    return "withdrawn";
+  }
+  const parents = loadParents(raw, candidateParentIds(raw, candidate.id));
+  if (
+    !candidateSourceIsCurrentlyUsable(source, candidate.sourcePolicyVersion) ||
+    parents.some(
+      (parent) =>
+        !parent.eligible ||
+        parent.unresolvedConflict ||
+        parent.workId !== candidate.workId,
+    )
+  ) {
+    invalidateDescriptionCandidateSqlite(raw, {
+      candidateId: candidate.id,
+      reason: "source_or_parent_policy_revoked",
+      policyVersion: input.descriptionPolicyVersion,
+      invalidatedAt: input.reconciledAt,
+    });
+    return "invalidated_source_policy";
+  }
+  if (
+    candidate.descriptionClass === "model_assisted_candidate" &&
+    input.currentModelVersion &&
+    candidate.modelVersion !== input.currentModelVersion
+  ) {
+    invalidateDescriptionCandidateSqlite(raw, {
+      candidateId: candidate.id,
+      reason: "model_version_invalidated",
+      policyVersion: input.descriptionPolicyVersion,
+      invalidatedAt: input.reconciledAt,
+    });
+    return "invalidated_model";
+  }
+  if (
+    candidate.descriptionClass === "model_assisted_candidate" &&
+    input.currentPromptVersion &&
+    candidate.promptVersion !== input.currentPromptVersion
+  ) {
+    invalidateDescriptionCandidateSqlite(raw, {
+      candidateId: candidate.id,
+      reason: "prompt_version_invalidated",
+      policyVersion: input.descriptionPolicyVersion,
+      invalidatedAt: input.reconciledAt,
+    });
+    return "invalidated_prompt";
+  }
+  const decision = currentDecision(raw, candidate.id);
+  if (decision?.policyVersion !== input.descriptionPolicyVersion) {
+    const rereview = requestDescriptionRereviewSqlite(raw, {
+      candidateId: candidate.id,
+      policyVersion: input.descriptionPolicyVersion,
+      queueCapacity: input.queueCapacity,
+      requestedAt: input.reconciledAt,
+    });
+    return rereview.state === "paused"
+      ? "rereview_paused"
+      : "rereview_required";
+  }
+  return "unchanged";
+};
+
+const scaled = (value: number, scopeWorks: number): number =>
+  scopeWorks <= 0 ? 0 : Math.round((value * 500) / scopeWorks);
+
+export const descriptionMetricsSqlite = (
+  raw: SqliteDatabase,
+  scopeWorks: number,
+): DescriptionMetrics => {
+  const counts = raw
+    .prepare(
+      `select
+         count(*) as candidates,
+         count(distinct c.work_id) as candidateWorks,
+         sum(case when d.state = 'rejected' then 1 else 0 end) as rejected,
+         sum(case when d.reviewer_ref is not null then 1 else 0 end) as reviewed,
+         sum(case when d.state = 'eligible' then 1 else 0 end) as eligible,
+         count(distinct case when d.state = 'eligible' then c.work_id end) as eligibleWorks,
+         sum(case when d.state = 'withdrawn' then 1 else 0 end) as withdrawn,
+         sum(case when d.state = 'invalidated' then 1 else 0 end) as invalidated,
+         sum(case when d.state = 'paused' then 1 else 0 end) as paused,
+         coalesce(sum(c.input_tokens), 0) as inputTokens,
+         coalesce(sum(c.output_tokens), 0) as outputTokens,
+         coalesce(sum(c.cost_microusd), 0) as costMicrousd
+       from description_candidates c
+       join description_decision_heads h on h.candidate_id = c.id
+       join description_decisions d on d.id = h.decision_id`,
+    )
+    .get() as Record<string, number | null>;
+  const queueRows = raw
+    .prepare(
+      `select state, count(*) as count
+       from description_review_queue group by state`,
+    )
+    .all() as Array<{
+    state: keyof DescriptionMetrics["queue"];
+    count: number;
+  }>;
+  const queue = {
+    queued: 0,
+    claimed: 0,
+    completed: 0,
+    cancelled: 0,
+  };
+  for (const row of queueRows) queue[row.state] = Number(row.count);
+  const classRows = raw
+    .prepare(
+      `select description_class as class, count(*) as count
+       from description_candidates group by description_class`,
+    )
+    .all() as Array<{
+    class: keyof DescriptionMetrics["byClass"];
+    count: number;
+  }>;
+  const byClass = {
+    licensed_verbatim: 0,
+    bukie_editorial: 0,
+    model_assisted_candidate: 0,
+  };
+  for (const row of classRows) byClass[row.class] = Number(row.count);
+  const candidates = Number(counts.candidates ?? 0);
+  const eligible = Number(counts.eligible ?? 0);
+  const candidateWorks = Number(counts.candidateWorks ?? 0);
+  const eligibleWorks = Number(counts.eligibleWorks ?? 0);
+  const inputTokens = Number(counts.inputTokens ?? 0);
+  const outputTokens = Number(counts.outputTokens ?? 0);
+  const costMicrousd = Number(counts.costMicrousd ?? 0);
+  return {
+    scopeWorks,
+    candidates,
+    rejected: Number(counts.rejected ?? 0),
+    reviewed: Number(counts.reviewed ?? 0),
+    eligible,
+    withdrawn: Number(counts.withdrawn ?? 0),
+    invalidated: Number(counts.invalidated ?? 0),
+    paused: Number(counts.paused ?? 0),
+    queue,
+    coverage: {
+      candidateWorks,
+      eligibleWorks,
+      candidateBasisPoints:
+        scopeWorks <= 0
+          ? 0
+          : Math.round((candidateWorks * 10_000) / scopeWorks),
+      eligibleBasisPoints:
+        scopeWorks <= 0 ? 0 : Math.round((eligibleWorks * 10_000) / scopeWorks),
+    },
+    tokens: {
+      input: inputTokens,
+      output: outputTokens,
+      total: inputTokens + outputTokens,
+    },
+    costMicrousd,
+    estimate500: {
+      candidates: scaled(candidates, scopeWorks),
+      eligible: scaled(eligible, scopeWorks),
+      inputTokens: scaled(inputTokens, scopeWorks),
+      outputTokens: scaled(outputTokens, scopeWorks),
+      costMicrousd: scaled(costMicrousd, scopeWorks),
+    },
+    byClass,
+  };
+};
+
+export const DESCRIPTION_PUBLIC_PROJECTION_TABLES = [] as const;

--- a/src/db/catalog/enrichment/descriptions/types.ts
+++ b/src/db/catalog/enrichment/descriptions/types.ts
@@ -4,6 +4,8 @@ export const DESCRIPTION_POLICY_VERSION = "description-gates-2026-07-29.v1";
 
 export const DESCRIPTION_REJECTION_CODES = [
   "claim_unsupported",
+  "claim_text_not_in_candidate",
+  "candidate_claim_coverage_incomplete",
   "parent_evidence_ineligible",
   "identity_mismatch",
   "evidence_conflict_unresolved",

--- a/src/db/catalog/enrichment/descriptions/types.ts
+++ b/src/db/catalog/enrichment/descriptions/types.ts
@@ -1,0 +1,165 @@
+import type { DescriptionClass, DescriptionDecisionState } from "../../values";
+
+export const DESCRIPTION_POLICY_VERSION = "description-gates-2026-07-29.v1";
+
+export const DESCRIPTION_REJECTION_CODES = [
+  "claim_unsupported",
+  "parent_evidence_ineligible",
+  "identity_mismatch",
+  "evidence_conflict_unresolved",
+  "length_out_of_range",
+  "readability_out_of_range",
+  "specificity_insufficient",
+  "tone_non_neutral",
+  "spoiler_risk",
+  "copying_similarity_high",
+  "licensed_derivative_not_permitted",
+  "licensed_provenance_incomplete",
+  "editorial_provenance_incomplete",
+  "model_provenance_incomplete",
+  "source_revision_mismatch",
+  "source_policy_ineligible",
+  "human_review_rejected",
+] as const;
+
+export const DESCRIPTION_WARNING_CODES = [
+  "copying_exact_eight_word_match",
+  "readability_borderline",
+  "ambiguous_identity_review",
+  "sensitive_content_review",
+  "sparse_evidence_review",
+  "initial_model_review",
+  "editorial_review",
+  "policy_version_review",
+] as const;
+
+export type DescriptionRejectionCode =
+  (typeof DESCRIPTION_REJECTION_CODES)[number];
+export type DescriptionWarningCode = (typeof DESCRIPTION_WARNING_CODES)[number];
+
+export type DescriptionClaimInput = {
+  text: string;
+  parentObservationIds: readonly string[];
+};
+
+export type DescriptionParentEvidence = {
+  id: string;
+  entityType: string;
+  entityId: string;
+  workId: string | null;
+  fieldKey: string;
+  value: unknown;
+  sourceText: string | null;
+  eligible: boolean;
+  unresolvedConflict: boolean;
+};
+
+type CandidateCommon = {
+  workId: string;
+  text: string;
+  sourceRecordId: string;
+  sourceRevision: string;
+  sourcePolicyVersion: string;
+  descriptionPolicyVersion: string;
+  claims: readonly DescriptionClaimInput[];
+  comparisonTexts: readonly string[];
+  ambiguousIdentity?: boolean;
+  sensitiveContent?: boolean;
+  createdAt: number;
+};
+
+export type LicensedDescriptionInput = CandidateCommon & {
+  descriptionClass: "licensed_verbatim";
+  license: {
+    name: string;
+    url: string;
+    attributionText: string | null;
+    derivativesPermitted: boolean;
+    sourceText: string;
+    transformed: boolean;
+  };
+};
+
+export type EditorialDescriptionInput = CandidateCommon & {
+  descriptionClass: "bukie_editorial";
+  editorial: {
+    editorRef: string;
+    reason: string;
+    revision: string;
+  };
+};
+
+export type ModelDescriptionInput = CandidateCommon & {
+  descriptionClass: "model_assisted_candidate";
+  model: {
+    modelId: string;
+    modelVersion: string;
+    promptVersion: string;
+    generatedAt: number;
+    generationDurationMs: number;
+    inputTokens: number;
+    outputTokens: number;
+    costMicrousd: number;
+  };
+};
+
+export type DescriptionCandidateInput =
+  | LicensedDescriptionInput
+  | EditorialDescriptionInput
+  | ModelDescriptionInput;
+
+export type DescriptionValidationResult = {
+  rejectionCodes: DescriptionRejectionCode[];
+  warningCodes: DescriptionWarningCode[];
+  requiresHumanReview: boolean;
+  wordCount: number;
+  readabilityScore: number;
+  qualityScore: number;
+};
+
+export type DescriptionCandidateResult = {
+  candidateId: string;
+  observationId: string;
+  decisionId: string;
+  state: DescriptionDecisionState;
+  validation: DescriptionValidationResult;
+  queue: "not_required" | "queued" | "deduplicated" | "overflow_paused";
+  changed: boolean;
+};
+
+export type DescriptionMetrics = {
+  scopeWorks: number;
+  candidates: number;
+  rejected: number;
+  reviewed: number;
+  eligible: number;
+  withdrawn: number;
+  invalidated: number;
+  paused: number;
+  queue: {
+    queued: number;
+    claimed: number;
+    completed: number;
+    cancelled: number;
+  };
+  coverage: {
+    candidateWorks: number;
+    eligibleWorks: number;
+    candidateBasisPoints: number;
+    eligibleBasisPoints: number;
+  };
+  tokens: {
+    input: number;
+    output: number;
+    total: number;
+  };
+  costMicrousd: number;
+  estimate500: {
+    candidates: number;
+    eligible: number;
+    inputTokens: number;
+    outputTokens: number;
+    costMicrousd: number;
+  };
+  byClass: Record<DescriptionClass, number>;
+};

--- a/src/db/catalog/enrichment/descriptions/validation.test.ts
+++ b/src/db/catalog/enrichment/descriptions/validation.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { DESCRIPTION_FIXTURE_TEXT, modelDescriptionFixture } from "./fixtures";
+import { validateDescriptionCandidate } from "./validation";
+
+const eligibleParents = modelDescriptionFixture().claims.map(
+  (claim, index) => ({
+    id: claim.parentObservationIds[0] ?? `missing-${index}`,
+    entityType: "work",
+    entityId: modelDescriptionFixture().workId,
+    workId: modelDescriptionFixture().workId,
+    fieldKey: `work.fixture_${index}`,
+    value: `fixture-${index}`,
+    sourceText: null,
+    eligible: true,
+    unresolvedConflict: false,
+  }),
+);
+
+describe("deterministic description validation", () => {
+  it("keeps the exact eight-word rule as a review warning", () => {
+    const candidate = modelDescriptionFixture(undefined, {
+      comparisonTexts: [
+        "This recorded evaluation fixture follows a central figure",
+      ],
+    });
+    const result = validateDescriptionCandidate({
+      candidate,
+      parents: eligibleParents,
+    });
+
+    expect(result.warningCodes).toContain("copying_exact_eight_word_match");
+    expect(result.rejectionCodes).not.toContain("copying_similarity_high");
+    expect(result.requiresHumanReview).toBe(true);
+  });
+
+  it("rejects high copying similarity separately from the warning heuristic", () => {
+    const candidate = modelDescriptionFixture(undefined, {
+      comparisonTexts: [DESCRIPTION_FIXTURE_TEXT],
+    });
+    const result = validateDescriptionCandidate({
+      candidate,
+      parents: eligibleParents,
+    });
+
+    expect(result.rejectionCodes).toContain("copying_similarity_high");
+  });
+
+  it.each([
+    {
+      name: "length",
+      text: "Too short to be an eligible description.",
+      code: "length_out_of_range",
+    },
+    {
+      name: "readability",
+      text: Array.from(
+        { length: 90 },
+        () => "antidisestablishmentarianism",
+      ).join(" "),
+      code: "readability_out_of_range",
+    },
+    {
+      name: "tone",
+      text: `${DESCRIPTION_FIXTURE_TEXT} This is a must-read masterpiece.`,
+      code: "tone_non_neutral",
+    },
+    {
+      name: "spoiler",
+      text: `${DESCRIPTION_FIXTURE_TEXT} The killer is the trusted guide.`,
+      code: "spoiler_risk",
+    },
+  ])("uses a stable rejection code for $name failures", ({ text, code }) => {
+    const result = validateDescriptionCandidate({
+      candidate: modelDescriptionFixture(undefined, { text }),
+      parents: eligibleParents,
+    });
+
+    expect(result.rejectionCodes).toContain(code);
+  });
+
+  it("requires explicit review for ambiguous and sensitive cases", () => {
+    const result = validateDescriptionCandidate({
+      candidate: modelDescriptionFixture(undefined, {
+        ambiguousIdentity: true,
+        sensitiveContent: true,
+      }),
+      parents: eligibleParents,
+    });
+
+    expect(result.warningCodes).toEqual(
+      expect.arrayContaining([
+        "ambiguous_identity_review",
+        "sensitive_content_review",
+        "initial_model_review",
+      ]),
+    );
+    expect(result.requiresHumanReview).toBe(true);
+  });
+});

--- a/src/db/catalog/enrichment/descriptions/validation.test.ts
+++ b/src/db/catalog/enrichment/descriptions/validation.test.ts
@@ -18,10 +18,12 @@ const eligibleParents = modelDescriptionFixture().claims.map(
 
 describe("deterministic description validation", () => {
   it("keeps the exact eight-word rule as a review warning", () => {
+    const sourceExcerpt = modelDescriptionFixture()
+      .text.split(/\s+/u)
+      .slice(0, 8)
+      .join(" ");
     const candidate = modelDescriptionFixture(undefined, {
-      comparisonTexts: [
-        "This recorded evaluation fixture follows a central figure",
-      ],
+      comparisonTexts: [sourceExcerpt],
     });
     const result = validateDescriptionCandidate({
       candidate,
@@ -95,5 +97,20 @@ describe("deterministic description validation", () => {
       ]),
     );
     expect(result.requiresHumanReview).toBe(true);
+  });
+
+  it("rejects candidate sentences that are not mapped verbatim to evidence claims", () => {
+    const candidate = modelDescriptionFixture();
+    const result = validateDescriptionCandidate({
+      candidate: {
+        ...candidate,
+        text: `${candidate.text} An unsupported factual sentence was added.`,
+      },
+      parents: eligibleParents,
+    });
+
+    expect(result.rejectionCodes).toContain(
+      "candidate_claim_coverage_incomplete",
+    );
   });
 });

--- a/src/db/catalog/enrichment/descriptions/validation.ts
+++ b/src/db/catalog/enrichment/descriptions/validation.ts
@@ -1,0 +1,302 @@
+import { hashCanonicalJson } from "../../identity";
+import type {
+  DescriptionCandidateInput,
+  DescriptionParentEvidence,
+  DescriptionRejectionCode,
+  DescriptionValidationResult,
+  DescriptionWarningCode,
+} from "./types";
+
+const PROMOTIONAL_PATTERNS = [
+  /\b(must[- ]read|masterpiece|unforgettable|best[- ]selling)\b/i,
+  /\b(gripping|stunning|incredible|perfect|brilliant)\b/i,
+  /\byou(?:'ll| will) (?:love|discover|experience)\b/i,
+  /\bthe (?:best|greatest|most important)\b/i,
+];
+
+const SPOILER_PATTERNS = [
+  /\b(?:dies|is killed|kills (?:himself|herself|themself))\b/i,
+  /\bthe (?:killer|murderer|traitor) is\b/i,
+  /\b(?:turns out|is revealed) to be\b/i,
+  /\b(?:ends|concludes) with\b/i,
+  /\bultimately (?:defeats|escapes|marries|returns|wins)\b/i,
+];
+
+const normalizeText = (value: string): string =>
+  value
+    .normalize("NFKC")
+    .toLocaleLowerCase("en")
+    .replace(/[^\p{L}\p{N}'-]+/gu, " ")
+    .trim();
+
+const words = (value: string): string[] =>
+  normalizeText(value).split(/\s+/).filter(Boolean);
+
+const syllables = (word: string): number => {
+  const normalized = word
+    .toLocaleLowerCase("en")
+    .replace(/(?:es|ed|e)$/u, "")
+    .replace(/^y/u, "");
+  return Math.max(1, normalized.match(/[aeiouy]+/gu)?.length ?? 1);
+};
+
+export const descriptionReadability = (text: string): number => {
+  const tokens = words(text);
+  const sentences = Math.max(
+    1,
+    text.split(/[.!?]+/u).filter((sentence) => sentence.trim()).length,
+  );
+  const syllableCount = tokens.reduce(
+    (total, token) => total + syllables(token),
+    0,
+  );
+  if (tokens.length === 0) return 0;
+  return Number(
+    (
+      206.835 -
+      1.015 * (tokens.length / sentences) -
+      84.6 * (syllableCount / tokens.length)
+    ).toFixed(2),
+  );
+};
+
+const ngrams = (tokens: readonly string[], length: number): Set<string> => {
+  const values = new Set<string>();
+  for (let index = 0; index <= tokens.length - length; index += 1) {
+    values.add(tokens.slice(index, index + length).join(" "));
+  }
+  return values;
+};
+
+const intersects = (left: Set<string>, right: Set<string>): boolean => {
+  for (const value of left) {
+    if (right.has(value)) return true;
+  }
+  return false;
+};
+
+const jaccard = (left: Set<string>, right: Set<string>): number => {
+  if (left.size === 0 || right.size === 0) return 0;
+  let intersection = 0;
+  for (const value of left) {
+    if (right.has(value)) intersection += 1;
+  }
+  return intersection / (left.size + right.size - intersection);
+};
+
+const copyingSignals = (
+  candidateText: string,
+  comparisonTexts: readonly string[],
+): { exactEight: boolean; highSimilarity: boolean } => {
+  const candidateWords = words(candidateText);
+  const candidateEight = ngrams(candidateWords, 8);
+  const candidateTwenty = ngrams(candidateWords, 20);
+  const candidateFive = ngrams(candidateWords, 5);
+  let exactEight = false;
+  let highSimilarity = false;
+  for (const text of comparisonTexts) {
+    const sourceWords = words(text);
+    exactEight ||= intersects(candidateEight, ngrams(sourceWords, 8));
+    highSimilarity ||=
+      intersects(candidateTwenty, ngrams(sourceWords, 20)) ||
+      jaccard(candidateFive, ngrams(sourceWords, 5)) >= 0.5;
+  }
+  return { exactEight, highSimilarity };
+};
+
+const add = <T extends string>(values: T[], value: T): void => {
+  if (!values.includes(value)) values.push(value);
+};
+
+const isNonempty = (value: string | null | undefined): boolean =>
+  Boolean(value?.trim());
+
+const provenanceRejections = (
+  input: DescriptionCandidateInput,
+): DescriptionRejectionCode[] => {
+  const result: DescriptionRejectionCode[] = [];
+  if (input.descriptionClass === "licensed_verbatim") {
+    const license = input.license;
+    if (
+      !isNonempty(license.name) ||
+      !isNonempty(license.url) ||
+      !isNonempty(license.sourceText)
+    ) {
+      add(result, "licensed_provenance_incomplete");
+    }
+    if (
+      license.transformed &&
+      (!license.derivativesPermitted ||
+        normalizeText(license.sourceText) !== normalizeText(input.text))
+    ) {
+      add(result, "licensed_derivative_not_permitted");
+    }
+    if (
+      !license.transformed &&
+      normalizeText(license.sourceText) !== normalizeText(input.text)
+    ) {
+      add(result, "licensed_derivative_not_permitted");
+    }
+  } else if (input.descriptionClass === "bukie_editorial") {
+    if (
+      !isNonempty(input.editorial.editorRef) ||
+      !isNonempty(input.editorial.reason) ||
+      !isNonempty(input.editorial.revision)
+    ) {
+      add(result, "editorial_provenance_incomplete");
+    }
+  } else {
+    const model = input.model;
+    if (
+      !isNonempty(model.modelId) ||
+      !isNonempty(model.modelVersion) ||
+      !isNonempty(model.promptVersion) ||
+      !Number.isSafeInteger(model.generatedAt) ||
+      !Number.isSafeInteger(model.generationDurationMs) ||
+      model.generationDurationMs < 0 ||
+      !Number.isSafeInteger(model.inputTokens) ||
+      model.inputTokens < 0 ||
+      !Number.isSafeInteger(model.outputTokens) ||
+      model.outputTokens < 0 ||
+      !Number.isSafeInteger(model.costMicrousd) ||
+      model.costMicrousd < 0
+    ) {
+      add(result, "model_provenance_incomplete");
+    }
+  }
+  return result;
+};
+
+export const validateDescriptionCandidate = (input: {
+  candidate: DescriptionCandidateInput;
+  parents: readonly DescriptionParentEvidence[];
+}): DescriptionValidationResult => {
+  const { candidate } = input;
+  const parentById = new Map(
+    input.parents.map((parent) => [parent.id, parent]),
+  );
+  const rejectionCodes = provenanceRejections(candidate);
+  const warningCodes: DescriptionWarningCode[] = [];
+  const wordCount = words(candidate.text).length;
+  const readabilityScore = descriptionReadability(candidate.text);
+  const minimumWords =
+    candidate.descriptionClass === "licensed_verbatim" ? 40 : 80;
+  const maximumWords =
+    candidate.descriptionClass === "licensed_verbatim" ? 250 : 140;
+  if (wordCount < minimumWords || wordCount > maximumWords) {
+    add(rejectionCodes, "length_out_of_range");
+  }
+  if (readabilityScore < 20 || readabilityScore > 105) {
+    add(rejectionCodes, "readability_out_of_range");
+  } else if (readabilityScore < 40 || readabilityScore > 90) {
+    add(warningCodes, "readability_borderline");
+  }
+  if (PROMOTIONAL_PATTERNS.some((pattern) => pattern.test(candidate.text))) {
+    add(rejectionCodes, "tone_non_neutral");
+  }
+  if (SPOILER_PATTERNS.some((pattern) => pattern.test(candidate.text))) {
+    add(rejectionCodes, "spoiler_risk");
+  }
+
+  const referencedIds = new Set<string>();
+  for (const claim of candidate.claims) {
+    if (claim.parentObservationIds.length === 0) {
+      add(rejectionCodes, "claim_unsupported");
+      continue;
+    }
+    for (const parentId of claim.parentObservationIds) {
+      referencedIds.add(parentId);
+      const parent = parentById.get(parentId);
+      if (!parent) {
+        add(rejectionCodes, "claim_unsupported");
+        continue;
+      }
+      if (!parent.eligible) {
+        add(rejectionCodes, "parent_evidence_ineligible");
+      }
+      if (parent.workId !== candidate.workId) {
+        add(rejectionCodes, "identity_mismatch");
+      }
+      if (parent.unresolvedConflict) {
+        add(rejectionCodes, "evidence_conflict_unresolved");
+      }
+    }
+  }
+  if (
+    candidate.descriptionClass !== "licensed_verbatim" &&
+    (candidate.claims.length < 2 || referencedIds.size < 2)
+  ) {
+    add(rejectionCodes, "specificity_insufficient");
+  } else if (referencedIds.size < 3) {
+    add(warningCodes, "sparse_evidence_review");
+  }
+
+  if (candidate.descriptionClass !== "licensed_verbatim") {
+    const comparisonTexts = [
+      ...candidate.comparisonTexts,
+      ...input.parents
+        .map((parent) => parent.sourceText)
+        .filter((text): text is string => Boolean(text)),
+    ];
+    const copying = copyingSignals(candidate.text, comparisonTexts);
+    if (copying.highSimilarity) {
+      add(rejectionCodes, "copying_similarity_high");
+    } else if (copying.exactEight) {
+      add(warningCodes, "copying_exact_eight_word_match");
+    }
+  }
+  if (candidate.ambiguousIdentity) {
+    add(warningCodes, "ambiguous_identity_review");
+  }
+  if (candidate.sensitiveContent) {
+    add(warningCodes, "sensitive_content_review");
+  }
+  if (candidate.descriptionClass === "model_assisted_candidate") {
+    add(warningCodes, "initial_model_review");
+  }
+  if (candidate.descriptionClass === "bukie_editorial") {
+    add(warningCodes, "editorial_review");
+  }
+
+  rejectionCodes.sort();
+  warningCodes.sort();
+  const qualityScore = Math.max(
+    0,
+    Math.min(
+      100,
+      Math.round(
+        100 -
+          rejectionCodes.length * 20 -
+          warningCodes.length * 4 -
+          Math.abs(60 - readabilityScore) / 3,
+      ),
+    ),
+  );
+  return {
+    rejectionCodes,
+    warningCodes,
+    requiresHumanReview: rejectionCodes.length === 0 && warningCodes.length > 0,
+    wordCount,
+    readabilityScore,
+    qualityScore,
+  };
+};
+
+export const descriptionGenerationInputHash = (
+  input: DescriptionCandidateInput,
+): string =>
+  hashCanonicalJson({
+    claims: input.claims,
+    descriptionPolicyVersion: input.descriptionPolicyVersion,
+    parentObservationIds: [
+      ...new Set(input.claims.flatMap((claim) => claim.parentObservationIds)),
+    ].sort(),
+    sourcePolicyVersion: input.sourcePolicyVersion,
+    ...(input.descriptionClass === "model_assisted_candidate"
+      ? {
+          modelId: input.model.modelId,
+          modelVersion: input.model.modelVersion,
+          promptVersion: input.model.promptVersion,
+        }
+      : {}),
+  });

--- a/src/db/catalog/enrichment/descriptions/validation.ts
+++ b/src/db/catalog/enrichment/descriptions/validation.ts
@@ -32,6 +32,11 @@ const normalizeText = (value: string): string =>
 const words = (value: string): string[] =>
   normalizeText(value).split(/\s+/).filter(Boolean);
 
+const sentences = (value: string): string[] =>
+  (value.match(/[^.!?]+(?:[.!?]+|$)/gu) ?? [])
+    .map((sentence) => sentence.trim())
+    .filter(Boolean);
+
 const syllables = (word: string): number => {
   const normalized = word
     .toLocaleLowerCase("en")
@@ -124,11 +129,7 @@ const provenanceRejections = (
     ) {
       add(result, "licensed_provenance_incomplete");
     }
-    if (
-      license.transformed &&
-      (!license.derivativesPermitted ||
-        normalizeText(license.sourceText) !== normalizeText(input.text))
-    ) {
+    if (license.transformed && !license.derivativesPermitted) {
       add(result, "licensed_derivative_not_permitted");
     }
     if (
@@ -199,7 +200,23 @@ export const validateDescriptionCandidate = (input: {
   }
 
   const referencedIds = new Set<string>();
+  const candidateSentenceKeys = new Set(
+    sentences(candidate.text).map(normalizeText),
+  );
+  const claimedSentenceKeys = new Set<string>();
   for (const claim of candidate.claims) {
+    const claimKey = normalizeText(claim.text);
+    if (!claimKey) {
+      add(rejectionCodes, "claim_unsupported");
+      continue;
+    }
+    if (candidate.descriptionClass !== "licensed_verbatim") {
+      if (!candidateSentenceKeys.has(claimKey)) {
+        add(rejectionCodes, "claim_text_not_in_candidate");
+      } else {
+        claimedSentenceKeys.add(claimKey);
+      }
+    }
     if (claim.parentObservationIds.length === 0) {
       add(rejectionCodes, "claim_unsupported");
       continue;
@@ -221,6 +238,14 @@ export const validateDescriptionCandidate = (input: {
         add(rejectionCodes, "evidence_conflict_unresolved");
       }
     }
+  }
+  if (
+    candidate.descriptionClass !== "licensed_verbatim" &&
+    [...candidateSentenceKeys].some(
+      (sentenceKey) => !claimedSentenceKeys.has(sentenceKey),
+    )
+  ) {
+    add(rejectionCodes, "candidate_claim_coverage_incomplete");
   }
   if (
     candidate.descriptionClass !== "licensed_verbatim" &&

--- a/src/db/catalog/postgres-rebuild.ts
+++ b/src/db/catalog/postgres-rebuild.ts
@@ -30,6 +30,14 @@ import {
 import { CATALOG_TARGET_TABLE_NAMES } from "./sqlite-rebuild";
 
 const CLEAR_TABLES = [
+  "description_projection_heads",
+  "description_projections",
+  "description_review_queue",
+  "description_decision_heads",
+  "description_decisions",
+  "description_claim_evidence",
+  "description_claims",
+  "description_candidates",
   "field_resolution_heads",
   "field_resolutions",
   "field_observations",
@@ -89,9 +97,11 @@ export async function rebuildCatalogPostgres(input: {
           .limit(1);
         if (existing.length > 0) return;
       } else {
-        for (const table of CLEAR_TABLES) {
-          await tx.execute(drizzleSql.raw(`delete from "${table}"`));
-        }
+        await tx.execute(
+          drizzleSql.raw(
+            `truncate table ${CLEAR_TABLES.map((table) => `"${table}"`).join(", ")} cascade`,
+          ),
+        );
       }
       const maybeFail = (table: keyof CatalogImportGraph) => {
         if (input.failAfterTable === table) {

--- a/src/db/catalog/repository.ts
+++ b/src/db/catalog/repository.ts
@@ -129,15 +129,6 @@ type ProvenanceRow = {
   metadataPolicy: string | Record<string, unknown> | null;
   assetPolicy: string | Record<string, unknown> | null;
   descriptionCandidateId: string | null;
-  descriptionDecisionState:
-    | "candidate"
-    | "review_required"
-    | "paused"
-    | "rejected"
-    | "eligible"
-    | "withdrawn"
-    | "invalidated"
-    | null;
 };
 
 type ProjectedWork = WorkSummary | Omit<WorkDetail, "provenance">;
@@ -452,8 +443,7 @@ export function createCatalogRepository(
           sl.state as "sourceLinkState",
           s.metadata_policy as "metadataPolicy",
           s.asset_policy as "assetPolicy",
-          dc.id as "descriptionCandidateId",
-          dd.state as "descriptionDecisionState"
+          dc.id as "descriptionCandidateId"
         from field_resolution_heads h
         join field_resolutions r on r.id = h.resolution_id
         left join field_observations o on o.id = r.selected_observation_id
@@ -465,10 +455,6 @@ export function createCatalogRepository(
          and sl.entity_id = r.entity_id
         left join description_candidates dc
           on dc.observation_id = o.id
-        left join description_decision_heads ddh
-          on ddh.candidate_id = dc.id
-        left join description_decisions dd
-          on dd.id = ddh.decision_id
         where h.entity_type = '${entityType}'
           and h.entity_id in (${values})
         order by h.entity_id asc, h.field_key asc
@@ -504,8 +490,7 @@ export function createCatalogRepository(
                 row.sourceLinkState === "active" &&
                 row.provenanceKind !== "synthetic" &&
                 (row.field !== "work.description" ||
-                  row.descriptionCandidateId === null ||
-                  row.descriptionDecisionState === "eligible") &&
+                  row.descriptionCandidateId === null) &&
                 sourcePolicyAllowsFieldDisplay(
                   row.field === "edition.covers"
                     ? row.assetPolicy

--- a/src/db/catalog/repository.ts
+++ b/src/db/catalog/repository.ts
@@ -128,6 +128,16 @@ type ProvenanceRow = {
   sourceLinkState: "active" | "candidate" | "rejected" | null;
   metadataPolicy: string | Record<string, unknown> | null;
   assetPolicy: string | Record<string, unknown> | null;
+  descriptionCandidateId: string | null;
+  descriptionDecisionState:
+    | "candidate"
+    | "review_required"
+    | "paused"
+    | "rejected"
+    | "eligible"
+    | "withdrawn"
+    | "invalidated"
+    | null;
 };
 
 type ProjectedWork = WorkSummary | Omit<WorkDetail, "provenance">;
@@ -441,7 +451,9 @@ export function createCatalogRepository(
           sr.state as "sourceRecordState",
           sl.state as "sourceLinkState",
           s.metadata_policy as "metadataPolicy",
-          s.asset_policy as "assetPolicy"
+          s.asset_policy as "assetPolicy",
+          dc.id as "descriptionCandidateId",
+          dd.state as "descriptionDecisionState"
         from field_resolution_heads h
         join field_resolutions r on r.id = h.resolution_id
         left join field_observations o on o.id = r.selected_observation_id
@@ -451,6 +463,12 @@ export function createCatalogRepository(
           on sl.source_record_id = sr.id
          and sl.entity_type = r.entity_type
          and sl.entity_id = r.entity_id
+        left join description_candidates dc
+          on dc.observation_id = o.id
+        left join description_decision_heads ddh
+          on ddh.candidate_id = dc.id
+        left join description_decisions dd
+          on dd.id = ddh.decision_id
         where h.entity_type = '${entityType}'
           and h.entity_id in (${values})
         order by h.entity_id asc, h.field_key asc
@@ -485,6 +503,9 @@ export function createCatalogRepository(
                 row.sourceRecordState === "active" &&
                 row.sourceLinkState === "active" &&
                 row.provenanceKind !== "synthetic" &&
+                (row.field !== "work.description" ||
+                  row.descriptionCandidateId === null ||
+                  row.descriptionDecisionState === "eligible") &&
                 sourcePolicyAllowsFieldDisplay(
                   row.field === "edition.covers"
                     ? row.assetPolicy

--- a/src/db/catalog/schema-parity.test.ts
+++ b/src/db/catalog/schema-parity.test.ts
@@ -177,4 +177,26 @@ describe("SQLite/Postgres normalized catalog schema parity", () => {
       );
     }
   });
+
+  it("adds evidence-gated description lifecycle tables in both providers", () => {
+    const sqliteMigration = readFileSync(
+      path.resolve("drizzle/0006_legal_trish_tilby.sql"),
+      "utf8",
+    );
+    const postgresMigration = readFileSync(
+      path.resolve("drizzle/pg/0008_gifted_typhoid_mary.sql"),
+      "utf8",
+    );
+    for (const migration of [sqliteMigration, postgresMigration]) {
+      expect(migration.match(/^CREATE TABLE/gm)).toHaveLength(8);
+      expect(migration).toContain("description_candidates");
+      expect(migration).toContain("description_claim_evidence");
+      expect(migration).toContain("description_decisions");
+      expect(migration).toContain("description_review_queue");
+      expect(migration).toContain("description_projections");
+      expect(migration).not.toMatch(
+        /update\s+works[\s\S]*description|insert\s+into\s+field_resolution_heads/i,
+      );
+    }
+  });
 });

--- a/src/db/catalog/schema-parity.test.ts
+++ b/src/db/catalog/schema-parity.test.ts
@@ -199,4 +199,23 @@ describe("SQLite/Postgres normalized catalog schema parity", () => {
       );
     }
   });
+
+  it("adds licensed transformation proof with deterministic legacy backfill", () => {
+    const sqliteMigration = readFileSync(
+      path.resolve("drizzle/0007_milky_omega_red.sql"),
+      "utf8",
+    );
+    const postgresMigration = readFileSync(
+      path.resolve("drizzle/pg/0009_moaning_catseye.sql"),
+      "utf8",
+    );
+    for (const migration of [sqliteMigration, postgresMigration]) {
+      expect(migration).toContain("licensed_source_text_hash");
+      expect(migration).toContain("licensed_text_transformed");
+      expect(migration).toContain("text_hash");
+      expect(migration).not.toMatch(
+        /update\s+works|insert\s+into\s+field_resolution_heads/i,
+      );
+    }
+  });
 });

--- a/src/db/catalog/schema.pg.ts
+++ b/src/db/catalog/schema.pg.ts
@@ -20,6 +20,10 @@ import {
   CATEGORY_STATUSES,
   CHANGE_TYPES,
   COVER_STATES,
+  DESCRIPTION_CLASSES,
+  DESCRIPTION_DECISION_STATES,
+  DESCRIPTION_PROJECTION_STATES,
+  DESCRIPTION_QUEUE_STATES,
   EDITION_FORMATS,
   IDENTIFIER_SCHEMES,
   OBSERVATION_STATES,
@@ -760,6 +764,322 @@ export const fieldResolutionHeadsPg = pgTable(
   ],
 );
 
+export const descriptionCandidatesPg = pgTable(
+  "description_candidates",
+  {
+    id: text("id").primaryKey(),
+    workId: text("work_id")
+      .notNull()
+      .references(() => worksPg.id, { onDelete: "restrict" }),
+    observationId: text("observation_id")
+      .notNull()
+      .references(() => fieldObservationsPg.id, { onDelete: "restrict" }),
+    descriptionClass: text("description_class").notNull(),
+    textContent: text("text_content").notNull(),
+    textHash: text("text_hash").notNull(),
+    sourceRevision: text("source_revision").notNull(),
+    sourcePolicyVersion: text("source_policy_version").notNull(),
+    descriptionPolicyVersion: text("description_policy_version").notNull(),
+    licenseName: text("license_name"),
+    licenseUrl: text("license_url"),
+    attributionText: text("attribution_text"),
+    derivativesPermitted: boolean("derivatives_permitted"),
+    editorRef: text("editor_ref"),
+    editorialReason: text("editorial_reason"),
+    editorialRevision: text("editorial_revision"),
+    modelId: text("model_id"),
+    modelVersion: text("model_version"),
+    promptVersion: text("prompt_version"),
+    generationInputHash: text("generation_input_hash"),
+    generatedAt: timestamp("generated_at"),
+    generationDurationMs: timestamp("generation_duration_ms"),
+    inputTokens: integer("input_tokens"),
+    outputTokens: integer("output_tokens"),
+    costMicrousd: timestamp("cost_microusd"),
+    qualityScore: doublePrecision("quality_score"),
+    ambiguousIdentity: boolean("ambiguous_identity").notNull().default(false),
+    sensitiveContent: boolean("sensitive_content").notNull().default(false),
+    createdAt: timestamp("created_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("description_candidates_observation_uq").on(
+      table.observationId,
+    ),
+    check(
+      "description_candidates_class_ck",
+      sql`${table.descriptionClass} in (${sql.raw(sqlList(DESCRIPTION_CLASSES))})`,
+    ),
+    check(
+      "description_candidates_text_ck",
+      sql`length(trim(${table.textContent})) > 0 and length(${table.textHash}) = 64`,
+    ),
+    check(
+      "description_candidates_versions_ck",
+      sql`length(trim(${table.sourceRevision})) > 0
+        and length(trim(${table.sourcePolicyVersion})) > 0
+        and length(trim(${table.descriptionPolicyVersion})) > 0`,
+    ),
+    check(
+      "description_candidates_license_ck",
+      sql`(
+        ${table.descriptionClass} = 'licensed_verbatim'
+        and length(trim(${table.licenseName})) > 0
+        and length(trim(${table.licenseUrl})) > 0
+        and ${table.derivativesPermitted} is not null
+      ) or (
+        ${table.descriptionClass} <> 'licensed_verbatim'
+        and ${table.licenseName} is null
+        and ${table.licenseUrl} is null
+        and ${table.attributionText} is null
+        and ${table.derivativesPermitted} is null
+      )`,
+    ),
+    check(
+      "description_candidates_editorial_ck",
+      sql`(
+        ${table.descriptionClass} = 'bukie_editorial'
+        and length(trim(${table.editorRef})) > 0
+        and length(trim(${table.editorialReason})) > 0
+        and length(trim(${table.editorialRevision})) > 0
+      ) or (
+        ${table.descriptionClass} <> 'bukie_editorial'
+        and ${table.editorRef} is null
+        and ${table.editorialReason} is null
+        and ${table.editorialRevision} is null
+      )`,
+    ),
+    check(
+      "description_candidates_model_ck",
+      sql`(
+        ${table.descriptionClass} = 'model_assisted_candidate'
+        and length(trim(${table.modelId})) > 0
+        and length(trim(${table.modelVersion})) > 0
+        and length(trim(${table.promptVersion})) > 0
+        and length(${table.generationInputHash}) = 64
+        and ${table.generatedAt} is not null
+        and ${table.generationDurationMs} >= 0
+        and ${table.inputTokens} >= 0
+        and ${table.outputTokens} >= 0
+        and ${table.costMicrousd} >= 0
+      ) or (
+        ${table.descriptionClass} <> 'model_assisted_candidate'
+        and ${table.modelId} is null
+        and ${table.modelVersion} is null
+        and ${table.promptVersion} is null
+        and ${table.generationInputHash} is null
+        and ${table.generatedAt} is null
+        and ${table.generationDurationMs} is null
+        and ${table.inputTokens} is null
+        and ${table.outputTokens} is null
+        and ${table.costMicrousd} is null
+      )`,
+    ),
+    check(
+      "description_candidates_quality_ck",
+      sql`${table.qualityScore} is null or ${table.qualityScore} between 0 and 100`,
+    ),
+    index("description_candidates_work_created_idx").on(
+      table.workId,
+      table.createdAt,
+    ),
+  ],
+);
+
+export const descriptionClaimsPg = pgTable(
+  "description_claims",
+  {
+    id: text("id").primaryKey(),
+    candidateId: text("candidate_id")
+      .notNull()
+      .references(() => descriptionCandidatesPg.id, { onDelete: "cascade" }),
+    position: integer("position").notNull(),
+    claimText: text("claim_text").notNull(),
+    claimHash: text("claim_hash").notNull(),
+  },
+  (table) => [
+    uniqueIndex("description_claims_position_uq").on(
+      table.candidateId,
+      table.position,
+    ),
+    check(
+      "description_claims_content_ck",
+      sql`${table.position} >= 0
+        and length(trim(${table.claimText})) > 0
+        and length(${table.claimHash}) = 64`,
+    ),
+    index("description_claims_candidate_idx").on(table.candidateId),
+  ],
+);
+
+export const descriptionClaimEvidencePg = pgTable(
+  "description_claim_evidence",
+  {
+    claimId: text("claim_id")
+      .notNull()
+      .references(() => descriptionClaimsPg.id, { onDelete: "cascade" }),
+    observationId: text("observation_id")
+      .notNull()
+      .references(() => fieldObservationsPg.id, { onDelete: "restrict" }),
+  },
+  (table) => [
+    primaryKey({
+      name: "description_claim_evidence_pk",
+      columns: [table.claimId, table.observationId],
+    }),
+    index("description_claim_evidence_observation_idx").on(table.observationId),
+  ],
+);
+
+export const descriptionDecisionsPg = pgTable(
+  "description_decisions",
+  {
+    id: text("id").primaryKey(),
+    candidateId: text("candidate_id")
+      .notNull()
+      .references(() => descriptionCandidatesPg.id, { onDelete: "restrict" }),
+    state: text("state").notNull(),
+    rejectionCodesJson: jsonb("rejection_codes_json").notNull(),
+    warningCodesJson: jsonb("warning_codes_json").notNull(),
+    reviewerRef: text("reviewer_ref"),
+    reviewReason: text("review_reason"),
+    previousDecisionId: text("previous_decision_id").references(
+      (): AnyPgColumn => descriptionDecisionsPg.id,
+      { onDelete: "restrict" },
+    ),
+    policyVersion: text("policy_version").notNull(),
+    decidedAt: timestamp("decided_at").notNull(),
+  },
+  (table) => [
+    check(
+      "description_decisions_state_ck",
+      sql`${table.state} in (${sql.raw(sqlList(DESCRIPTION_DECISION_STATES))})`,
+    ),
+    check(
+      "description_decisions_review_ck",
+      sql`(${table.reviewerRef} is null and ${table.reviewReason} is null)
+        or (
+          length(trim(${table.reviewerRef})) > 0
+          and length(trim(${table.reviewReason})) > 0
+        )`,
+    ),
+    check(
+      "description_decisions_policy_ck",
+      sql`length(trim(${table.policyVersion})) > 0`,
+    ),
+    index("description_decisions_candidate_history_idx").on(
+      table.candidateId,
+      table.decidedAt,
+    ),
+  ],
+);
+
+export const descriptionDecisionHeadsPg = pgTable(
+  "description_decision_heads",
+  {
+    candidateId: text("candidate_id")
+      .primaryKey()
+      .references(() => descriptionCandidatesPg.id, { onDelete: "restrict" }),
+    decisionId: text("decision_id")
+      .notNull()
+      .references(() => descriptionDecisionsPg.id, { onDelete: "restrict" }),
+  },
+  (table) => [
+    uniqueIndex("description_decision_heads_decision_uq").on(table.decisionId),
+  ],
+);
+
+export const descriptionReviewQueuePg = pgTable(
+  "description_review_queue",
+  {
+    candidateId: text("candidate_id")
+      .primaryKey()
+      .references(() => descriptionCandidatesPg.id, { onDelete: "restrict" }),
+    state: text("state").notNull(),
+    priority: integer("priority").notNull(),
+    reasonCodesJson: jsonb("reason_codes_json").notNull(),
+    queuedAt: timestamp("queued_at").notNull(),
+    updatedAt: timestamp("updated_at").notNull(),
+    reviewerRef: text("reviewer_ref"),
+  },
+  (table) => [
+    check(
+      "description_review_queue_state_ck",
+      sql`${table.state} in (${sql.raw(sqlList(DESCRIPTION_QUEUE_STATES))})`,
+    ),
+    check(
+      "description_review_queue_values_ck",
+      sql`${table.priority} >= 0
+        and (${table.reviewerRef} is null or length(trim(${table.reviewerRef})) > 0)`,
+    ),
+    index("description_review_queue_active_idx").on(
+      table.state,
+      table.priority,
+      table.queuedAt,
+    ),
+  ],
+);
+
+export const descriptionProjectionsPg = pgTable(
+  "description_projections",
+  {
+    id: text("id").primaryKey(),
+    workId: text("work_id")
+      .notNull()
+      .references(() => worksPg.id, { onDelete: "restrict" }),
+    candidateId: text("candidate_id").references(
+      () => descriptionCandidatesPg.id,
+      { onDelete: "restrict" },
+    ),
+    state: text("state").notNull(),
+    previousProjectionId: text("previous_projection_id").references(
+      (): AnyPgColumn => descriptionProjectionsPg.id,
+      { onDelete: "restrict" },
+    ),
+    reasonCode: text("reason_code").notNull(),
+    actorRef: text("actor_ref").notNull(),
+    policyVersion: text("policy_version").notNull(),
+    projectedAt: timestamp("projected_at").notNull(),
+  },
+  (table) => [
+    check(
+      "description_projections_state_ck",
+      sql`${table.state} in (${sql.raw(sqlList(DESCRIPTION_PROJECTION_STATES))})`,
+    ),
+    check(
+      "description_projections_selection_ck",
+      sql`(${table.state} in ('selected', 'rolled_back') and ${table.candidateId} is not null)
+        or (${table.state} in ('withdrawn', 'invalidated') and ${table.candidateId} is null)`,
+    ),
+    check(
+      "description_projections_nonempty_ck",
+      sql`length(trim(${table.reasonCode})) > 0
+        and length(trim(${table.actorRef})) > 0
+        and length(trim(${table.policyVersion})) > 0`,
+    ),
+    index("description_projections_work_history_idx").on(
+      table.workId,
+      table.projectedAt,
+    ),
+  ],
+);
+
+export const descriptionProjectionHeadsPg = pgTable(
+  "description_projection_heads",
+  {
+    workId: text("work_id")
+      .primaryKey()
+      .references(() => worksPg.id, { onDelete: "restrict" }),
+    projectionId: text("projection_id")
+      .notNull()
+      .references(() => descriptionProjectionsPg.id, { onDelete: "restrict" }),
+  },
+  (table) => [
+    uniqueIndex("description_projection_heads_projection_uq").on(
+      table.projectionId,
+    ),
+  ],
+);
+
 export const entityAliasesPg = pgTable(
   "entity_aliases",
   {
@@ -830,6 +1150,14 @@ export const catalogPostgresTables = {
   fieldObservations: fieldObservationsPg,
   fieldResolutions: fieldResolutionsPg,
   fieldResolutionHeads: fieldResolutionHeadsPg,
+  descriptionCandidates: descriptionCandidatesPg,
+  descriptionClaims: descriptionClaimsPg,
+  descriptionClaimEvidence: descriptionClaimEvidencePg,
+  descriptionDecisions: descriptionDecisionsPg,
+  descriptionDecisionHeads: descriptionDecisionHeadsPg,
+  descriptionReviewQueue: descriptionReviewQueuePg,
+  descriptionProjections: descriptionProjectionsPg,
+  descriptionProjectionHeads: descriptionProjectionHeadsPg,
   entityAliases: entityAliasesPg,
   catalogChangeEvents: catalogChangeEventsPg,
 };

--- a/src/db/catalog/schema.pg.ts
+++ b/src/db/catalog/schema.pg.ts
@@ -784,6 +784,8 @@ export const descriptionCandidatesPg = pgTable(
     licenseUrl: text("license_url"),
     attributionText: text("attribution_text"),
     derivativesPermitted: boolean("derivatives_permitted"),
+    licensedSourceTextHash: text("licensed_source_text_hash"),
+    licensedTextTransformed: boolean("licensed_text_transformed"),
     editorRef: text("editor_ref"),
     editorialReason: text("editorial_reason"),
     editorialRevision: text("editorial_revision"),
@@ -826,12 +828,16 @@ export const descriptionCandidatesPg = pgTable(
         and length(trim(${table.licenseName})) > 0
         and length(trim(${table.licenseUrl})) > 0
         and ${table.derivativesPermitted} is not null
+        and length(${table.licensedSourceTextHash}) = 64
+        and ${table.licensedTextTransformed} is not null
       ) or (
         ${table.descriptionClass} <> 'licensed_verbatim'
         and ${table.licenseName} is null
         and ${table.licenseUrl} is null
         and ${table.attributionText} is null
         and ${table.derivativesPermitted} is null
+        and ${table.licensedSourceTextHash} is null
+        and ${table.licensedTextTransformed} is null
       )`,
     ),
     check(

--- a/src/db/catalog/schema.ts
+++ b/src/db/catalog/schema.ts
@@ -17,6 +17,10 @@ import {
   CATEGORY_STATUSES,
   CHANGE_TYPES,
   COVER_STATES,
+  DESCRIPTION_CLASSES,
+  DESCRIPTION_DECISION_STATES,
+  DESCRIPTION_PROJECTION_STATES,
+  DESCRIPTION_QUEUE_STATES,
   EDITION_FORMATS,
   IDENTIFIER_SCHEMES,
   OBSERVATION_STATES,
@@ -774,6 +778,332 @@ export const fieldResolutionHeads = sqliteTable(
   ],
 );
 
+export const descriptionCandidates = sqliteTable(
+  "description_candidates",
+  {
+    id: text("id").primaryKey(),
+    workId: text("work_id")
+      .notNull()
+      .references(() => works.id, { onDelete: "restrict" }),
+    observationId: text("observation_id")
+      .notNull()
+      .references(() => fieldObservations.id, { onDelete: "restrict" }),
+    descriptionClass: text("description_class").notNull(),
+    textContent: text("text_content").notNull(),
+    textHash: text("text_hash").notNull(),
+    sourceRevision: text("source_revision").notNull(),
+    sourcePolicyVersion: text("source_policy_version").notNull(),
+    descriptionPolicyVersion: text("description_policy_version").notNull(),
+    licenseName: text("license_name"),
+    licenseUrl: text("license_url"),
+    attributionText: text("attribution_text"),
+    derivativesPermitted: integer("derivatives_permitted", { mode: "boolean" }),
+    editorRef: text("editor_ref"),
+    editorialReason: text("editorial_reason"),
+    editorialRevision: text("editorial_revision"),
+    modelId: text("model_id"),
+    modelVersion: text("model_version"),
+    promptVersion: text("prompt_version"),
+    generationInputHash: text("generation_input_hash"),
+    generatedAt: integer("generated_at"),
+    generationDurationMs: integer("generation_duration_ms"),
+    inputTokens: integer("input_tokens"),
+    outputTokens: integer("output_tokens"),
+    costMicrousd: integer("cost_microusd"),
+    qualityScore: real("quality_score"),
+    ambiguousIdentity: integer("ambiguous_identity", { mode: "boolean" })
+      .notNull()
+      .default(false),
+    sensitiveContent: integer("sensitive_content", { mode: "boolean" })
+      .notNull()
+      .default(false),
+    createdAt: integer("created_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("description_candidates_observation_uq").on(
+      table.observationId,
+    ),
+    check(
+      "description_candidates_class_ck",
+      sql`${table.descriptionClass} in (${sql.raw(sqlList(DESCRIPTION_CLASSES))})`,
+    ),
+    check(
+      "description_candidates_text_ck",
+      sql`length(trim(${table.textContent})) > 0 and length(${table.textHash}) = 64`,
+    ),
+    check(
+      "description_candidates_versions_ck",
+      sql`length(trim(${table.sourceRevision})) > 0
+        and length(trim(${table.sourcePolicyVersion})) > 0
+        and length(trim(${table.descriptionPolicyVersion})) > 0`,
+    ),
+    check(
+      "description_candidates_license_ck",
+      sql`(
+        ${table.descriptionClass} = 'licensed_verbatim'
+        and length(trim(${table.licenseName})) > 0
+        and length(trim(${table.licenseUrl})) > 0
+        and ${table.derivativesPermitted} is not null
+      ) or (
+        ${table.descriptionClass} <> 'licensed_verbatim'
+        and ${table.licenseName} is null
+        and ${table.licenseUrl} is null
+        and ${table.attributionText} is null
+        and ${table.derivativesPermitted} is null
+      )`,
+    ),
+    check(
+      "description_candidates_editorial_ck",
+      sql`(
+        ${table.descriptionClass} = 'bukie_editorial'
+        and length(trim(${table.editorRef})) > 0
+        and length(trim(${table.editorialReason})) > 0
+        and length(trim(${table.editorialRevision})) > 0
+      ) or (
+        ${table.descriptionClass} <> 'bukie_editorial'
+        and ${table.editorRef} is null
+        and ${table.editorialReason} is null
+        and ${table.editorialRevision} is null
+      )`,
+    ),
+    check(
+      "description_candidates_model_ck",
+      sql`(
+        ${table.descriptionClass} = 'model_assisted_candidate'
+        and length(trim(${table.modelId})) > 0
+        and length(trim(${table.modelVersion})) > 0
+        and length(trim(${table.promptVersion})) > 0
+        and length(${table.generationInputHash}) = 64
+        and ${table.generatedAt} is not null
+        and ${table.generationDurationMs} >= 0
+        and ${table.inputTokens} >= 0
+        and ${table.outputTokens} >= 0
+        and ${table.costMicrousd} >= 0
+      ) or (
+        ${table.descriptionClass} <> 'model_assisted_candidate'
+        and ${table.modelId} is null
+        and ${table.modelVersion} is null
+        and ${table.promptVersion} is null
+        and ${table.generationInputHash} is null
+        and ${table.generatedAt} is null
+        and ${table.generationDurationMs} is null
+        and ${table.inputTokens} is null
+        and ${table.outputTokens} is null
+        and ${table.costMicrousd} is null
+      )`,
+    ),
+    check(
+      "description_candidates_quality_ck",
+      sql`${table.qualityScore} is null or ${table.qualityScore} between 0 and 100`,
+    ),
+    index("description_candidates_work_created_idx").on(
+      table.workId,
+      table.createdAt,
+    ),
+  ],
+);
+
+export const descriptionClaims = sqliteTable(
+  "description_claims",
+  {
+    id: text("id").primaryKey(),
+    candidateId: text("candidate_id")
+      .notNull()
+      .references(() => descriptionCandidates.id, { onDelete: "cascade" }),
+    position: integer("position").notNull(),
+    claimText: text("claim_text").notNull(),
+    claimHash: text("claim_hash").notNull(),
+  },
+  (table) => [
+    uniqueIndex("description_claims_position_uq").on(
+      table.candidateId,
+      table.position,
+    ),
+    check(
+      "description_claims_content_ck",
+      sql`${table.position} >= 0
+        and length(trim(${table.claimText})) > 0
+        and length(${table.claimHash}) = 64`,
+    ),
+    index("description_claims_candidate_idx").on(table.candidateId),
+  ],
+);
+
+export const descriptionClaimEvidence = sqliteTable(
+  "description_claim_evidence",
+  {
+    claimId: text("claim_id")
+      .notNull()
+      .references(() => descriptionClaims.id, { onDelete: "cascade" }),
+    observationId: text("observation_id")
+      .notNull()
+      .references(() => fieldObservations.id, { onDelete: "restrict" }),
+  },
+  (table) => [
+    primaryKey({
+      name: "description_claim_evidence_pk",
+      columns: [table.claimId, table.observationId],
+    }),
+    index("description_claim_evidence_observation_idx").on(table.observationId),
+  ],
+);
+
+export const descriptionDecisions = sqliteTable(
+  "description_decisions",
+  {
+    id: text("id").primaryKey(),
+    candidateId: text("candidate_id")
+      .notNull()
+      .references(() => descriptionCandidates.id, { onDelete: "restrict" }),
+    state: text("state").notNull(),
+    rejectionCodesJson: text("rejection_codes_json").notNull(),
+    warningCodesJson: text("warning_codes_json").notNull(),
+    reviewerRef: text("reviewer_ref"),
+    reviewReason: text("review_reason"),
+    previousDecisionId: text("previous_decision_id").references(
+      (): AnySQLiteColumn => descriptionDecisions.id,
+      { onDelete: "restrict" },
+    ),
+    policyVersion: text("policy_version").notNull(),
+    decidedAt: integer("decided_at").notNull(),
+  },
+  (table) => [
+    check(
+      "description_decisions_state_ck",
+      sql`${table.state} in (${sql.raw(sqlList(DESCRIPTION_DECISION_STATES))})`,
+    ),
+    check(
+      "description_decisions_json_ck",
+      sql`json_valid(${table.rejectionCodesJson})
+        and json_valid(${table.warningCodesJson})`,
+    ),
+    check(
+      "description_decisions_review_ck",
+      sql`(${table.reviewerRef} is null and ${table.reviewReason} is null)
+        or (
+          length(trim(${table.reviewerRef})) > 0
+          and length(trim(${table.reviewReason})) > 0
+        )`,
+    ),
+    check(
+      "description_decisions_policy_ck",
+      sql`length(trim(${table.policyVersion})) > 0`,
+    ),
+    index("description_decisions_candidate_history_idx").on(
+      table.candidateId,
+      table.decidedAt,
+    ),
+  ],
+);
+
+export const descriptionDecisionHeads = sqliteTable(
+  "description_decision_heads",
+  {
+    candidateId: text("candidate_id")
+      .primaryKey()
+      .references(() => descriptionCandidates.id, { onDelete: "restrict" }),
+    decisionId: text("decision_id")
+      .notNull()
+      .references(() => descriptionDecisions.id, { onDelete: "restrict" }),
+  },
+  (table) => [
+    uniqueIndex("description_decision_heads_decision_uq").on(table.decisionId),
+  ],
+);
+
+export const descriptionReviewQueue = sqliteTable(
+  "description_review_queue",
+  {
+    candidateId: text("candidate_id")
+      .primaryKey()
+      .references(() => descriptionCandidates.id, { onDelete: "restrict" }),
+    state: text("state").notNull(),
+    priority: integer("priority").notNull(),
+    reasonCodesJson: text("reason_codes_json").notNull(),
+    queuedAt: integer("queued_at").notNull(),
+    updatedAt: integer("updated_at").notNull(),
+    reviewerRef: text("reviewer_ref"),
+  },
+  (table) => [
+    check(
+      "description_review_queue_state_ck",
+      sql`${table.state} in (${sql.raw(sqlList(DESCRIPTION_QUEUE_STATES))})`,
+    ),
+    check(
+      "description_review_queue_values_ck",
+      sql`${table.priority} >= 0
+        and json_valid(${table.reasonCodesJson})
+        and (${table.reviewerRef} is null or length(trim(${table.reviewerRef})) > 0)`,
+    ),
+    index("description_review_queue_active_idx").on(
+      table.state,
+      table.priority,
+      table.queuedAt,
+    ),
+  ],
+);
+
+export const descriptionProjections = sqliteTable(
+  "description_projections",
+  {
+    id: text("id").primaryKey(),
+    workId: text("work_id")
+      .notNull()
+      .references(() => works.id, { onDelete: "restrict" }),
+    candidateId: text("candidate_id").references(
+      () => descriptionCandidates.id,
+      { onDelete: "restrict" },
+    ),
+    state: text("state").notNull(),
+    previousProjectionId: text("previous_projection_id").references(
+      (): AnySQLiteColumn => descriptionProjections.id,
+      { onDelete: "restrict" },
+    ),
+    reasonCode: text("reason_code").notNull(),
+    actorRef: text("actor_ref").notNull(),
+    policyVersion: text("policy_version").notNull(),
+    projectedAt: integer("projected_at").notNull(),
+  },
+  (table) => [
+    check(
+      "description_projections_state_ck",
+      sql`${table.state} in (${sql.raw(sqlList(DESCRIPTION_PROJECTION_STATES))})`,
+    ),
+    check(
+      "description_projections_selection_ck",
+      sql`(${table.state} in ('selected', 'rolled_back') and ${table.candidateId} is not null)
+        or (${table.state} in ('withdrawn', 'invalidated') and ${table.candidateId} is null)`,
+    ),
+    check(
+      "description_projections_nonempty_ck",
+      sql`length(trim(${table.reasonCode})) > 0
+        and length(trim(${table.actorRef})) > 0
+        and length(trim(${table.policyVersion})) > 0`,
+    ),
+    index("description_projections_work_history_idx").on(
+      table.workId,
+      table.projectedAt,
+    ),
+  ],
+);
+
+export const descriptionProjectionHeads = sqliteTable(
+  "description_projection_heads",
+  {
+    workId: text("work_id")
+      .primaryKey()
+      .references(() => works.id, { onDelete: "restrict" }),
+    projectionId: text("projection_id")
+      .notNull()
+      .references(() => descriptionProjections.id, { onDelete: "restrict" }),
+  },
+  (table) => [
+    uniqueIndex("description_projection_heads_projection_uq").on(
+      table.projectionId,
+    ),
+  ],
+);
+
 export const entityAliases = sqliteTable(
   "entity_aliases",
   {
@@ -848,6 +1178,14 @@ export const catalogSqliteTables = {
   fieldObservations,
   fieldResolutions,
   fieldResolutionHeads,
+  descriptionCandidates,
+  descriptionClaims,
+  descriptionClaimEvidence,
+  descriptionDecisions,
+  descriptionDecisionHeads,
+  descriptionReviewQueue,
+  descriptionProjections,
+  descriptionProjectionHeads,
   entityAliases,
   catalogChangeEvents,
 };

--- a/src/db/catalog/schema.ts
+++ b/src/db/catalog/schema.ts
@@ -798,6 +798,10 @@ export const descriptionCandidates = sqliteTable(
     licenseUrl: text("license_url"),
     attributionText: text("attribution_text"),
     derivativesPermitted: integer("derivatives_permitted", { mode: "boolean" }),
+    licensedSourceTextHash: text("licensed_source_text_hash"),
+    licensedTextTransformed: integer("licensed_text_transformed", {
+      mode: "boolean",
+    }),
     editorRef: text("editor_ref"),
     editorialReason: text("editorial_reason"),
     editorialRevision: text("editorial_revision"),
@@ -844,12 +848,16 @@ export const descriptionCandidates = sqliteTable(
         and length(trim(${table.licenseName})) > 0
         and length(trim(${table.licenseUrl})) > 0
         and ${table.derivativesPermitted} is not null
+        and length(${table.licensedSourceTextHash}) = 64
+        and ${table.licensedTextTransformed} is not null
       ) or (
         ${table.descriptionClass} <> 'licensed_verbatim'
         and ${table.licenseName} is null
         and ${table.licenseUrl} is null
         and ${table.attributionText} is null
         and ${table.derivativesPermitted} is null
+        and ${table.licensedSourceTextHash} is null
+        and ${table.licensedTextTransformed} is null
       )`,
     ),
     check(

--- a/src/db/catalog/sqlite-rebuild.ts
+++ b/src/db/catalog/sqlite-rebuild.ts
@@ -34,6 +34,14 @@ export const CATALOG_TARGET_TABLE_NAMES = [
   "catalog_change_events",
   "categories",
   "cover_assets",
+  "description_candidates",
+  "description_claim_evidence",
+  "description_claims",
+  "description_decision_heads",
+  "description_decisions",
+  "description_projection_heads",
+  "description_projections",
+  "description_review_queue",
   "edition_covers",
   "edition_identifiers",
   "edition_languages",
@@ -54,6 +62,14 @@ export const CATALOG_TARGET_TABLE_NAMES = [
 ] as const;
 
 const CLEAR_SQL = `
+  delete from description_projection_heads;
+  delete from description_projections;
+  delete from description_review_queue;
+  delete from description_decision_heads;
+  delete from description_decisions;
+  delete from description_claim_evidence;
+  delete from description_claims;
+  delete from description_candidates;
   delete from field_resolution_heads;
   delete from field_resolutions;
   delete from field_observations;
@@ -256,6 +272,7 @@ export function rebuildCatalogSqlite(input: {
   try {
     migrateCatalogSqlite(raw);
     const rebuild = raw.transaction(() => {
+      raw.pragma("defer_foreign_keys = ON");
       raw.exec(CLEAR_SQL);
       importCatalogGraphSqlite(raw, input.graph, {
         failAfterTable: input.failAfterTable,

--- a/src/db/catalog/values.ts
+++ b/src/db/catalog/values.ts
@@ -98,12 +98,44 @@ export const CHANGE_TYPES = [
   "work_split",
   "edition_reassignment",
 ] as const;
+export const DESCRIPTION_CLASSES = [
+  "licensed_verbatim",
+  "bukie_editorial",
+  "model_assisted_candidate",
+] as const;
+export const DESCRIPTION_DECISION_STATES = [
+  "candidate",
+  "review_required",
+  "paused",
+  "rejected",
+  "eligible",
+  "withdrawn",
+  "invalidated",
+] as const;
+export const DESCRIPTION_QUEUE_STATES = [
+  "queued",
+  "claimed",
+  "completed",
+  "cancelled",
+] as const;
+export const DESCRIPTION_PROJECTION_STATES = [
+  "selected",
+  "withdrawn",
+  "invalidated",
+  "rolled_back",
+] as const;
 
 export type CatalogEntityType = (typeof CATALOG_ENTITY_TYPES)[number];
 export type CatalogFieldKey = (typeof CATALOG_FIELD_KEYS)[number];
 export type ProvenanceKind = (typeof PROVENANCE_KINDS)[number];
 export type ObservationState = (typeof OBSERVATION_STATES)[number];
 export type ResolutionState = (typeof RESOLUTION_STATES)[number];
+export type DescriptionClass = (typeof DESCRIPTION_CLASSES)[number];
+export type DescriptionDecisionState =
+  (typeof DESCRIPTION_DECISION_STATES)[number];
+export type DescriptionQueueState = (typeof DESCRIPTION_QUEUE_STATES)[number];
+export type DescriptionProjectionState =
+  (typeof DESCRIPTION_PROJECTION_STATES)[number];
 
 export function sqlList(values: readonly string[]): string {
   return values.map((value) => `'${value.replaceAll("'", "''")}'`).join(", ");


### PR DESCRIPTION
## Summary

- Add evidence-gated enrichment for licensed verbatim, Bukie editorial, and model-assisted description candidates without changing reader-facing catalog output.
- Keep generated text non-public until deterministic evidence and quality gates plus every required human review pass; preserve `proposedEvidenceOnly` and live policy revocation.

## Linked Issue

- Closes #133
- Labels aligned with linked issue: `enhancement`, `backend`, `database`, `quality`, `data-curation`, `area: catalog`

## Changes

- Add eight logically equivalent SQLite/Postgres tables for immutable class-specific candidate provenance, claim-to-parent evidence, decision history, bounded review queue state, and internal dry-run projection history.
- Record licensed rights/attribution/revision and derivative permission, editorial editor/reviewer/reason/revision, and provider-neutral model/version/prompt/generation/token/cost/policy metadata.
- Add deterministic stable-code gates for claim support, parent eligibility, identity, unresolved conflicts, length, readability, specificity, tone, spoilers, copying similarity, ambiguity, sensitivity, source revision, and text policy.
- Treat exact eight-word overlap only as a human-review warning; keep quality scores advisory and absent from eligibility logic.
- Add idempotent retries, queue deduplication/caps, SQLite immediate transactions, a Postgres queue advisory lock, withdrawal, revocation, policy/model/prompt invalidation, re-review, rollback, and read-time fail-closed checks.
- Keep internal description projections separate from `field_resolution_heads`; add repository defense-in-depth so a forced head still cannot expose a proposed, rejected, paused, withdrawn, invalidated, or unreviewed description candidate.
- Add deterministic five-work fixtures and a disposable proof command with candidate/rejected/reviewed/eligible/withdrawn/queue/coverage/token/cost metrics plus a reproducible 500-work estimate.

## Validation

- [x] `bun run lint`
- [x] `bun run test` — 265 passed, 5 environment-gated tests skipped locally
- [x] `bun run test:storybook -- --run` — 39 passed
- [x] `bun run test:playwright` — 28 passed
- [x] `bun run build:ci`
- [x] `bunx tsc --noEmit`
- [x] Markdown lint — 59 files, 0 issues
- [x] `bun run db:generate` and `bun run db:generate:pg` — no schema changes after committed snapshots
- [x] `git diff --check`
- [x] disposable SQLite description proof run twice with identical candidate IDs, snapshot hash, metrics, unchanged public resolution-head hash, and unchanged work descriptions
- [x] isolated PostgreSQL 16 CI lifecycle proof

## UX Notes

- [x] no visual changes
- [ ] responsive behavior verified at affected breakpoints
- [x] accessibility impact reviewed

Notes:

- Production book-detail layout remains deferred to #136.
- Browser comparison was unnecessary because public detail/API/JSON-LD output is unchanged and the full existing Playwright suite passes.

## Architecture Notes

- [ ] no architectural impact
- [x] follows existing architecture and framework defaults
- [x] introduces or updates a documented decision in `docs/decisions`

ADR / decision links:

- `docs/decisions/0016-catalog-metadata-provenance.md`
- `docs/research/book-detail-enrichment.md`
- `docs/catalog-enrichment.md`

## Data / API / Infra Impact

- [ ] no data, API, or infra impact
- [x] database schema changed
- [ ] seed/import/catalog data changed
- [ ] API contract changed
- [ ] environment variables changed
- [x] CI/CD or deployment behavior changed

Operational notes:

- Migrations add nullable-independent description lifecycle tables only; they do not backfill or modify production catalog data.
- The executable proof accepts only the existing five-work diagnostic manifest and an explicitly disposable SQLite target. It performs no provider call or catalog-wide scan.
- No model vendor is selected or called. All model behavior uses provider-neutral contracts and deterministic recorded fixtures.
- Existing source policies for Wikipedia, publishers, retailers, competitors, and search content remain pending/disabled.

## Risks

- [ ] low risk
- [x] medium risk
- [ ] high risk

Main risks and mitigations:

- risk: a future resolver could try to select a candidate observation without consulting description review state.
- mitigation: description dry-run heads are separate from public heads, current candidate sources remain proposed-only, and repository read-time eligibility now independently requires an `eligible` description decision.
- risk: concurrent workers could exceed the review cap or race decisions.
- mitigation: SQLite uses immediate transactions, Postgres uses transactional row/advisory locks, candidate/queue identities deduplicate retries, and rollback tests force failures after each transition boundary.
- risk: policy, source, model, or prompt changes could leave stale text selected internally.
- mitigation: live reads reapply source/link/parent/policy/model/prompt state and reconciliation deterministically withdraws, invalidates, or requeues the candidate.

## Checklist

- [x] scope matches the linked issue
- [x] PR labels match the linked issue labels where applicable
- [x] touched code is cleaner than before
- [x] tests cover the changed behavior
- [x] docs were updated where needed
- [x] local-only/generated artifacts are excluded from git