### PR TITLE
feat(catalog): verify edition-matched cover assets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,7 @@ jobs:
         run: >-
           bun run test --
           src/db/catalog/enrichment/persistence.pg.test.ts
+          src/db/catalog/enrichment/covers/repository.pg.test.ts
           src/db/catalog/enrichment/descriptions/repository.pg.test.ts
           src/db/catalog/work-first-publication.pg.test.ts
           --no-file-parallelism

--- a/docs/adding-covers.md
+++ b/docs/adding-covers.md
@@ -28,41 +28,40 @@ responsible for mutating production data.
    credential. Vercel itself should keep using a separate **Object Read only**
    credential.
 
-## Recommended: fetch and publish one cover
+## Inspect an exact-edition candidate
 
 Run this from the repository root:
 
 ```powershell
-bun run covers:fetch:r2 -- --id=<work-id> --concurrency=1 --force
+bun run covers:fetch -- --id=<legacy-record-id> --concurrency=1 --force
 ```
 
 This command:
 
-1. finds a candidate through Open Library;
+1. finds a candidate through the selected edition's exact ISBN;
 2. optimizes it to WebP;
-3. writes the ignored staging file to
-   `public/covers/<work-id>.webp`;
-4. uploads it to `R2_BUCKET/covers/<work-id>.webp`.
+3. decodes it and records deterministic technical/review signals in the
+   command output;
+4. writes the ignored staging file to
+   `public/covers/<legacy-record-id>.webp`.
 
-The command never mutates a runtime database. Catalog rebuild/import derives
-the normalized cover relation from the reviewed artifact. If any publishing
-job fails, the command finishes the remaining queue and exits nonzero.
+The command never mutates a runtime database or a public cover projection.
+Works without an exact selected-edition ISBN remain review candidates instead
+of falling back to title/author search. Inspection flags are advisory; identity
+and permission remain hard gates.
 
-Upload the object before deploying catalog or database changes that reference
-it. Until the object exists, the app deliberately displays the placeholder.
+`covers:fetch:r2` is deliberately blocked while the recorded Open Library
+asset policy is pending. Publishing resumes only after a reviewed dry run and
+an approved policy permit caching, transformation, and display. Until then,
+missing or rejected candidates use the accessible placeholder.
 
 ## Review before publishing
 
-To inspect a new image locally before uploading:
+After dry-run approval, open the staged image and publish exactly that reviewed
+file with the approved versioned object key:
 
 ```powershell
-bun run covers:fetch -- --id=<work-id> --concurrency=1 --force
-```
-
-Open `public/covers/<work-id>.webp`, then publish exactly that file:
-
-```powershell
-bunx wrangler r2 object put "<bucket>/covers/<work-id>.webp" `
+bunx wrangler r2 object put "<bucket>/covers/<approved-versioned-key>.webp" `
   --file="public/covers/<work-id>.webp" `
   --content-type="image/webp" `
   --cache-control="public, max-age=31536000, immutable" `

--- a/docs/catalog-enrichment.md
+++ b/docs/catalog-enrichment.md
@@ -264,14 +264,23 @@ transformation history. Stable flags cover corruption, tiny dimensions,
 square canvases, sidebars, extreme aspect/crop, blur or upscaling risk,
 duplicates, and locale/adaptation conflicts. The quality score is advisory;
 it cannot override source policy, rights, attribution, identity, or review.
+Cached candidates require fetch, cache, and display permission, while any
+recorded transformation also requires transformation permission. A strong
+edition tuple is eligible only when its approval is backed by a persisted
+curated source relation.
 
 Selection is deterministic and internal. Exact selected-edition evidence is
 preferred over a work-representative candidate, then identity strength and
 technical quality break ties with stable checksum/ID ordering. Missing,
 rejected, or uncertain candidates resolve to `/covers/placeholder.svg`.
+Checksum duplicates use the lowest stable candidate ID as their canonical
+member; every noncanonical member receives the same review flag regardless of
+arrival order.
 Withdrawal creates a tombstone, executes the policy-required purge callback,
-and recomputes the next candidate or placeholder. Selection rollback appends a
-new history event and never rewrites public heads.
+and recomputes the next candidate or placeholder. Review, idempotent
+withdrawal, purge retry, and selection rollback have matching SQLite and
+PostgreSQL operations. Selection rollback appends a new history event and
+never rewrites public heads.
 
 Run the deterministic five-work audit only against an explicitly disposable
 SQLite target:

--- a/docs/catalog-enrichment.md
+++ b/docs/catalog-enrichment.md
@@ -246,3 +246,42 @@ coverage, queue, token, cost, and linearly scaled 500-work estimates. It also
 hashes public resolution heads and work description values before and after
 the run and refuses to finish if either changes. Rebuilding and rerunning the
 same manifest produces the same candidate IDs, snapshot hash, and metrics.
+
+## Edition-matched cover inspection
+
+Issue #134 adds an internal cover-candidate path without changing
+`edition_covers`, `cover_assets`, `field_resolution_heads`, or reader-facing
+cover values. A candidate is explicitly either:
+
+- a selected-edition cover, which requires an exact ISBN, a provider edition
+  relation, or a policy-approved strong edition tuple; or
+- a work-representative cover, which has no edition ID and requires an approved
+  work relation.
+
+Every inspection records media type, bytes, dimensions, aspect ratio, SHA-256
+checksum, decode result, source revision, object key, representation type, and
+transformation history. Stable flags cover corruption, tiny dimensions,
+square canvases, sidebars, extreme aspect/crop, blur or upscaling risk,
+duplicates, and locale/adaptation conflicts. The quality score is advisory;
+it cannot override source policy, rights, attribution, identity, or review.
+
+Selection is deterministic and internal. Exact selected-edition evidence is
+preferred over a work-representative candidate, then identity strength and
+technical quality break ties with stable checksum/ID ordering. Missing,
+rejected, or uncertain candidates resolve to `/covers/placeholder.svg`.
+Withdrawal creates a tombstone, executes the policy-required purge callback,
+and recomputes the next candidate or placeholder. Selection rollback appends a
+new history event and never rewrites public heads.
+
+Run the deterministic five-work audit only against an explicitly disposable
+SQLite target:
+
+```powershell
+bun run db:catalog:cover-sample --target=sqlite:.data/catalog-targets/issue-134-cover-test.sqlite --confirm-disposable
+```
+
+The proof makes no provider calls. It records the audited Dune square/sidebar
+and edition-conflict signals, the Moby-Dick French adaptation/locale conflict,
+and the weak identity/upscaling signals for The City and the Stars, Born a
+Crime, and Faithful Place. It retries every inspection and refuses to finish
+if any public cover relation, asset row, or resolution head changes.

--- a/drizzle/0008_aspiring_karma.sql
+++ b/drizzle/0008_aspiring_karma.sql
@@ -1,0 +1,145 @@
+CREATE TABLE `cover_candidates` (
+	`id` text PRIMARY KEY NOT NULL,
+	`work_id` text NOT NULL,
+	`edition_id` text,
+	`source_record_id` text NOT NULL,
+	`representation_type` text NOT NULL,
+	`identity_match_kind` text NOT NULL,
+	`identity_evidence_json` text NOT NULL,
+	`permission_state` text NOT NULL,
+	`rights_basis` text,
+	`attribution_text` text,
+	`attribution_url` text,
+	`source_url` text NOT NULL,
+	`source_revision` text NOT NULL,
+	`source_policy_version` text NOT NULL,
+	`object_key` text NOT NULL,
+	`transformation_history_json` text NOT NULL,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`work_id`) REFERENCES `works`(`id`) ON UPDATE no action ON DELETE restrict,
+	FOREIGN KEY (`edition_id`) REFERENCES `editions`(`id`) ON UPDATE no action ON DELETE restrict,
+	FOREIGN KEY (`source_record_id`) REFERENCES `source_records`(`id`) ON UPDATE no action ON DELETE restrict,
+	CONSTRAINT "cover_candidates_representation_ck" CHECK("cover_candidates"."representation_type" in ('selected_edition', 'work_representative')
+        and (
+          ("cover_candidates"."representation_type" = 'selected_edition' and "cover_candidates"."edition_id" is not null)
+          or ("cover_candidates"."representation_type" = 'work_representative' and "cover_candidates"."edition_id" is null)
+        )),
+	CONSTRAINT "cover_candidates_identity_ck" CHECK("cover_candidates"."identity_match_kind" in ('exact_isbn', 'provider_edition_relation', 'approved_strong_edition_tuple', 'provider_work_relation', 'curated_work_relation', 'title_creator_candidate', 'conflicting')),
+	CONSTRAINT "cover_candidates_permission_ck" CHECK("cover_candidates"."permission_state" in ('approved', 'pending', 'denied')),
+	CONSTRAINT "cover_candidates_json_ck" CHECK(json_valid("cover_candidates"."identity_evidence_json")
+        and json_valid("cover_candidates"."transformation_history_json")),
+	CONSTRAINT "cover_candidates_nonempty_ck" CHECK(length(trim("cover_candidates"."source_url")) > 0
+        and length(trim("cover_candidates"."source_revision")) > 0
+        and length(trim("cover_candidates"."source_policy_version")) > 0
+        and length(trim("cover_candidates"."object_key")) > 0
+        and substr("cover_candidates"."object_key", 1, 8) = '/covers/')
+);
+--> statement-breakpoint
+CREATE INDEX `cover_candidates_work_created_idx` ON `cover_candidates` (`work_id`,`created_at`);--> statement-breakpoint
+CREATE INDEX `cover_candidates_source_record_idx` ON `cover_candidates` (`source_record_id`);--> statement-breakpoint
+CREATE TABLE `cover_decision_heads` (
+	`candidate_id` text PRIMARY KEY NOT NULL,
+	`decision_id` text NOT NULL,
+	FOREIGN KEY (`candidate_id`) REFERENCES `cover_candidates`(`id`) ON UPDATE no action ON DELETE restrict,
+	FOREIGN KEY (`decision_id`) REFERENCES `cover_decisions`(`id`) ON UPDATE no action ON DELETE restrict
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `cover_decision_heads_decision_uq` ON `cover_decision_heads` (`decision_id`);--> statement-breakpoint
+CREATE TABLE `cover_decisions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`candidate_id` text NOT NULL,
+	`inspection_id` text NOT NULL,
+	`state` text NOT NULL,
+	`gate_codes_json` text NOT NULL,
+	`warning_codes_json` text NOT NULL,
+	`reviewer_ref` text,
+	`review_reason` text,
+	`purge_state` text NOT NULL,
+	`previous_decision_id` text,
+	`policy_version` text NOT NULL,
+	`decided_at` integer NOT NULL,
+	FOREIGN KEY (`candidate_id`) REFERENCES `cover_candidates`(`id`) ON UPDATE no action ON DELETE restrict,
+	FOREIGN KEY (`inspection_id`) REFERENCES `cover_inspections`(`id`) ON UPDATE no action ON DELETE restrict,
+	FOREIGN KEY (`previous_decision_id`) REFERENCES `cover_decisions`(`id`) ON UPDATE no action ON DELETE restrict,
+	CONSTRAINT "cover_decisions_state_ck" CHECK("cover_decisions"."state" in ('review_required', 'eligible', 'rejected', 'withdrawn')),
+	CONSTRAINT "cover_decisions_purge_ck" CHECK("cover_decisions"."purge_state" in ('not_required', 'pending', 'completed', 'failed')),
+	CONSTRAINT "cover_decisions_json_ck" CHECK(json_valid("cover_decisions"."gate_codes_json")
+        and json_valid("cover_decisions"."warning_codes_json")),
+	CONSTRAINT "cover_decisions_review_ck" CHECK(("cover_decisions"."reviewer_ref" is null and "cover_decisions"."review_reason" is null)
+        or (
+          length(trim("cover_decisions"."reviewer_ref")) > 0
+          and length(trim("cover_decisions"."review_reason")) > 0
+        )),
+	CONSTRAINT "cover_decisions_policy_ck" CHECK(length(trim("cover_decisions"."policy_version")) > 0)
+);
+--> statement-breakpoint
+CREATE INDEX `cover_decisions_candidate_history_idx` ON `cover_decisions` (`candidate_id`,`decided_at`);--> statement-breakpoint
+CREATE TABLE `cover_inspections` (
+	`id` text PRIMARY KEY NOT NULL,
+	`candidate_id` text NOT NULL,
+	`media_type` text,
+	`byte_size` integer NOT NULL,
+	`width` integer,
+	`height` integer,
+	`aspect_ratio` real,
+	`checksum` text NOT NULL,
+	`decode_result` text NOT NULL,
+	`flags_json` text NOT NULL,
+	`quality_score` real NOT NULL,
+	`duplicate_of_candidate_id` text,
+	`inspection_version` text NOT NULL,
+	`inspected_at` integer NOT NULL,
+	FOREIGN KEY (`candidate_id`) REFERENCES `cover_candidates`(`id`) ON UPDATE no action ON DELETE restrict,
+	FOREIGN KEY (`duplicate_of_candidate_id`) REFERENCES `cover_candidates`(`id`) ON UPDATE no action ON DELETE restrict,
+	CONSTRAINT "cover_inspections_decode_ck" CHECK("cover_inspections"."decode_result" in ('decoded', 'corrupt', 'unsupported')
+        and (
+          ("cover_inspections"."decode_result" = 'decoded'
+            and "cover_inspections"."media_type" is not null
+            and "cover_inspections"."width" > 0
+            and "cover_inspections"."height" > 0
+            and "cover_inspections"."aspect_ratio" > 0)
+          or ("cover_inspections"."decode_result" <> 'decoded'
+            and "cover_inspections"."width" is null
+            and "cover_inspections"."height" is null
+            and "cover_inspections"."aspect_ratio" is null)
+        )),
+	CONSTRAINT "cover_inspections_values_ck" CHECK("cover_inspections"."byte_size" > 0
+        and length("cover_inspections"."checksum") = 64
+        and json_valid("cover_inspections"."flags_json")
+        and "cover_inspections"."quality_score" between 0 and 100
+        and length(trim("cover_inspections"."inspection_version")) > 0)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `cover_inspections_identity_uq` ON `cover_inspections` (`candidate_id`,`checksum`,`inspection_version`);--> statement-breakpoint
+CREATE INDEX `cover_inspections_checksum_idx` ON `cover_inspections` (`checksum`);--> statement-breakpoint
+CREATE INDEX `cover_inspections_candidate_idx` ON `cover_inspections` (`candidate_id`);--> statement-breakpoint
+CREATE TABLE `cover_projection_heads` (
+	`work_id` text PRIMARY KEY NOT NULL,
+	`projection_id` text NOT NULL,
+	FOREIGN KEY (`work_id`) REFERENCES `works`(`id`) ON UPDATE no action ON DELETE restrict,
+	FOREIGN KEY (`projection_id`) REFERENCES `cover_projections`(`id`) ON UPDATE no action ON DELETE restrict
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `cover_projection_heads_projection_uq` ON `cover_projection_heads` (`projection_id`);--> statement-breakpoint
+CREATE TABLE `cover_projections` (
+	`id` text PRIMARY KEY NOT NULL,
+	`work_id` text NOT NULL,
+	`candidate_id` text,
+	`state` text NOT NULL,
+	`previous_projection_id` text,
+	`reason_code` text NOT NULL,
+	`actor_ref` text NOT NULL,
+	`policy_version` text NOT NULL,
+	`projected_at` integer NOT NULL,
+	FOREIGN KEY (`work_id`) REFERENCES `works`(`id`) ON UPDATE no action ON DELETE restrict,
+	FOREIGN KEY (`candidate_id`) REFERENCES `cover_candidates`(`id`) ON UPDATE no action ON DELETE restrict,
+	FOREIGN KEY (`previous_projection_id`) REFERENCES `cover_projections`(`id`) ON UPDATE no action ON DELETE restrict,
+	CONSTRAINT "cover_projections_state_ck" CHECK("cover_projections"."state" in ('selected', 'placeholder', 'withdrawn', 'rolled_back')),
+	CONSTRAINT "cover_projections_selection_ck" CHECK(("cover_projections"."state" in ('selected', 'rolled_back') and "cover_projections"."candidate_id" is not null)
+        or ("cover_projections"."state" in ('placeholder', 'withdrawn') and "cover_projections"."candidate_id" is null)),
+	CONSTRAINT "cover_projections_nonempty_ck" CHECK(length(trim("cover_projections"."reason_code")) > 0
+        and length(trim("cover_projections"."actor_ref")) > 0
+        and length(trim("cover_projections"."policy_version")) > 0)
+);
+--> statement-breakpoint
+CREATE INDEX `cover_projections_work_history_idx` ON `cover_projections` (`work_id`,`projected_at`);

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,3871 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e44fb0fb-4dd0-4ba2-a464-626228bcfa86",
+  "prevId": "150f4f10-3e1d-4324-9577-3bcbf3de2a47",
+  "tables": {
+    "authors": {
+      "name": "authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_name": {
+          "name": "sort_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authors_sort_name_idx": {
+          "name": "authors_sort_name_idx",
+          "columns": [
+            "sort_name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "authors_name_nonempty_ck": {
+          "name": "authors_name_nonempty_ck",
+          "value": "length(trim(\"authors\".\"display_name\")) > 0"
+        },
+        "authors_sort_name_ck": {
+          "name": "authors_sort_name_ck",
+          "value": "\"authors\".\"sort_name\" is null or length(trim(\"authors\".\"sort_name\")) > 0"
+        }
+      }
+    },
+    "catalog_change_events": {
+      "name": "catalog_change_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "catalog_change_events_type_created_idx": {
+          "name": "catalog_change_events_type_created_idx",
+          "columns": [
+            "change_type",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "catalog_change_events_type_ck": {
+          "name": "catalog_change_events_type_ck",
+          "value": "\"catalog_change_events\".\"change_type\" in ('work_merge', 'work_split', 'edition_reassignment')"
+        },
+        "catalog_change_events_json_ck": {
+          "name": "catalog_change_events_json_ck",
+          "value": "json_valid(\"catalog_change_events\".\"payload_json\")"
+        },
+        "catalog_change_events_nonempty_ck": {
+          "name": "catalog_change_events_nonempty_ck",
+          "value": "length(trim(\"catalog_change_events\".\"actor_ref\")) > 0 and length(trim(\"catalog_change_events\".\"reason\")) > 0"
+        }
+      }
+    },
+    "categories": {
+      "name": "categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "categories_slug_uq": {
+          "name": "categories_slug_uq",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "categories_nonempty_ck": {
+          "name": "categories_nonempty_ck",
+          "value": "length(trim(\"categories\".\"slug\")) > 0 and length(trim(\"categories\".\"label\")) > 0"
+        },
+        "categories_status_ck": {
+          "name": "categories_status_ck",
+          "value": "\"categories\".\"status\" in ('active', 'retired')"
+        }
+      }
+    },
+    "cover_assets": {
+      "name": "cover_assets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_policy_id": {
+          "name": "source_policy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cover_assets_object_key_uq": {
+          "name": "cover_assets_object_key_uq",
+          "columns": [
+            "object_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "cover_assets_source_policy_id_metadata_sources_id_fk": {
+          "name": "cover_assets_source_policy_id_metadata_sources_id_fk",
+          "tableFrom": "cover_assets",
+          "tableTo": "metadata_sources",
+          "columnsFrom": [
+            "source_policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "cover_assets_object_key_ck": {
+          "name": "cover_assets_object_key_ck",
+          "value": "length(trim(\"cover_assets\".\"object_key\")) > 0 and substr(\"cover_assets\".\"object_key\", 1, 8) = '/covers/'"
+        },
+        "cover_assets_state_ck": {
+          "name": "cover_assets_state_ck",
+          "value": "\"cover_assets\".\"state\" in ('available', 'missing', 'withdrawn', 'failed')"
+        },
+        "cover_assets_dimensions_ck": {
+          "name": "cover_assets_dimensions_ck",
+          "value": "(\"cover_assets\".\"width\" is null or \"cover_assets\".\"width\" > 0)\n        and (\"cover_assets\".\"height\" is null or \"cover_assets\".\"height\" > 0)\n        and (\"cover_assets\".\"bytes\" is null or \"cover_assets\".\"bytes\" > 0)"
+        }
+      }
+    },
+    "cover_candidates": {
+      "name": "cover_candidates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "representation_type": {
+          "name": "representation_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identity_match_kind": {
+          "name": "identity_match_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identity_evidence_json": {
+          "name": "identity_evidence_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permission_state": {
+          "name": "permission_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rights_basis": {
+          "name": "rights_basis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attribution_text": {
+          "name": "attribution_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attribution_url": {
+          "name": "attribution_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_policy_version": {
+          "name": "source_policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transformation_history_json": {
+          "name": "transformation_history_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cover_candidates_work_created_idx": {
+          "name": "cover_candidates_work_created_idx",
+          "columns": [
+            "work_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "cover_candidates_source_record_idx": {
+          "name": "cover_candidates_source_record_idx",
+          "columns": [
+            "source_record_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "cover_candidates_work_id_works_id_fk": {
+          "name": "cover_candidates_work_id_works_id_fk",
+          "tableFrom": "cover_candidates",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cover_candidates_edition_id_editions_id_fk": {
+          "name": "cover_candidates_edition_id_editions_id_fk",
+          "tableFrom": "cover_candidates",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cover_candidates_source_record_id_source_records_id_fk": {
+          "name": "cover_candidates_source_record_id_source_records_id_fk",
+          "tableFrom": "cover_candidates",
+          "tableTo": "source_records",
+          "columnsFrom": [
+            "source_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "cover_candidates_representation_ck": {
+          "name": "cover_candidates_representation_ck",
+          "value": "\"cover_candidates\".\"representation_type\" in ('selected_edition', 'work_representative')\n        and (\n          (\"cover_candidates\".\"representation_type\" = 'selected_edition' and \"cover_candidates\".\"edition_id\" is not null)\n          or (\"cover_candidates\".\"representation_type\" = 'work_representative' and \"cover_candidates\".\"edition_id\" is null)\n        )"
+        },
+        "cover_candidates_identity_ck": {
+          "name": "cover_candidates_identity_ck",
+          "value": "\"cover_candidates\".\"identity_match_kind\" in ('exact_isbn', 'provider_edition_relation', 'approved_strong_edition_tuple', 'provider_work_relation', 'curated_work_relation', 'title_creator_candidate', 'conflicting')"
+        },
+        "cover_candidates_permission_ck": {
+          "name": "cover_candidates_permission_ck",
+          "value": "\"cover_candidates\".\"permission_state\" in ('approved', 'pending', 'denied')"
+        },
+        "cover_candidates_json_ck": {
+          "name": "cover_candidates_json_ck",
+          "value": "json_valid(\"cover_candidates\".\"identity_evidence_json\")\n        and json_valid(\"cover_candidates\".\"transformation_history_json\")"
+        },
+        "cover_candidates_nonempty_ck": {
+          "name": "cover_candidates_nonempty_ck",
+          "value": "length(trim(\"cover_candidates\".\"source_url\")) > 0\n        and length(trim(\"cover_candidates\".\"source_revision\")) > 0\n        and length(trim(\"cover_candidates\".\"source_policy_version\")) > 0\n        and length(trim(\"cover_candidates\".\"object_key\")) > 0\n        and substr(\"cover_candidates\".\"object_key\", 1, 8) = '/covers/'"
+        }
+      }
+    },
+    "cover_decision_heads": {
+      "name": "cover_decision_heads",
+      "columns": {
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision_id": {
+          "name": "decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cover_decision_heads_decision_uq": {
+          "name": "cover_decision_heads_decision_uq",
+          "columns": [
+            "decision_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "cover_decision_heads_candidate_id_cover_candidates_id_fk": {
+          "name": "cover_decision_heads_candidate_id_cover_candidates_id_fk",
+          "tableFrom": "cover_decision_heads",
+          "tableTo": "cover_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cover_decision_heads_decision_id_cover_decisions_id_fk": {
+          "name": "cover_decision_heads_decision_id_cover_decisions_id_fk",
+          "tableFrom": "cover_decision_heads",
+          "tableTo": "cover_decisions",
+          "columnsFrom": [
+            "decision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cover_decisions": {
+      "name": "cover_decisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gate_codes_json": {
+          "name": "gate_codes_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "warning_codes_json": {
+          "name": "warning_codes_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reviewer_ref": {
+          "name": "reviewer_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_reason": {
+          "name": "review_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purge_state": {
+          "name": "purge_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "previous_decision_id": {
+          "name": "previous_decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cover_decisions_candidate_history_idx": {
+          "name": "cover_decisions_candidate_history_idx",
+          "columns": [
+            "candidate_id",
+            "decided_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "cover_decisions_candidate_id_cover_candidates_id_fk": {
+          "name": "cover_decisions_candidate_id_cover_candidates_id_fk",
+          "tableFrom": "cover_decisions",
+          "tableTo": "cover_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cover_decisions_inspection_id_cover_inspections_id_fk": {
+          "name": "cover_decisions_inspection_id_cover_inspections_id_fk",
+          "tableFrom": "cover_decisions",
+          "tableTo": "cover_inspections",
+          "columnsFrom": [
+            "inspection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cover_decisions_previous_decision_id_cover_decisions_id_fk": {
+          "name": "cover_decisions_previous_decision_id_cover_decisions_id_fk",
+          "tableFrom": "cover_decisions",
+          "tableTo": "cover_decisions",
+          "columnsFrom": [
+            "previous_decision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "cover_decisions_state_ck": {
+          "name": "cover_decisions_state_ck",
+          "value": "\"cover_decisions\".\"state\" in ('review_required', 'eligible', 'rejected', 'withdrawn')"
+        },
+        "cover_decisions_purge_ck": {
+          "name": "cover_decisions_purge_ck",
+          "value": "\"cover_decisions\".\"purge_state\" in ('not_required', 'pending', 'completed', 'failed')"
+        },
+        "cover_decisions_json_ck": {
+          "name": "cover_decisions_json_ck",
+          "value": "json_valid(\"cover_decisions\".\"gate_codes_json\")\n        and json_valid(\"cover_decisions\".\"warning_codes_json\")"
+        },
+        "cover_decisions_review_ck": {
+          "name": "cover_decisions_review_ck",
+          "value": "(\"cover_decisions\".\"reviewer_ref\" is null and \"cover_decisions\".\"review_reason\" is null)\n        or (\n          length(trim(\"cover_decisions\".\"reviewer_ref\")) > 0\n          and length(trim(\"cover_decisions\".\"review_reason\")) > 0\n        )"
+        },
+        "cover_decisions_policy_ck": {
+          "name": "cover_decisions_policy_ck",
+          "value": "length(trim(\"cover_decisions\".\"policy_version\")) > 0"
+        }
+      }
+    },
+    "cover_inspections": {
+      "name": "cover_inspections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aspect_ratio": {
+          "name": "aspect_ratio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decode_result": {
+          "name": "decode_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "flags_json": {
+          "name": "flags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duplicate_of_candidate_id": {
+          "name": "duplicate_of_candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inspection_version": {
+          "name": "inspection_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspected_at": {
+          "name": "inspected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cover_inspections_identity_uq": {
+          "name": "cover_inspections_identity_uq",
+          "columns": [
+            "candidate_id",
+            "checksum",
+            "inspection_version"
+          ],
+          "isUnique": true
+        },
+        "cover_inspections_checksum_idx": {
+          "name": "cover_inspections_checksum_idx",
+          "columns": [
+            "checksum"
+          ],
+          "isUnique": false
+        },
+        "cover_inspections_candidate_idx": {
+          "name": "cover_inspections_candidate_idx",
+          "columns": [
+            "candidate_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "cover_inspections_candidate_id_cover_candidates_id_fk": {
+          "name": "cover_inspections_candidate_id_cover_candidates_id_fk",
+          "tableFrom": "cover_inspections",
+          "tableTo": "cover_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cover_inspections_duplicate_of_candidate_id_cover_candidates_id_fk": {
+          "name": "cover_inspections_duplicate_of_candidate_id_cover_candidates_id_fk",
+          "tableFrom": "cover_inspections",
+          "tableTo": "cover_candidates",
+          "columnsFrom": [
+            "duplicate_of_candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "cover_inspections_decode_ck": {
+          "name": "cover_inspections_decode_ck",
+          "value": "\"cover_inspections\".\"decode_result\" in ('decoded', 'corrupt', 'unsupported')\n        and (\n          (\"cover_inspections\".\"decode_result\" = 'decoded'\n            and \"cover_inspections\".\"media_type\" is not null\n            and \"cover_inspections\".\"width\" > 0\n            and \"cover_inspections\".\"height\" > 0\n            and \"cover_inspections\".\"aspect_ratio\" > 0)\n          or (\"cover_inspections\".\"decode_result\" <> 'decoded'\n            and \"cover_inspections\".\"width\" is null\n            and \"cover_inspections\".\"height\" is null\n            and \"cover_inspections\".\"aspect_ratio\" is null)\n        )"
+        },
+        "cover_inspections_values_ck": {
+          "name": "cover_inspections_values_ck",
+          "value": "\"cover_inspections\".\"byte_size\" > 0\n        and length(\"cover_inspections\".\"checksum\") = 64\n        and json_valid(\"cover_inspections\".\"flags_json\")\n        and \"cover_inspections\".\"quality_score\" between 0 and 100\n        and length(trim(\"cover_inspections\".\"inspection_version\")) > 0"
+        }
+      }
+    },
+    "cover_projection_heads": {
+      "name": "cover_projection_heads",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projection_id": {
+          "name": "projection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cover_projection_heads_projection_uq": {
+          "name": "cover_projection_heads_projection_uq",
+          "columns": [
+            "projection_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "cover_projection_heads_work_id_works_id_fk": {
+          "name": "cover_projection_heads_work_id_works_id_fk",
+          "tableFrom": "cover_projection_heads",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cover_projection_heads_projection_id_cover_projections_id_fk": {
+          "name": "cover_projection_heads_projection_id_cover_projections_id_fk",
+          "tableFrom": "cover_projection_heads",
+          "tableTo": "cover_projections",
+          "columnsFrom": [
+            "projection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cover_projections": {
+      "name": "cover_projections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "previous_projection_id": {
+          "name": "previous_projection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projected_at": {
+          "name": "projected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cover_projections_work_history_idx": {
+          "name": "cover_projections_work_history_idx",
+          "columns": [
+            "work_id",
+            "projected_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "cover_projections_work_id_works_id_fk": {
+          "name": "cover_projections_work_id_works_id_fk",
+          "tableFrom": "cover_projections",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cover_projections_candidate_id_cover_candidates_id_fk": {
+          "name": "cover_projections_candidate_id_cover_candidates_id_fk",
+          "tableFrom": "cover_projections",
+          "tableTo": "cover_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cover_projections_previous_projection_id_cover_projections_id_fk": {
+          "name": "cover_projections_previous_projection_id_cover_projections_id_fk",
+          "tableFrom": "cover_projections",
+          "tableTo": "cover_projections",
+          "columnsFrom": [
+            "previous_projection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "cover_projections_state_ck": {
+          "name": "cover_projections_state_ck",
+          "value": "\"cover_projections\".\"state\" in ('selected', 'placeholder', 'withdrawn', 'rolled_back')"
+        },
+        "cover_projections_selection_ck": {
+          "name": "cover_projections_selection_ck",
+          "value": "(\"cover_projections\".\"state\" in ('selected', 'rolled_back') and \"cover_projections\".\"candidate_id\" is not null)\n        or (\"cover_projections\".\"state\" in ('placeholder', 'withdrawn') and \"cover_projections\".\"candidate_id\" is null)"
+        },
+        "cover_projections_nonempty_ck": {
+          "name": "cover_projections_nonempty_ck",
+          "value": "length(trim(\"cover_projections\".\"reason_code\")) > 0\n        and length(trim(\"cover_projections\".\"actor_ref\")) > 0\n        and length(trim(\"cover_projections\".\"policy_version\")) > 0"
+        }
+      }
+    },
+    "description_candidates": {
+      "name": "description_candidates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "observation_id": {
+          "name": "observation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description_class": {
+          "name": "description_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_hash": {
+          "name": "text_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_policy_version": {
+          "name": "source_policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description_policy_version": {
+          "name": "description_policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "license_name": {
+          "name": "license_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "license_url": {
+          "name": "license_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attribution_text": {
+          "name": "attribution_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "derivatives_permitted": {
+          "name": "derivatives_permitted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "licensed_source_text_hash": {
+          "name": "licensed_source_text_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "licensed_text_transformed": {
+          "name": "licensed_text_transformed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editor_ref": {
+          "name": "editor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editorial_reason": {
+          "name": "editorial_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "editorial_revision": {
+          "name": "editorial_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generation_input_hash": {
+          "name": "generation_input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generation_duration_ms": {
+          "name": "generation_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_microusd": {
+          "name": "cost_microusd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ambiguous_identity": {
+          "name": "ambiguous_identity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sensitive_content": {
+          "name": "sensitive_content",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "description_candidates_observation_uq": {
+          "name": "description_candidates_observation_uq",
+          "columns": [
+            "observation_id"
+          ],
+          "isUnique": true
+        },
+        "description_candidates_work_created_idx": {
+          "name": "description_candidates_work_created_idx",
+          "columns": [
+            "work_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "description_candidates_work_id_works_id_fk": {
+          "name": "description_candidates_work_id_works_id_fk",
+          "tableFrom": "description_candidates",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_candidates_observation_id_field_observations_id_fk": {
+          "name": "description_candidates_observation_id_field_observations_id_fk",
+          "tableFrom": "description_candidates",
+          "tableTo": "field_observations",
+          "columnsFrom": [
+            "observation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "description_candidates_class_ck": {
+          "name": "description_candidates_class_ck",
+          "value": "\"description_candidates\".\"description_class\" in ('licensed_verbatim', 'bukie_editorial', 'model_assisted_candidate')"
+        },
+        "description_candidates_text_ck": {
+          "name": "description_candidates_text_ck",
+          "value": "length(trim(\"description_candidates\".\"text_content\")) > 0 and length(\"description_candidates\".\"text_hash\") = 64"
+        },
+        "description_candidates_versions_ck": {
+          "name": "description_candidates_versions_ck",
+          "value": "length(trim(\"description_candidates\".\"source_revision\")) > 0\n        and length(trim(\"description_candidates\".\"source_policy_version\")) > 0\n        and length(trim(\"description_candidates\".\"description_policy_version\")) > 0"
+        },
+        "description_candidates_license_ck": {
+          "name": "description_candidates_license_ck",
+          "value": "(\n        \"description_candidates\".\"description_class\" = 'licensed_verbatim'\n        and length(trim(\"description_candidates\".\"license_name\")) > 0\n        and length(trim(\"description_candidates\".\"license_url\")) > 0\n        and \"description_candidates\".\"derivatives_permitted\" is not null\n        and length(\"description_candidates\".\"licensed_source_text_hash\") = 64\n        and \"description_candidates\".\"licensed_text_transformed\" is not null\n      ) or (\n        \"description_candidates\".\"description_class\" <> 'licensed_verbatim'\n        and \"description_candidates\".\"license_name\" is null\n        and \"description_candidates\".\"license_url\" is null\n        and \"description_candidates\".\"attribution_text\" is null\n        and \"description_candidates\".\"derivatives_permitted\" is null\n        and \"description_candidates\".\"licensed_source_text_hash\" is null\n        and \"description_candidates\".\"licensed_text_transformed\" is null\n      )"
+        },
+        "description_candidates_editorial_ck": {
+          "name": "description_candidates_editorial_ck",
+          "value": "(\n        \"description_candidates\".\"description_class\" = 'bukie_editorial'\n        and length(trim(\"description_candidates\".\"editor_ref\")) > 0\n        and length(trim(\"description_candidates\".\"editorial_reason\")) > 0\n        and length(trim(\"description_candidates\".\"editorial_revision\")) > 0\n      ) or (\n        \"description_candidates\".\"description_class\" <> 'bukie_editorial'\n        and \"description_candidates\".\"editor_ref\" is null\n        and \"description_candidates\".\"editorial_reason\" is null\n        and \"description_candidates\".\"editorial_revision\" is null\n      )"
+        },
+        "description_candidates_model_ck": {
+          "name": "description_candidates_model_ck",
+          "value": "(\n        \"description_candidates\".\"description_class\" = 'model_assisted_candidate'\n        and length(trim(\"description_candidates\".\"model_id\")) > 0\n        and length(trim(\"description_candidates\".\"model_version\")) > 0\n        and length(trim(\"description_candidates\".\"prompt_version\")) > 0\n        and length(\"description_candidates\".\"generation_input_hash\") = 64\n        and \"description_candidates\".\"generated_at\" is not null\n        and \"description_candidates\".\"generation_duration_ms\" >= 0\n        and \"description_candidates\".\"input_tokens\" >= 0\n        and \"description_candidates\".\"output_tokens\" >= 0\n        and \"description_candidates\".\"cost_microusd\" >= 0\n      ) or (\n        \"description_candidates\".\"description_class\" <> 'model_assisted_candidate'\n        and \"description_candidates\".\"model_id\" is null\n        and \"description_candidates\".\"model_version\" is null\n        and \"description_candidates\".\"prompt_version\" is null\n        and \"description_candidates\".\"generation_input_hash\" is null\n        and \"description_candidates\".\"generated_at\" is null\n        and \"description_candidates\".\"generation_duration_ms\" is null\n        and \"description_candidates\".\"input_tokens\" is null\n        and \"description_candidates\".\"output_tokens\" is null\n        and \"description_candidates\".\"cost_microusd\" is null\n      )"
+        },
+        "description_candidates_quality_ck": {
+          "name": "description_candidates_quality_ck",
+          "value": "\"description_candidates\".\"quality_score\" is null or \"description_candidates\".\"quality_score\" between 0 and 100"
+        }
+      }
+    },
+    "description_claim_evidence": {
+      "name": "description_claim_evidence",
+      "columns": {
+        "claim_id": {
+          "name": "claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "observation_id": {
+          "name": "observation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "description_claim_evidence_observation_idx": {
+          "name": "description_claim_evidence_observation_idx",
+          "columns": [
+            "observation_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "description_claim_evidence_claim_id_description_claims_id_fk": {
+          "name": "description_claim_evidence_claim_id_description_claims_id_fk",
+          "tableFrom": "description_claim_evidence",
+          "tableTo": "description_claims",
+          "columnsFrom": [
+            "claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "description_claim_evidence_observation_id_field_observations_id_fk": {
+          "name": "description_claim_evidence_observation_id_field_observations_id_fk",
+          "tableFrom": "description_claim_evidence",
+          "tableTo": "field_observations",
+          "columnsFrom": [
+            "observation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "description_claim_evidence_pk": {
+          "columns": [
+            "claim_id",
+            "observation_id"
+          ],
+          "name": "description_claim_evidence_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "description_claims": {
+      "name": "description_claims",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claim_text": {
+          "name": "claim_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claim_hash": {
+          "name": "claim_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "description_claims_position_uq": {
+          "name": "description_claims_position_uq",
+          "columns": [
+            "candidate_id",
+            "position"
+          ],
+          "isUnique": true
+        },
+        "description_claims_candidate_idx": {
+          "name": "description_claims_candidate_idx",
+          "columns": [
+            "candidate_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "description_claims_candidate_id_description_candidates_id_fk": {
+          "name": "description_claims_candidate_id_description_candidates_id_fk",
+          "tableFrom": "description_claims",
+          "tableTo": "description_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "description_claims_content_ck": {
+          "name": "description_claims_content_ck",
+          "value": "\"description_claims\".\"position\" >= 0\n        and length(trim(\"description_claims\".\"claim_text\")) > 0\n        and length(\"description_claims\".\"claim_hash\") = 64"
+        }
+      }
+    },
+    "description_decision_heads": {
+      "name": "description_decision_heads",
+      "columns": {
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision_id": {
+          "name": "decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "description_decision_heads_decision_uq": {
+          "name": "description_decision_heads_decision_uq",
+          "columns": [
+            "decision_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "description_decision_heads_candidate_id_description_candidates_id_fk": {
+          "name": "description_decision_heads_candidate_id_description_candidates_id_fk",
+          "tableFrom": "description_decision_heads",
+          "tableTo": "description_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_decision_heads_decision_id_description_decisions_id_fk": {
+          "name": "description_decision_heads_decision_id_description_decisions_id_fk",
+          "tableFrom": "description_decision_heads",
+          "tableTo": "description_decisions",
+          "columnsFrom": [
+            "decision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "description_decisions": {
+      "name": "description_decisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rejection_codes_json": {
+          "name": "rejection_codes_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "warning_codes_json": {
+          "name": "warning_codes_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reviewer_ref": {
+          "name": "reviewer_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_reason": {
+          "name": "review_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_decision_id": {
+          "name": "previous_decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "description_decisions_candidate_history_idx": {
+          "name": "description_decisions_candidate_history_idx",
+          "columns": [
+            "candidate_id",
+            "decided_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "description_decisions_candidate_id_description_candidates_id_fk": {
+          "name": "description_decisions_candidate_id_description_candidates_id_fk",
+          "tableFrom": "description_decisions",
+          "tableTo": "description_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_decisions_previous_decision_id_description_decisions_id_fk": {
+          "name": "description_decisions_previous_decision_id_description_decisions_id_fk",
+          "tableFrom": "description_decisions",
+          "tableTo": "description_decisions",
+          "columnsFrom": [
+            "previous_decision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "description_decisions_state_ck": {
+          "name": "description_decisions_state_ck",
+          "value": "\"description_decisions\".\"state\" in ('candidate', 'review_required', 'paused', 'rejected', 'eligible', 'withdrawn', 'invalidated')"
+        },
+        "description_decisions_json_ck": {
+          "name": "description_decisions_json_ck",
+          "value": "json_valid(\"description_decisions\".\"rejection_codes_json\")\n        and json_valid(\"description_decisions\".\"warning_codes_json\")"
+        },
+        "description_decisions_review_ck": {
+          "name": "description_decisions_review_ck",
+          "value": "(\"description_decisions\".\"reviewer_ref\" is null and \"description_decisions\".\"review_reason\" is null)\n        or (\n          length(trim(\"description_decisions\".\"reviewer_ref\")) > 0\n          and length(trim(\"description_decisions\".\"review_reason\")) > 0\n        )"
+        },
+        "description_decisions_policy_ck": {
+          "name": "description_decisions_policy_ck",
+          "value": "length(trim(\"description_decisions\".\"policy_version\")) > 0"
+        }
+      }
+    },
+    "description_projection_heads": {
+      "name": "description_projection_heads",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projection_id": {
+          "name": "projection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "description_projection_heads_projection_uq": {
+          "name": "description_projection_heads_projection_uq",
+          "columns": [
+            "projection_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "description_projection_heads_work_id_works_id_fk": {
+          "name": "description_projection_heads_work_id_works_id_fk",
+          "tableFrom": "description_projection_heads",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_projection_heads_projection_id_description_projections_id_fk": {
+          "name": "description_projection_heads_projection_id_description_projections_id_fk",
+          "tableFrom": "description_projection_heads",
+          "tableTo": "description_projections",
+          "columnsFrom": [
+            "projection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "description_projections": {
+      "name": "description_projections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "previous_projection_id": {
+          "name": "previous_projection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projected_at": {
+          "name": "projected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "description_projections_work_history_idx": {
+          "name": "description_projections_work_history_idx",
+          "columns": [
+            "work_id",
+            "projected_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "description_projections_work_id_works_id_fk": {
+          "name": "description_projections_work_id_works_id_fk",
+          "tableFrom": "description_projections",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_projections_candidate_id_description_candidates_id_fk": {
+          "name": "description_projections_candidate_id_description_candidates_id_fk",
+          "tableFrom": "description_projections",
+          "tableTo": "description_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_projections_previous_projection_id_description_projections_id_fk": {
+          "name": "description_projections_previous_projection_id_description_projections_id_fk",
+          "tableFrom": "description_projections",
+          "tableTo": "description_projections",
+          "columnsFrom": [
+            "previous_projection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "description_projections_state_ck": {
+          "name": "description_projections_state_ck",
+          "value": "\"description_projections\".\"state\" in ('selected', 'withdrawn', 'invalidated', 'rolled_back')"
+        },
+        "description_projections_selection_ck": {
+          "name": "description_projections_selection_ck",
+          "value": "(\"description_projections\".\"state\" in ('selected', 'rolled_back') and \"description_projections\".\"candidate_id\" is not null)\n        or (\"description_projections\".\"state\" in ('withdrawn', 'invalidated') and \"description_projections\".\"candidate_id\" is null)"
+        },
+        "description_projections_nonempty_ck": {
+          "name": "description_projections_nonempty_ck",
+          "value": "length(trim(\"description_projections\".\"reason_code\")) > 0\n        and length(trim(\"description_projections\".\"actor_ref\")) > 0\n        and length(trim(\"description_projections\".\"policy_version\")) > 0"
+        }
+      }
+    },
+    "description_review_queue": {
+      "name": "description_review_queue",
+      "columns": {
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason_codes_json": {
+          "name": "reason_codes_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reviewer_ref": {
+          "name": "reviewer_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "description_review_queue_active_idx": {
+          "name": "description_review_queue_active_idx",
+          "columns": [
+            "state",
+            "priority",
+            "queued_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "description_review_queue_candidate_id_description_candidates_id_fk": {
+          "name": "description_review_queue_candidate_id_description_candidates_id_fk",
+          "tableFrom": "description_review_queue",
+          "tableTo": "description_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "description_review_queue_state_ck": {
+          "name": "description_review_queue_state_ck",
+          "value": "\"description_review_queue\".\"state\" in ('queued', 'claimed', 'completed', 'cancelled')"
+        },
+        "description_review_queue_values_ck": {
+          "name": "description_review_queue_values_ck",
+          "value": "\"description_review_queue\".\"priority\" >= 0\n        and json_valid(\"description_review_queue\".\"reason_codes_json\")\n        and (\"description_review_queue\".\"reviewer_ref\" is null or length(trim(\"description_review_queue\".\"reviewer_ref\")) > 0)"
+        }
+      }
+    },
+    "edition_covers": {
+      "name": "edition_covers",
+      "columns": {
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cover_asset_id": {
+          "name": "cover_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "edition_covers_position_uq": {
+          "name": "edition_covers_position_uq",
+          "columns": [
+            "edition_id",
+            "position"
+          ],
+          "isUnique": true
+        },
+        "edition_covers_primary_uq": {
+          "name": "edition_covers_primary_uq",
+          "columns": [
+            "edition_id"
+          ],
+          "isUnique": true,
+          "where": "\"edition_covers\".\"is_primary\" = 1"
+        },
+        "edition_covers_owner_position_idx": {
+          "name": "edition_covers_owner_position_idx",
+          "columns": [
+            "edition_id",
+            "position"
+          ],
+          "isUnique": false
+        },
+        "edition_covers_primary_lookup_idx": {
+          "name": "edition_covers_primary_lookup_idx",
+          "columns": [
+            "edition_id",
+            "is_primary"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "edition_covers_edition_id_editions_id_fk": {
+          "name": "edition_covers_edition_id_editions_id_fk",
+          "tableFrom": "edition_covers",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edition_covers_cover_asset_id_cover_assets_id_fk": {
+          "name": "edition_covers_cover_asset_id_cover_assets_id_fk",
+          "tableFrom": "edition_covers",
+          "tableTo": "cover_assets",
+          "columnsFrom": [
+            "cover_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edition_covers_pk": {
+          "columns": [
+            "edition_id",
+            "cover_asset_id"
+          ],
+          "name": "edition_covers_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "edition_covers_position_ck": {
+          "name": "edition_covers_position_ck",
+          "value": "\"edition_covers\".\"position\" >= 0"
+        }
+      }
+    },
+    "edition_identifiers": {
+      "name": "edition_identifiers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheme": {
+          "name": "scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_normalized": {
+          "name": "value_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_display": {
+          "name": "value_display",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "edition_identifiers_value_uq": {
+          "name": "edition_identifiers_value_uq",
+          "columns": [
+            "scheme",
+            "value_normalized"
+          ],
+          "isUnique": true
+        },
+        "edition_identifiers_primary_uq": {
+          "name": "edition_identifiers_primary_uq",
+          "columns": [
+            "edition_id"
+          ],
+          "isUnique": true,
+          "where": "\"edition_identifiers\".\"is_primary\" = 1"
+        },
+        "edition_identifiers_owner_idx": {
+          "name": "edition_identifiers_owner_idx",
+          "columns": [
+            "edition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "edition_identifiers_edition_id_editions_id_fk": {
+          "name": "edition_identifiers_edition_id_editions_id_fk",
+          "tableFrom": "edition_identifiers",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "edition_identifiers_scheme_ck": {
+          "name": "edition_identifiers_scheme_ck",
+          "value": "\"edition_identifiers\".\"scheme\" in ('isbn10', 'isbn13')"
+        },
+        "edition_identifiers_value_ck": {
+          "name": "edition_identifiers_value_ck",
+          "value": "length(trim(\"edition_identifiers\".\"value_normalized\")) > 0"
+        }
+      }
+    },
+    "edition_languages": {
+      "name": "edition_languages",
+      "columns": {
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language_tag": {
+          "name": "language_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "edition_languages_position_uq": {
+          "name": "edition_languages_position_uq",
+          "columns": [
+            "edition_id",
+            "position"
+          ],
+          "isUnique": true
+        },
+        "edition_languages_owner_position_idx": {
+          "name": "edition_languages_owner_position_idx",
+          "columns": [
+            "edition_id",
+            "position"
+          ],
+          "isUnique": false
+        },
+        "edition_languages_language_edition_idx": {
+          "name": "edition_languages_language_edition_idx",
+          "columns": [
+            "language_tag",
+            "edition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "edition_languages_edition_id_editions_id_fk": {
+          "name": "edition_languages_edition_id_editions_id_fk",
+          "tableFrom": "edition_languages",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edition_languages_language_tag_languages_tag_fk": {
+          "name": "edition_languages_language_tag_languages_tag_fk",
+          "tableFrom": "edition_languages",
+          "tableTo": "languages",
+          "columnsFrom": [
+            "language_tag"
+          ],
+          "columnsTo": [
+            "tag"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edition_languages_pk": {
+          "columns": [
+            "edition_id",
+            "language_tag"
+          ],
+          "name": "edition_languages_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "edition_languages_position_ck": {
+          "name": "edition_languages_position_ck",
+          "value": "\"edition_languages\".\"position\" >= 0"
+        }
+      }
+    },
+    "edition_publishers": {
+      "name": "edition_publishers",
+      "columns": {
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "publisher_id": {
+          "name": "publisher_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "edition_publishers_position_uq": {
+          "name": "edition_publishers_position_uq",
+          "columns": [
+            "edition_id",
+            "position"
+          ],
+          "isUnique": true
+        },
+        "edition_publishers_owner_position_idx": {
+          "name": "edition_publishers_owner_position_idx",
+          "columns": [
+            "edition_id",
+            "position"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "edition_publishers_edition_id_editions_id_fk": {
+          "name": "edition_publishers_edition_id_editions_id_fk",
+          "tableFrom": "edition_publishers",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edition_publishers_publisher_id_publishers_id_fk": {
+          "name": "edition_publishers_publisher_id_publishers_id_fk",
+          "tableFrom": "edition_publishers",
+          "tableTo": "publishers",
+          "columnsFrom": [
+            "publisher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edition_publishers_pk": {
+          "columns": [
+            "edition_id",
+            "publisher_id"
+          ],
+          "name": "edition_publishers_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "edition_publishers_position_ck": {
+          "name": "edition_publishers_position_ck",
+          "value": "\"edition_publishers\".\"position\" >= 0"
+        },
+        "edition_publishers_role_ck": {
+          "name": "edition_publishers_role_ck",
+          "value": "\"edition_publishers\".\"role\" is null or \"edition_publishers\".\"role\" in ('publisher', 'co_publisher', 'imprint', 'distributor')"
+        }
+      }
+    },
+    "editions": {
+      "name": "editions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publication_date": {
+          "name": "publication_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publication_precision": {
+          "name": "publication_precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publication_sort_date": {
+          "name": "publication_sort_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pages": {
+          "name": "pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cataloged_at": {
+          "name": "cataloged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "editions_work_id_idx": {
+          "name": "editions_work_id_idx",
+          "columns": [
+            "work_id"
+          ],
+          "isUnique": false
+        },
+        "editions_publication_sort_work_idx": {
+          "name": "editions_publication_sort_work_idx",
+          "columns": [
+            "publication_sort_date",
+            "work_id"
+          ],
+          "isUnique": false
+        },
+        "editions_cataloged_work_idx": {
+          "name": "editions_cataloged_work_idx",
+          "columns": [
+            "cataloged_at",
+            "work_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "editions_work_id_works_id_fk": {
+          "name": "editions_work_id_works_id_fk",
+          "tableFrom": "editions",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "editions_title_ck": {
+          "name": "editions_title_ck",
+          "value": "\"editions\".\"title\" is null or length(trim(\"editions\".\"title\")) > 0"
+        },
+        "editions_subtitle_ck": {
+          "name": "editions_subtitle_ck",
+          "value": "\"editions\".\"subtitle\" is null or length(trim(\"editions\".\"subtitle\")) > 0"
+        },
+        "editions_format_ck": {
+          "name": "editions_format_ck",
+          "value": "\"editions\".\"format\" is null or \"editions\".\"format\" in ('hardcover', 'paperback', 'ebook', 'audiobook', 'other')"
+        },
+        "editions_pages_ck": {
+          "name": "editions_pages_ck",
+          "value": "\"editions\".\"pages\" is null or \"editions\".\"pages\" > 0"
+        },
+        "editions_publication_precision_ck": {
+          "name": "editions_publication_precision_ck",
+          "value": "\"editions\".\"publication_precision\" is null or \"editions\".\"publication_precision\" in ('year', 'month', 'day')"
+        },
+        "editions_publication_date_ck": {
+          "name": "editions_publication_date_ck",
+          "value": "(\n        \"editions\".\"publication_date\" is null\n        and \"editions\".\"publication_precision\" is null\n        and \"editions\".\"publication_sort_date\" is null\n      ) or (\n        \"editions\".\"publication_precision\" = 'year'\n        and length(\"editions\".\"publication_date\") = 4\n        and \"editions\".\"publication_sort_date\" = \"editions\".\"publication_date\" || '-01-01'\n      ) or (\n        \"editions\".\"publication_precision\" = 'month'\n        and length(\"editions\".\"publication_date\") = 7\n        and substr(\"editions\".\"publication_date\", 5, 1) = '-'\n        and \"editions\".\"publication_sort_date\" = \"editions\".\"publication_date\" || '-01'\n      ) or (\n        \"editions\".\"publication_precision\" = 'day'\n        and length(\"editions\".\"publication_date\") = 10\n        and substr(\"editions\".\"publication_date\", 5, 1) = '-'\n        and substr(\"editions\".\"publication_date\", 8, 1) = '-'\n        and \"editions\".\"publication_sort_date\" = \"editions\".\"publication_date\"\n      )"
+        }
+      }
+    },
+    "entity_aliases": {
+      "name": "entity_aliases",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_id": {
+          "name": "from_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_id": {
+          "name": "to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "entity_aliases_target_idx": {
+          "name": "entity_aliases_target_idx",
+          "columns": [
+            "entity_type",
+            "to_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "entity_aliases_pk": {
+          "columns": [
+            "entity_type",
+            "from_id"
+          ],
+          "name": "entity_aliases_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "entity_aliases_ck": {
+          "name": "entity_aliases_ck",
+          "value": "\"entity_aliases\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset')\n        and \"entity_aliases\".\"from_id\" <> \"entity_aliases\".\"to_id\"\n        and length(trim(\"entity_aliases\".\"reason\")) > 0"
+        }
+      }
+    },
+    "field_observations": {
+      "name": "field_observations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_json": {
+          "name": "value_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comparison_hash": {
+          "name": "comparison_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provenance_kind": {
+          "name": "provenance_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_modified_at": {
+          "name": "source_modified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retrieved_at": {
+          "name": "retrieved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mapping_confidence": {
+          "name": "mapping_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "derivation_name": {
+          "name": "derivation_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "derivation_version": {
+          "name": "derivation_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_ids_json": {
+          "name": "parent_ids_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "field_observations_identity_uq": {
+          "name": "field_observations_identity_uq",
+          "columns": [
+            "id"
+          ],
+          "isUnique": true
+        },
+        "field_observations_source_field_state_idx": {
+          "name": "field_observations_source_field_state_idx",
+          "columns": [
+            "source_record_id",
+            "field_key",
+            "state"
+          ],
+          "isUnique": false
+        },
+        "field_observations_target_field_idx": {
+          "name": "field_observations_target_field_idx",
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "field_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "field_observations_source_record_id_source_records_id_fk": {
+          "name": "field_observations_source_record_id_source_records_id_fk",
+          "tableFrom": "field_observations",
+          "tableTo": "source_records",
+          "columnsFrom": [
+            "source_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "field_observations_target_ck": {
+          "name": "field_observations_target_ck",
+          "value": "\"field_observations\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and \"field_observations\".\"field_key\" in ('work.preferred_title', 'work.description', 'work.first_publication_date', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')"
+        },
+        "field_observations_json_ck": {
+          "name": "field_observations_json_ck",
+          "value": "json_valid(\"field_observations\".\"value_json\") and (\"field_observations\".\"parent_ids_json\" is null or json_valid(\"field_observations\".\"parent_ids_json\"))"
+        },
+        "field_observations_hash_ck": {
+          "name": "field_observations_hash_ck",
+          "value": "length(\"field_observations\".\"comparison_hash\") = 64"
+        },
+        "field_observations_provenance_ck": {
+          "name": "field_observations_provenance_ck",
+          "value": "\"field_observations\".\"provenance_kind\" in ('curated', 'imported', 'derived', 'synthetic')"
+        },
+        "field_observations_state_ck": {
+          "name": "field_observations_state_ck",
+          "value": "\"field_observations\".\"state\" in ('active', 'stale', 'withdrawn', 'invalid')"
+        },
+        "field_observations_confidence_ck": {
+          "name": "field_observations_confidence_ck",
+          "value": "\"field_observations\".\"mapping_confidence\" between 0 and 1"
+        },
+        "field_observations_curated_ck": {
+          "name": "field_observations_curated_ck",
+          "value": "\"field_observations\".\"provenance_kind\" <> 'curated'\n        or (length(trim(\"field_observations\".\"actor_ref\")) > 0 and length(trim(\"field_observations\".\"reason\")) > 0)"
+        },
+        "field_observations_derived_ck": {
+          "name": "field_observations_derived_ck",
+          "value": "\"field_observations\".\"provenance_kind\" <> 'derived'\n        or (\n          length(trim(\"field_observations\".\"derivation_name\")) > 0\n          and length(trim(\"field_observations\".\"derivation_version\")) > 0\n          and json_valid(\"field_observations\".\"parent_ids_json\")\n        )"
+        }
+      }
+    },
+    "field_resolution_heads": {
+      "name": "field_resolution_heads",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolution_id": {
+          "name": "resolution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "field_resolution_heads_resolution_uq": {
+          "name": "field_resolution_heads_resolution_uq",
+          "columns": [
+            "resolution_id"
+          ],
+          "isUnique": true
+        },
+        "field_resolution_heads_lookup_idx": {
+          "name": "field_resolution_heads_lookup_idx",
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "field_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "field_resolution_heads_resolution_id_field_resolutions_id_fk": {
+          "name": "field_resolution_heads_resolution_id_field_resolutions_id_fk",
+          "tableFrom": "field_resolution_heads",
+          "tableTo": "field_resolutions",
+          "columnsFrom": [
+            "resolution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "field_resolution_heads_pk": {
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "field_key"
+          ],
+          "name": "field_resolution_heads_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "field_resolution_heads_target_ck": {
+          "name": "field_resolution_heads_target_ck",
+          "value": "\"field_resolution_heads\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and \"field_resolution_heads\".\"field_key\" in ('work.preferred_title', 'work.description', 'work.first_publication_date', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')"
+        }
+      }
+    },
+    "field_resolutions": {
+      "name": "field_resolutions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "selected_observation_id": {
+          "name": "selected_observation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "previous_resolution_id": {
+          "name": "previous_resolution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolver_version": {
+          "name": "resolver_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "field_resolutions_target_history_idx": {
+          "name": "field_resolutions_target_history_idx",
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "field_key",
+            "resolved_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "field_resolutions_selected_observation_id_field_observations_id_fk": {
+          "name": "field_resolutions_selected_observation_id_field_observations_id_fk",
+          "tableFrom": "field_resolutions",
+          "tableTo": "field_observations",
+          "columnsFrom": [
+            "selected_observation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "field_resolutions_previous_resolution_id_field_resolutions_id_fk": {
+          "name": "field_resolutions_previous_resolution_id_field_resolutions_id_fk",
+          "tableFrom": "field_resolutions",
+          "tableTo": "field_resolutions",
+          "columnsFrom": [
+            "previous_resolution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "field_resolutions_target_ck": {
+          "name": "field_resolutions_target_ck",
+          "value": "\"field_resolutions\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and \"field_resolutions\".\"field_key\" in ('work.preferred_title', 'work.description', 'work.first_publication_date', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')"
+        },
+        "field_resolutions_state_ck": {
+          "name": "field_resolutions_state_ck",
+          "value": "\"field_resolutions\".\"state\" in ('present', 'missing', 'conflicting', 'stale', 'withdrawn')"
+        },
+        "field_resolutions_selection_ck": {
+          "name": "field_resolutions_selection_ck",
+          "value": "(\n        \"field_resolutions\".\"state\" in ('present', 'stale')\n        and \"field_resolutions\".\"selected_observation_id\" is not null\n      ) or (\n        \"field_resolutions\".\"state\" in ('missing', 'conflicting', 'withdrawn')\n        and \"field_resolutions\".\"selected_observation_id\" is null\n      )"
+        },
+        "field_resolutions_nonempty_ck": {
+          "name": "field_resolutions_nonempty_ck",
+          "value": "length(trim(\"field_resolutions\".\"reason\")) > 0\n        and length(trim(\"field_resolutions\".\"actor_ref\")) > 0\n        and length(trim(\"field_resolutions\".\"resolver_version\")) > 0"
+        }
+      }
+    },
+    "languages": {
+      "name": "languages",
+      "columns": {
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "languages_nonempty_ck": {
+          "name": "languages_nonempty_ck",
+          "value": "length(trim(\"languages\".\"tag\")) > 0 and length(trim(\"languages\".\"label\")) > 0"
+        }
+      }
+    },
+    "metadata_sources": {
+      "name": "metadata_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "terms_url": {
+          "name": "terms_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attribution_url": {
+          "name": "attribution_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approval_state": {
+          "name": "approval_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_policy": {
+          "name": "metadata_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "asset_policy": {
+          "name": "asset_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_policy": {
+          "name": "payload_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_interval_ms": {
+          "name": "refresh_interval_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "metadata_sources_key_uq": {
+          "name": "metadata_sources_key_uq",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "metadata_sources_nonempty_ck": {
+          "name": "metadata_sources_nonempty_ck",
+          "value": "length(trim(\"metadata_sources\".\"key\")) > 0 and length(trim(\"metadata_sources\".\"name\")) > 0"
+        },
+        "metadata_sources_approval_state_ck": {
+          "name": "metadata_sources_approval_state_ck",
+          "value": "\"metadata_sources\".\"approval_state\" in ('pending', 'approved', 'suspended', 'retired')"
+        },
+        "metadata_sources_payload_policy_ck": {
+          "name": "metadata_sources_payload_policy_ck",
+          "value": "\"metadata_sources\".\"payload_policy\" in ('none', 'selected_fields', 'full')"
+        },
+        "metadata_sources_policy_json_ck": {
+          "name": "metadata_sources_policy_json_ck",
+          "value": "json_valid(\"metadata_sources\".\"metadata_policy\") and json_valid(\"metadata_sources\".\"asset_policy\")"
+        },
+        "metadata_sources_approved_review_ck": {
+          "name": "metadata_sources_approved_review_ck",
+          "value": "\"metadata_sources\".\"approval_state\" <> 'approved' or \"metadata_sources\".\"reviewed_at\" is not null"
+        },
+        "metadata_sources_refresh_ck": {
+          "name": "metadata_sources_refresh_ck",
+          "value": "\"metadata_sources\".\"refresh_interval_ms\" is null or \"metadata_sources\".\"refresh_interval_ms\" > 0"
+        }
+      }
+    },
+    "publishers": {
+      "name": "publishers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "publishers_name_nonempty_ck": {
+          "name": "publishers_name_nonempty_ck",
+          "value": "length(trim(\"publishers\".\"display_name\")) > 0"
+        }
+      }
+    },
+    "source_record_links": {
+      "name": "source_record_links",
+      "columns": {
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "match_kind": {
+          "name": "match_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mapping_confidence": {
+          "name": "mapping_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "source_record_links_entity_idx": {
+          "name": "source_record_links_entity_idx",
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "state"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "source_record_links_source_record_id_source_records_id_fk": {
+          "name": "source_record_links_source_record_id_source_records_id_fk",
+          "tableFrom": "source_record_links",
+          "tableTo": "source_records",
+          "columnsFrom": [
+            "source_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "source_record_links_pk": {
+          "columns": [
+            "source_record_id",
+            "entity_type",
+            "entity_id"
+          ],
+          "name": "source_record_links_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "source_record_links_entity_type_ck": {
+          "name": "source_record_links_entity_type_ck",
+          "value": "\"source_record_links\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset')"
+        },
+        "source_record_links_match_kind_ck": {
+          "name": "source_record_links_match_kind_ck",
+          "value": "\"source_record_links\".\"match_kind\" in ('exact_identifier', 'source_relationship', 'curated', 'candidate')"
+        },
+        "source_record_links_state_ck": {
+          "name": "source_record_links_state_ck",
+          "value": "\"source_record_links\".\"state\" in ('active', 'candidate', 'rejected')"
+        },
+        "source_record_links_confidence_ck": {
+          "name": "source_record_links_confidence_ck",
+          "value": "\"source_record_links\".\"mapping_confidence\" between 0 and 1"
+        },
+        "source_record_links_actor_ck": {
+          "name": "source_record_links_actor_ck",
+          "value": "(\n        \"source_record_links\".\"match_kind\" <> 'curated' and \"source_record_links\".\"state\" <> 'rejected'\n      ) or (\n        length(trim(\"source_record_links\".\"actor_ref\")) > 0 and length(trim(\"source_record_links\".\"reason\")) > 0\n      )"
+        }
+      }
+    },
+    "source_records": {
+      "name": "source_records",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_modified_at": {
+          "name": "source_modified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retrieved_at": {
+          "name": "retrieved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "importer_version": {
+          "name": "importer_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_row_hash": {
+          "name": "source_row_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "source_records_source_key_uq": {
+          "name": "source_records_source_key_uq",
+          "columns": [
+            "source_id",
+            "record_key"
+          ],
+          "isUnique": true
+        },
+        "source_records_refresh_idx": {
+          "name": "source_records_refresh_idx",
+          "columns": [
+            "source_id",
+            "state",
+            "retrieved_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "source_records_source_id_metadata_sources_id_fk": {
+          "name": "source_records_source_id_metadata_sources_id_fk",
+          "tableFrom": "source_records",
+          "tableTo": "metadata_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "source_records_key_nonempty_ck": {
+          "name": "source_records_key_nonempty_ck",
+          "value": "length(trim(\"source_records\".\"record_key\")) > 0"
+        },
+        "source_records_state_ck": {
+          "name": "source_records_state_ck",
+          "value": "\"source_records\".\"state\" in ('active', 'withdrawn', 'deleted')"
+        },
+        "source_records_payload_json_ck": {
+          "name": "source_records_payload_json_ck",
+          "value": "\"source_records\".\"payload_json\" is null or json_valid(\"source_records\".\"payload_json\")"
+        },
+        "source_records_import_hash_ck": {
+          "name": "source_records_import_hash_ck",
+          "value": "(\"source_records\".\"importer_version\" is null and \"source_records\".\"source_row_hash\" is null)\n        or (length(trim(\"source_records\".\"importer_version\")) > 0 and length(\"source_records\".\"source_row_hash\") = 64)"
+        }
+      }
+    },
+    "work_authors": {
+      "name": "work_authors",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'author'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "work_authors_position_uq": {
+          "name": "work_authors_position_uq",
+          "columns": [
+            "work_id",
+            "position"
+          ],
+          "isUnique": true
+        },
+        "work_authors_owner_position_idx": {
+          "name": "work_authors_owner_position_idx",
+          "columns": [
+            "work_id",
+            "position"
+          ],
+          "isUnique": false
+        },
+        "work_authors_author_work_idx": {
+          "name": "work_authors_author_work_idx",
+          "columns": [
+            "author_id",
+            "work_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "work_authors_work_id_works_id_fk": {
+          "name": "work_authors_work_id_works_id_fk",
+          "tableFrom": "work_authors",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_authors_author_id_authors_id_fk": {
+          "name": "work_authors_author_id_authors_id_fk",
+          "tableFrom": "work_authors",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "work_authors_pk": {
+          "columns": [
+            "work_id",
+            "author_id",
+            "role"
+          ],
+          "name": "work_authors_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "work_authors_role_ck": {
+          "name": "work_authors_role_ck",
+          "value": "\"work_authors\".\"role\" in ('author', 'editor', 'translator', 'illustrator')"
+        },
+        "work_authors_position_ck": {
+          "name": "work_authors_position_ck",
+          "value": "\"work_authors\".\"position\" >= 0"
+        }
+      }
+    },
+    "work_categories": {
+      "name": "work_categories",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "work_categories_position_uq": {
+          "name": "work_categories_position_uq",
+          "columns": [
+            "work_id",
+            "position"
+          ],
+          "isUnique": true
+        },
+        "work_categories_primary_uq": {
+          "name": "work_categories_primary_uq",
+          "columns": [
+            "work_id"
+          ],
+          "isUnique": true,
+          "where": "\"work_categories\".\"is_primary\" = 1"
+        },
+        "work_categories_owner_position_idx": {
+          "name": "work_categories_owner_position_idx",
+          "columns": [
+            "work_id",
+            "position"
+          ],
+          "isUnique": false
+        },
+        "work_categories_category_work_idx": {
+          "name": "work_categories_category_work_idx",
+          "columns": [
+            "category_id",
+            "work_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "work_categories_work_id_works_id_fk": {
+          "name": "work_categories_work_id_works_id_fk",
+          "tableFrom": "work_categories",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_categories_category_id_categories_id_fk": {
+          "name": "work_categories_category_id_categories_id_fk",
+          "tableFrom": "work_categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "work_categories_pk": {
+          "columns": [
+            "work_id",
+            "category_id"
+          ],
+          "name": "work_categories_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "work_categories_position_ck": {
+          "name": "work_categories_position_ck",
+          "value": "\"work_categories\".\"position\" >= 0"
+        }
+      }
+    },
+    "works": {
+      "name": "works",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preferred_title": {
+          "name": "preferred_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_title": {
+          "name": "sort_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_publication_date": {
+          "name": "first_publication_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_publication_precision": {
+          "name": "first_publication_precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_publication_sort_date": {
+          "name": "first_publication_sort_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferred_edition_id": {
+          "name": "preferred_edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "works_sort_title_id_idx": {
+          "name": "works_sort_title_id_idx",
+          "columns": [
+            "sort_title",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "works_preferred_edition_idx": {
+          "name": "works_preferred_edition_idx",
+          "columns": [
+            "preferred_edition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "works_preferred_edition_id_editions_id_fk": {
+          "name": "works_preferred_edition_id_editions_id_fk",
+          "tableFrom": "works",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "preferred_edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "works_titles_nonempty_ck": {
+          "name": "works_titles_nonempty_ck",
+          "value": "length(trim(\"works\".\"preferred_title\")) > 0 and length(trim(\"works\".\"sort_title\")) > 0"
+        },
+        "works_first_publication_precision_ck": {
+          "name": "works_first_publication_precision_ck",
+          "value": "\"works\".\"first_publication_precision\" is null or \"works\".\"first_publication_precision\" in ('year', 'month', 'day')"
+        },
+        "works_first_publication_date_ck": {
+          "name": "works_first_publication_date_ck",
+          "value": "(\n        \"works\".\"first_publication_date\" is null\n        and \"works\".\"first_publication_precision\" is null\n        and \"works\".\"first_publication_sort_date\" is null\n      ) or (\n        \"works\".\"first_publication_date\" is not null\n        and \"works\".\"first_publication_precision\" is not null\n        and \"works\".\"first_publication_sort_date\" is not null\n        and (\n          (\n            \"works\".\"first_publication_precision\" = 'year'\n            and length(\"works\".\"first_publication_date\") = 4\n            and \"works\".\"first_publication_sort_date\" = \"works\".\"first_publication_date\" || '-01-01'\n          ) or (\n            \"works\".\"first_publication_precision\" = 'month'\n            and length(\"works\".\"first_publication_date\") = 7\n            and substr(\"works\".\"first_publication_date\", 5, 1) = '-'\n            and \"works\".\"first_publication_sort_date\" = \"works\".\"first_publication_date\" || '-01'\n          ) or (\n            \"works\".\"first_publication_precision\" = 'day'\n            and length(\"works\".\"first_publication_date\") = 10\n            and substr(\"works\".\"first_publication_date\", 5, 1) = '-'\n            and substr(\"works\".\"first_publication_date\", 8, 1) = '-'\n            and \"works\".\"first_publication_sort_date\" = \"works\".\"first_publication_date\"\n          )\n        )\n      )"
+        }
+      }
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1785319005748,
       "tag": "0007_milky_omega_red",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1785322084944,
+      "tag": "0008_aspiring_karma",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/pg/0010_clammy_cerebro.sql
+++ b/drizzle/pg/0010_clammy_cerebro.sql
@@ -1,0 +1,140 @@
+CREATE TABLE "cover_candidates" (
+	"id" text PRIMARY KEY NOT NULL,
+	"work_id" text NOT NULL,
+	"edition_id" text,
+	"source_record_id" text NOT NULL,
+	"representation_type" text NOT NULL,
+	"identity_match_kind" text NOT NULL,
+	"identity_evidence_json" jsonb NOT NULL,
+	"permission_state" text NOT NULL,
+	"rights_basis" text,
+	"attribution_text" text,
+	"attribution_url" text,
+	"source_url" text NOT NULL,
+	"source_revision" text NOT NULL,
+	"source_policy_version" text NOT NULL,
+	"object_key" text NOT NULL,
+	"transformation_history_json" jsonb NOT NULL,
+	"created_at" bigint NOT NULL,
+	CONSTRAINT "cover_candidates_representation_ck" CHECK ("cover_candidates"."representation_type" in ('selected_edition', 'work_representative')
+        and (
+          ("cover_candidates"."representation_type" = 'selected_edition' and "cover_candidates"."edition_id" is not null)
+          or ("cover_candidates"."representation_type" = 'work_representative' and "cover_candidates"."edition_id" is null)
+        )),
+	CONSTRAINT "cover_candidates_identity_ck" CHECK ("cover_candidates"."identity_match_kind" in ('exact_isbn', 'provider_edition_relation', 'approved_strong_edition_tuple', 'provider_work_relation', 'curated_work_relation', 'title_creator_candidate', 'conflicting')),
+	CONSTRAINT "cover_candidates_permission_ck" CHECK ("cover_candidates"."permission_state" in ('approved', 'pending', 'denied')),
+	CONSTRAINT "cover_candidates_nonempty_ck" CHECK (length(trim("cover_candidates"."source_url")) > 0
+        and length(trim("cover_candidates"."source_revision")) > 0
+        and length(trim("cover_candidates"."source_policy_version")) > 0
+        and length(trim("cover_candidates"."object_key")) > 0
+        and substring("cover_candidates"."object_key" from 1 for 8) = '/covers/')
+);
+--> statement-breakpoint
+CREATE TABLE "cover_decision_heads" (
+	"candidate_id" text PRIMARY KEY NOT NULL,
+	"decision_id" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "cover_decisions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"candidate_id" text NOT NULL,
+	"inspection_id" text NOT NULL,
+	"state" text NOT NULL,
+	"gate_codes_json" jsonb NOT NULL,
+	"warning_codes_json" jsonb NOT NULL,
+	"reviewer_ref" text,
+	"review_reason" text,
+	"purge_state" text NOT NULL,
+	"previous_decision_id" text,
+	"policy_version" text NOT NULL,
+	"decided_at" bigint NOT NULL,
+	CONSTRAINT "cover_decisions_state_ck" CHECK ("cover_decisions"."state" in ('review_required', 'eligible', 'rejected', 'withdrawn')),
+	CONSTRAINT "cover_decisions_purge_ck" CHECK ("cover_decisions"."purge_state" in ('not_required', 'pending', 'completed', 'failed')),
+	CONSTRAINT "cover_decisions_review_ck" CHECK (("cover_decisions"."reviewer_ref" is null and "cover_decisions"."review_reason" is null)
+        or (
+          length(trim("cover_decisions"."reviewer_ref")) > 0
+          and length(trim("cover_decisions"."review_reason")) > 0
+        )),
+	CONSTRAINT "cover_decisions_policy_ck" CHECK (length(trim("cover_decisions"."policy_version")) > 0)
+);
+--> statement-breakpoint
+CREATE TABLE "cover_inspections" (
+	"id" text PRIMARY KEY NOT NULL,
+	"candidate_id" text NOT NULL,
+	"media_type" text,
+	"byte_size" bigint NOT NULL,
+	"width" integer,
+	"height" integer,
+	"aspect_ratio" double precision,
+	"checksum" text NOT NULL,
+	"decode_result" text NOT NULL,
+	"flags_json" jsonb NOT NULL,
+	"quality_score" double precision NOT NULL,
+	"duplicate_of_candidate_id" text,
+	"inspection_version" text NOT NULL,
+	"inspected_at" bigint NOT NULL,
+	CONSTRAINT "cover_inspections_decode_ck" CHECK ("cover_inspections"."decode_result" in ('decoded', 'corrupt', 'unsupported')
+        and (
+          ("cover_inspections"."decode_result" = 'decoded'
+            and "cover_inspections"."media_type" is not null
+            and "cover_inspections"."width" > 0
+            and "cover_inspections"."height" > 0
+            and "cover_inspections"."aspect_ratio" > 0)
+          or ("cover_inspections"."decode_result" <> 'decoded'
+            and "cover_inspections"."width" is null
+            and "cover_inspections"."height" is null
+            and "cover_inspections"."aspect_ratio" is null)
+        )),
+	CONSTRAINT "cover_inspections_values_ck" CHECK ("cover_inspections"."byte_size" > 0
+        and length("cover_inspections"."checksum") = 64
+        and "cover_inspections"."quality_score" between 0 and 100
+        and length(trim("cover_inspections"."inspection_version")) > 0)
+);
+--> statement-breakpoint
+CREATE TABLE "cover_projection_heads" (
+	"work_id" text PRIMARY KEY NOT NULL,
+	"projection_id" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "cover_projections" (
+	"id" text PRIMARY KEY NOT NULL,
+	"work_id" text NOT NULL,
+	"candidate_id" text,
+	"state" text NOT NULL,
+	"previous_projection_id" text,
+	"reason_code" text NOT NULL,
+	"actor_ref" text NOT NULL,
+	"policy_version" text NOT NULL,
+	"projected_at" bigint NOT NULL,
+	CONSTRAINT "cover_projections_state_ck" CHECK ("cover_projections"."state" in ('selected', 'placeholder', 'withdrawn', 'rolled_back')),
+	CONSTRAINT "cover_projections_selection_ck" CHECK (("cover_projections"."state" in ('selected', 'rolled_back') and "cover_projections"."candidate_id" is not null)
+        or ("cover_projections"."state" in ('placeholder', 'withdrawn') and "cover_projections"."candidate_id" is null)),
+	CONSTRAINT "cover_projections_nonempty_ck" CHECK (length(trim("cover_projections"."reason_code")) > 0
+        and length(trim("cover_projections"."actor_ref")) > 0
+        and length(trim("cover_projections"."policy_version")) > 0)
+);
+--> statement-breakpoint
+ALTER TABLE "cover_candidates" ADD CONSTRAINT "cover_candidates_work_id_works_id_fk" FOREIGN KEY ("work_id") REFERENCES "public"."works"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "cover_candidates" ADD CONSTRAINT "cover_candidates_edition_id_editions_id_fk" FOREIGN KEY ("edition_id") REFERENCES "public"."editions"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "cover_candidates" ADD CONSTRAINT "cover_candidates_source_record_id_source_records_id_fk" FOREIGN KEY ("source_record_id") REFERENCES "public"."source_records"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "cover_decision_heads" ADD CONSTRAINT "cover_decision_heads_candidate_id_cover_candidates_id_fk" FOREIGN KEY ("candidate_id") REFERENCES "public"."cover_candidates"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "cover_decision_heads" ADD CONSTRAINT "cover_decision_heads_decision_id_cover_decisions_id_fk" FOREIGN KEY ("decision_id") REFERENCES "public"."cover_decisions"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "cover_decisions" ADD CONSTRAINT "cover_decisions_candidate_id_cover_candidates_id_fk" FOREIGN KEY ("candidate_id") REFERENCES "public"."cover_candidates"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "cover_decisions" ADD CONSTRAINT "cover_decisions_inspection_id_cover_inspections_id_fk" FOREIGN KEY ("inspection_id") REFERENCES "public"."cover_inspections"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "cover_decisions" ADD CONSTRAINT "cover_decisions_previous_decision_id_cover_decisions_id_fk" FOREIGN KEY ("previous_decision_id") REFERENCES "public"."cover_decisions"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "cover_inspections" ADD CONSTRAINT "cover_inspections_candidate_id_cover_candidates_id_fk" FOREIGN KEY ("candidate_id") REFERENCES "public"."cover_candidates"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "cover_inspections" ADD CONSTRAINT "cover_inspections_duplicate_of_candidate_id_cover_candidates_id_fk" FOREIGN KEY ("duplicate_of_candidate_id") REFERENCES "public"."cover_candidates"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "cover_projection_heads" ADD CONSTRAINT "cover_projection_heads_work_id_works_id_fk" FOREIGN KEY ("work_id") REFERENCES "public"."works"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "cover_projection_heads" ADD CONSTRAINT "cover_projection_heads_projection_id_cover_projections_id_fk" FOREIGN KEY ("projection_id") REFERENCES "public"."cover_projections"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "cover_projections" ADD CONSTRAINT "cover_projections_work_id_works_id_fk" FOREIGN KEY ("work_id") REFERENCES "public"."works"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "cover_projections" ADD CONSTRAINT "cover_projections_candidate_id_cover_candidates_id_fk" FOREIGN KEY ("candidate_id") REFERENCES "public"."cover_candidates"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "cover_projections" ADD CONSTRAINT "cover_projections_previous_projection_id_cover_projections_id_fk" FOREIGN KEY ("previous_projection_id") REFERENCES "public"."cover_projections"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "cover_candidates_work_created_idx" ON "cover_candidates" USING btree ("work_id","created_at");--> statement-breakpoint
+CREATE INDEX "cover_candidates_source_record_idx" ON "cover_candidates" USING btree ("source_record_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "cover_decision_heads_decision_uq" ON "cover_decision_heads" USING btree ("decision_id");--> statement-breakpoint
+CREATE INDEX "cover_decisions_candidate_history_idx" ON "cover_decisions" USING btree ("candidate_id","decided_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "cover_inspections_identity_uq" ON "cover_inspections" USING btree ("candidate_id","checksum","inspection_version");--> statement-breakpoint
+CREATE INDEX "cover_inspections_checksum_idx" ON "cover_inspections" USING btree ("checksum");--> statement-breakpoint
+CREATE INDEX "cover_inspections_candidate_idx" ON "cover_inspections" USING btree ("candidate_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "cover_projection_heads_projection_uq" ON "cover_projection_heads" USING btree ("projection_id");--> statement-breakpoint
+CREATE INDEX "cover_projections_work_history_idx" ON "cover_projections" USING btree ("work_id","projected_at");

--- a/drizzle/pg/meta/0010_snapshot.json
+++ b/drizzle/pg/meta/0010_snapshot.json
@@ -1,0 +1,4372 @@
+{
+  "id": "dbe37d76-f1da-42ce-a7d0-2d8a769ca387",
+  "prevId": "e1dc8dbf-eaf7-44ef-85a9-4e44280ce5f7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.authors": {
+      "name": "authors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_name": {
+          "name": "sort_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "authors_sort_name_idx": {
+          "name": "authors_sort_name_idx",
+          "columns": [
+            {
+              "expression": "sort_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "authors_name_nonempty_ck": {
+          "name": "authors_name_nonempty_ck",
+          "value": "length(trim(\"authors\".\"display_name\")) > 0"
+        },
+        "authors_sort_name_ck": {
+          "name": "authors_sort_name_ck",
+          "value": "\"authors\".\"sort_name\" is null or length(trim(\"authors\".\"sort_name\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.catalog_change_events": {
+      "name": "catalog_change_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "catalog_change_events_type_created_idx": {
+          "name": "catalog_change_events_type_created_idx",
+          "columns": [
+            {
+              "expression": "change_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_change_events_type_ck": {
+          "name": "catalog_change_events_type_ck",
+          "value": "\"catalog_change_events\".\"change_type\" in ('work_merge', 'work_split', 'edition_reassignment')"
+        },
+        "catalog_change_events_nonempty_ck": {
+          "name": "catalog_change_events_nonempty_ck",
+          "value": "length(trim(\"catalog_change_events\".\"actor_ref\")) > 0 and length(trim(\"catalog_change_events\".\"reason\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "categories_slug_uq": {
+          "name": "categories_slug_uq",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "categories_nonempty_ck": {
+          "name": "categories_nonempty_ck",
+          "value": "length(trim(\"categories\".\"slug\")) > 0 and length(trim(\"categories\".\"label\")) > 0"
+        },
+        "categories_status_ck": {
+          "name": "categories_status_ck",
+          "value": "\"categories\".\"status\" in ('active', 'retired')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.cover_assets": {
+      "name": "cover_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_policy_id": {
+          "name": "source_policy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cover_assets_object_key_uq": {
+          "name": "cover_assets_object_key_uq",
+          "columns": [
+            {
+              "expression": "object_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cover_assets_source_policy_id_metadata_sources_id_fk": {
+          "name": "cover_assets_source_policy_id_metadata_sources_id_fk",
+          "tableFrom": "cover_assets",
+          "tableTo": "metadata_sources",
+          "columnsFrom": [
+            "source_policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cover_assets_object_key_ck": {
+          "name": "cover_assets_object_key_ck",
+          "value": "length(trim(\"cover_assets\".\"object_key\")) > 0 and substring(\"cover_assets\".\"object_key\" from 1 for 8) = '/covers/'"
+        },
+        "cover_assets_state_ck": {
+          "name": "cover_assets_state_ck",
+          "value": "\"cover_assets\".\"state\" in ('available', 'missing', 'withdrawn', 'failed')"
+        },
+        "cover_assets_dimensions_ck": {
+          "name": "cover_assets_dimensions_ck",
+          "value": "(\"cover_assets\".\"width\" is null or \"cover_assets\".\"width\" > 0)\n        and (\"cover_assets\".\"height\" is null or \"cover_assets\".\"height\" > 0)\n        and (\"cover_assets\".\"bytes\" is null or \"cover_assets\".\"bytes\" > 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.cover_candidates": {
+      "name": "cover_candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "representation_type": {
+          "name": "representation_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_match_kind": {
+          "name": "identity_match_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_evidence_json": {
+          "name": "identity_evidence_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_state": {
+          "name": "permission_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rights_basis": {
+          "name": "rights_basis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution_text": {
+          "name": "attribution_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution_url": {
+          "name": "attribution_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_policy_version": {
+          "name": "source_policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transformation_history_json": {
+          "name": "transformation_history_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cover_candidates_work_created_idx": {
+          "name": "cover_candidates_work_created_idx",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cover_candidates_source_record_idx": {
+          "name": "cover_candidates_source_record_idx",
+          "columns": [
+            {
+              "expression": "source_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cover_candidates_work_id_works_id_fk": {
+          "name": "cover_candidates_work_id_works_id_fk",
+          "tableFrom": "cover_candidates",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cover_candidates_edition_id_editions_id_fk": {
+          "name": "cover_candidates_edition_id_editions_id_fk",
+          "tableFrom": "cover_candidates",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cover_candidates_source_record_id_source_records_id_fk": {
+          "name": "cover_candidates_source_record_id_source_records_id_fk",
+          "tableFrom": "cover_candidates",
+          "tableTo": "source_records",
+          "columnsFrom": [
+            "source_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cover_candidates_representation_ck": {
+          "name": "cover_candidates_representation_ck",
+          "value": "\"cover_candidates\".\"representation_type\" in ('selected_edition', 'work_representative')\n        and (\n          (\"cover_candidates\".\"representation_type\" = 'selected_edition' and \"cover_candidates\".\"edition_id\" is not null)\n          or (\"cover_candidates\".\"representation_type\" = 'work_representative' and \"cover_candidates\".\"edition_id\" is null)\n        )"
+        },
+        "cover_candidates_identity_ck": {
+          "name": "cover_candidates_identity_ck",
+          "value": "\"cover_candidates\".\"identity_match_kind\" in ('exact_isbn', 'provider_edition_relation', 'approved_strong_edition_tuple', 'provider_work_relation', 'curated_work_relation', 'title_creator_candidate', 'conflicting')"
+        },
+        "cover_candidates_permission_ck": {
+          "name": "cover_candidates_permission_ck",
+          "value": "\"cover_candidates\".\"permission_state\" in ('approved', 'pending', 'denied')"
+        },
+        "cover_candidates_nonempty_ck": {
+          "name": "cover_candidates_nonempty_ck",
+          "value": "length(trim(\"cover_candidates\".\"source_url\")) > 0\n        and length(trim(\"cover_candidates\".\"source_revision\")) > 0\n        and length(trim(\"cover_candidates\".\"source_policy_version\")) > 0\n        and length(trim(\"cover_candidates\".\"object_key\")) > 0\n        and substring(\"cover_candidates\".\"object_key\" from 1 for 8) = '/covers/'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.cover_decision_heads": {
+      "name": "cover_decision_heads",
+      "schema": "",
+      "columns": {
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "decision_id": {
+          "name": "decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cover_decision_heads_decision_uq": {
+          "name": "cover_decision_heads_decision_uq",
+          "columns": [
+            {
+              "expression": "decision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cover_decision_heads_candidate_id_cover_candidates_id_fk": {
+          "name": "cover_decision_heads_candidate_id_cover_candidates_id_fk",
+          "tableFrom": "cover_decision_heads",
+          "tableTo": "cover_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cover_decision_heads_decision_id_cover_decisions_id_fk": {
+          "name": "cover_decision_heads_decision_id_cover_decisions_id_fk",
+          "tableFrom": "cover_decision_heads",
+          "tableTo": "cover_decisions",
+          "columnsFrom": [
+            "decision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cover_decisions": {
+      "name": "cover_decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gate_codes_json": {
+          "name": "gate_codes_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "warning_codes_json": {
+          "name": "warning_codes_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer_ref": {
+          "name": "reviewer_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_reason": {
+          "name": "review_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purge_state": {
+          "name": "purge_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_decision_id": {
+          "name": "previous_decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cover_decisions_candidate_history_idx": {
+          "name": "cover_decisions_candidate_history_idx",
+          "columns": [
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cover_decisions_candidate_id_cover_candidates_id_fk": {
+          "name": "cover_decisions_candidate_id_cover_candidates_id_fk",
+          "tableFrom": "cover_decisions",
+          "tableTo": "cover_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cover_decisions_inspection_id_cover_inspections_id_fk": {
+          "name": "cover_decisions_inspection_id_cover_inspections_id_fk",
+          "tableFrom": "cover_decisions",
+          "tableTo": "cover_inspections",
+          "columnsFrom": [
+            "inspection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cover_decisions_previous_decision_id_cover_decisions_id_fk": {
+          "name": "cover_decisions_previous_decision_id_cover_decisions_id_fk",
+          "tableFrom": "cover_decisions",
+          "tableTo": "cover_decisions",
+          "columnsFrom": [
+            "previous_decision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cover_decisions_state_ck": {
+          "name": "cover_decisions_state_ck",
+          "value": "\"cover_decisions\".\"state\" in ('review_required', 'eligible', 'rejected', 'withdrawn')"
+        },
+        "cover_decisions_purge_ck": {
+          "name": "cover_decisions_purge_ck",
+          "value": "\"cover_decisions\".\"purge_state\" in ('not_required', 'pending', 'completed', 'failed')"
+        },
+        "cover_decisions_review_ck": {
+          "name": "cover_decisions_review_ck",
+          "value": "(\"cover_decisions\".\"reviewer_ref\" is null and \"cover_decisions\".\"review_reason\" is null)\n        or (\n          length(trim(\"cover_decisions\".\"reviewer_ref\")) > 0\n          and length(trim(\"cover_decisions\".\"review_reason\")) > 0\n        )"
+        },
+        "cover_decisions_policy_ck": {
+          "name": "cover_decisions_policy_ck",
+          "value": "length(trim(\"cover_decisions\".\"policy_version\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.cover_inspections": {
+      "name": "cover_inspections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aspect_ratio": {
+          "name": "aspect_ratio",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decode_result": {
+          "name": "decode_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flags_json": {
+          "name": "flags_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duplicate_of_candidate_id": {
+          "name": "duplicate_of_candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inspection_version": {
+          "name": "inspection_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inspected_at": {
+          "name": "inspected_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cover_inspections_identity_uq": {
+          "name": "cover_inspections_identity_uq",
+          "columns": [
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checksum",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "inspection_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cover_inspections_checksum_idx": {
+          "name": "cover_inspections_checksum_idx",
+          "columns": [
+            {
+              "expression": "checksum",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cover_inspections_candidate_idx": {
+          "name": "cover_inspections_candidate_idx",
+          "columns": [
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cover_inspections_candidate_id_cover_candidates_id_fk": {
+          "name": "cover_inspections_candidate_id_cover_candidates_id_fk",
+          "tableFrom": "cover_inspections",
+          "tableTo": "cover_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cover_inspections_duplicate_of_candidate_id_cover_candidates_id_fk": {
+          "name": "cover_inspections_duplicate_of_candidate_id_cover_candidates_id_fk",
+          "tableFrom": "cover_inspections",
+          "tableTo": "cover_candidates",
+          "columnsFrom": [
+            "duplicate_of_candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cover_inspections_decode_ck": {
+          "name": "cover_inspections_decode_ck",
+          "value": "\"cover_inspections\".\"decode_result\" in ('decoded', 'corrupt', 'unsupported')\n        and (\n          (\"cover_inspections\".\"decode_result\" = 'decoded'\n            and \"cover_inspections\".\"media_type\" is not null\n            and \"cover_inspections\".\"width\" > 0\n            and \"cover_inspections\".\"height\" > 0\n            and \"cover_inspections\".\"aspect_ratio\" > 0)\n          or (\"cover_inspections\".\"decode_result\" <> 'decoded'\n            and \"cover_inspections\".\"width\" is null\n            and \"cover_inspections\".\"height\" is null\n            and \"cover_inspections\".\"aspect_ratio\" is null)\n        )"
+        },
+        "cover_inspections_values_ck": {
+          "name": "cover_inspections_values_ck",
+          "value": "\"cover_inspections\".\"byte_size\" > 0\n        and length(\"cover_inspections\".\"checksum\") = 64\n        and \"cover_inspections\".\"quality_score\" between 0 and 100\n        and length(trim(\"cover_inspections\".\"inspection_version\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.cover_projection_heads": {
+      "name": "cover_projection_heads",
+      "schema": "",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "projection_id": {
+          "name": "projection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cover_projection_heads_projection_uq": {
+          "name": "cover_projection_heads_projection_uq",
+          "columns": [
+            {
+              "expression": "projection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cover_projection_heads_work_id_works_id_fk": {
+          "name": "cover_projection_heads_work_id_works_id_fk",
+          "tableFrom": "cover_projection_heads",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cover_projection_heads_projection_id_cover_projections_id_fk": {
+          "name": "cover_projection_heads_projection_id_cover_projections_id_fk",
+          "tableFrom": "cover_projection_heads",
+          "tableTo": "cover_projections",
+          "columnsFrom": [
+            "projection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cover_projections": {
+      "name": "cover_projections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_projection_id": {
+          "name": "previous_projection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projected_at": {
+          "name": "projected_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cover_projections_work_history_idx": {
+          "name": "cover_projections_work_history_idx",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "projected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cover_projections_work_id_works_id_fk": {
+          "name": "cover_projections_work_id_works_id_fk",
+          "tableFrom": "cover_projections",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cover_projections_candidate_id_cover_candidates_id_fk": {
+          "name": "cover_projections_candidate_id_cover_candidates_id_fk",
+          "tableFrom": "cover_projections",
+          "tableTo": "cover_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cover_projections_previous_projection_id_cover_projections_id_fk": {
+          "name": "cover_projections_previous_projection_id_cover_projections_id_fk",
+          "tableFrom": "cover_projections",
+          "tableTo": "cover_projections",
+          "columnsFrom": [
+            "previous_projection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cover_projections_state_ck": {
+          "name": "cover_projections_state_ck",
+          "value": "\"cover_projections\".\"state\" in ('selected', 'placeholder', 'withdrawn', 'rolled_back')"
+        },
+        "cover_projections_selection_ck": {
+          "name": "cover_projections_selection_ck",
+          "value": "(\"cover_projections\".\"state\" in ('selected', 'rolled_back') and \"cover_projections\".\"candidate_id\" is not null)\n        or (\"cover_projections\".\"state\" in ('placeholder', 'withdrawn') and \"cover_projections\".\"candidate_id\" is null)"
+        },
+        "cover_projections_nonempty_ck": {
+          "name": "cover_projections_nonempty_ck",
+          "value": "length(trim(\"cover_projections\".\"reason_code\")) > 0\n        and length(trim(\"cover_projections\".\"actor_ref\")) > 0\n        and length(trim(\"cover_projections\".\"policy_version\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.description_candidates": {
+      "name": "description_candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observation_id": {
+          "name": "observation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_class": {
+          "name": "description_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_hash": {
+          "name": "text_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_policy_version": {
+          "name": "source_policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_policy_version": {
+          "name": "description_policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "license_name": {
+          "name": "license_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_url": {
+          "name": "license_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution_text": {
+          "name": "attribution_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "derivatives_permitted": {
+          "name": "derivatives_permitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "licensed_source_text_hash": {
+          "name": "licensed_source_text_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "licensed_text_transformed": {
+          "name": "licensed_text_transformed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editor_ref": {
+          "name": "editor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editorial_reason": {
+          "name": "editorial_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editorial_revision": {
+          "name": "editorial_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation_input_hash": {
+          "name": "generation_input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation_duration_ms": {
+          "name": "generation_duration_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_microusd": {
+          "name": "cost_microusd",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ambiguous_identity": {
+          "name": "ambiguous_identity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sensitive_content": {
+          "name": "sensitive_content",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "description_candidates_observation_uq": {
+          "name": "description_candidates_observation_uq",
+          "columns": [
+            {
+              "expression": "observation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "description_candidates_work_created_idx": {
+          "name": "description_candidates_work_created_idx",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "description_candidates_work_id_works_id_fk": {
+          "name": "description_candidates_work_id_works_id_fk",
+          "tableFrom": "description_candidates",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_candidates_observation_id_field_observations_id_fk": {
+          "name": "description_candidates_observation_id_field_observations_id_fk",
+          "tableFrom": "description_candidates",
+          "tableTo": "field_observations",
+          "columnsFrom": [
+            "observation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "description_candidates_class_ck": {
+          "name": "description_candidates_class_ck",
+          "value": "\"description_candidates\".\"description_class\" in ('licensed_verbatim', 'bukie_editorial', 'model_assisted_candidate')"
+        },
+        "description_candidates_text_ck": {
+          "name": "description_candidates_text_ck",
+          "value": "length(trim(\"description_candidates\".\"text_content\")) > 0 and length(\"description_candidates\".\"text_hash\") = 64"
+        },
+        "description_candidates_versions_ck": {
+          "name": "description_candidates_versions_ck",
+          "value": "length(trim(\"description_candidates\".\"source_revision\")) > 0\n        and length(trim(\"description_candidates\".\"source_policy_version\")) > 0\n        and length(trim(\"description_candidates\".\"description_policy_version\")) > 0"
+        },
+        "description_candidates_license_ck": {
+          "name": "description_candidates_license_ck",
+          "value": "(\n        \"description_candidates\".\"description_class\" = 'licensed_verbatim'\n        and length(trim(\"description_candidates\".\"license_name\")) > 0\n        and length(trim(\"description_candidates\".\"license_url\")) > 0\n        and \"description_candidates\".\"derivatives_permitted\" is not null\n        and length(\"description_candidates\".\"licensed_source_text_hash\") = 64\n        and \"description_candidates\".\"licensed_text_transformed\" is not null\n      ) or (\n        \"description_candidates\".\"description_class\" <> 'licensed_verbatim'\n        and \"description_candidates\".\"license_name\" is null\n        and \"description_candidates\".\"license_url\" is null\n        and \"description_candidates\".\"attribution_text\" is null\n        and \"description_candidates\".\"derivatives_permitted\" is null\n        and \"description_candidates\".\"licensed_source_text_hash\" is null\n        and \"description_candidates\".\"licensed_text_transformed\" is null\n      )"
+        },
+        "description_candidates_editorial_ck": {
+          "name": "description_candidates_editorial_ck",
+          "value": "(\n        \"description_candidates\".\"description_class\" = 'bukie_editorial'\n        and length(trim(\"description_candidates\".\"editor_ref\")) > 0\n        and length(trim(\"description_candidates\".\"editorial_reason\")) > 0\n        and length(trim(\"description_candidates\".\"editorial_revision\")) > 0\n      ) or (\n        \"description_candidates\".\"description_class\" <> 'bukie_editorial'\n        and \"description_candidates\".\"editor_ref\" is null\n        and \"description_candidates\".\"editorial_reason\" is null\n        and \"description_candidates\".\"editorial_revision\" is null\n      )"
+        },
+        "description_candidates_model_ck": {
+          "name": "description_candidates_model_ck",
+          "value": "(\n        \"description_candidates\".\"description_class\" = 'model_assisted_candidate'\n        and length(trim(\"description_candidates\".\"model_id\")) > 0\n        and length(trim(\"description_candidates\".\"model_version\")) > 0\n        and length(trim(\"description_candidates\".\"prompt_version\")) > 0\n        and length(\"description_candidates\".\"generation_input_hash\") = 64\n        and \"description_candidates\".\"generated_at\" is not null\n        and \"description_candidates\".\"generation_duration_ms\" >= 0\n        and \"description_candidates\".\"input_tokens\" >= 0\n        and \"description_candidates\".\"output_tokens\" >= 0\n        and \"description_candidates\".\"cost_microusd\" >= 0\n      ) or (\n        \"description_candidates\".\"description_class\" <> 'model_assisted_candidate'\n        and \"description_candidates\".\"model_id\" is null\n        and \"description_candidates\".\"model_version\" is null\n        and \"description_candidates\".\"prompt_version\" is null\n        and \"description_candidates\".\"generation_input_hash\" is null\n        and \"description_candidates\".\"generated_at\" is null\n        and \"description_candidates\".\"generation_duration_ms\" is null\n        and \"description_candidates\".\"input_tokens\" is null\n        and \"description_candidates\".\"output_tokens\" is null\n        and \"description_candidates\".\"cost_microusd\" is null\n      )"
+        },
+        "description_candidates_quality_ck": {
+          "name": "description_candidates_quality_ck",
+          "value": "\"description_candidates\".\"quality_score\" is null or \"description_candidates\".\"quality_score\" between 0 and 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.description_claim_evidence": {
+      "name": "description_claim_evidence",
+      "schema": "",
+      "columns": {
+        "claim_id": {
+          "name": "claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observation_id": {
+          "name": "observation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "description_claim_evidence_observation_idx": {
+          "name": "description_claim_evidence_observation_idx",
+          "columns": [
+            {
+              "expression": "observation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "description_claim_evidence_claim_id_description_claims_id_fk": {
+          "name": "description_claim_evidence_claim_id_description_claims_id_fk",
+          "tableFrom": "description_claim_evidence",
+          "tableTo": "description_claims",
+          "columnsFrom": [
+            "claim_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "description_claim_evidence_observation_id_field_observations_id_fk": {
+          "name": "description_claim_evidence_observation_id_field_observations_id_fk",
+          "tableFrom": "description_claim_evidence",
+          "tableTo": "field_observations",
+          "columnsFrom": [
+            "observation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "description_claim_evidence_pk": {
+          "name": "description_claim_evidence_pk",
+          "columns": [
+            "claim_id",
+            "observation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.description_claims": {
+      "name": "description_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_text": {
+          "name": "claim_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_hash": {
+          "name": "claim_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "description_claims_position_uq": {
+          "name": "description_claims_position_uq",
+          "columns": [
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "description_claims_candidate_idx": {
+          "name": "description_claims_candidate_idx",
+          "columns": [
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "description_claims_candidate_id_description_candidates_id_fk": {
+          "name": "description_claims_candidate_id_description_candidates_id_fk",
+          "tableFrom": "description_claims",
+          "tableTo": "description_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "description_claims_content_ck": {
+          "name": "description_claims_content_ck",
+          "value": "\"description_claims\".\"position\" >= 0\n        and length(trim(\"description_claims\".\"claim_text\")) > 0\n        and length(\"description_claims\".\"claim_hash\") = 64"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.description_decision_heads": {
+      "name": "description_decision_heads",
+      "schema": "",
+      "columns": {
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "decision_id": {
+          "name": "decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "description_decision_heads_decision_uq": {
+          "name": "description_decision_heads_decision_uq",
+          "columns": [
+            {
+              "expression": "decision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "description_decision_heads_candidate_id_description_candidates_id_fk": {
+          "name": "description_decision_heads_candidate_id_description_candidates_id_fk",
+          "tableFrom": "description_decision_heads",
+          "tableTo": "description_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_decision_heads_decision_id_description_decisions_id_fk": {
+          "name": "description_decision_heads_decision_id_description_decisions_id_fk",
+          "tableFrom": "description_decision_heads",
+          "tableTo": "description_decisions",
+          "columnsFrom": [
+            "decision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.description_decisions": {
+      "name": "description_decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_codes_json": {
+          "name": "rejection_codes_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "warning_codes_json": {
+          "name": "warning_codes_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer_ref": {
+          "name": "reviewer_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_reason": {
+          "name": "review_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_decision_id": {
+          "name": "previous_decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "description_decisions_candidate_history_idx": {
+          "name": "description_decisions_candidate_history_idx",
+          "columns": [
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "description_decisions_candidate_id_description_candidates_id_fk": {
+          "name": "description_decisions_candidate_id_description_candidates_id_fk",
+          "tableFrom": "description_decisions",
+          "tableTo": "description_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_decisions_previous_decision_id_description_decisions_id_fk": {
+          "name": "description_decisions_previous_decision_id_description_decisions_id_fk",
+          "tableFrom": "description_decisions",
+          "tableTo": "description_decisions",
+          "columnsFrom": [
+            "previous_decision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "description_decisions_state_ck": {
+          "name": "description_decisions_state_ck",
+          "value": "\"description_decisions\".\"state\" in ('candidate', 'review_required', 'paused', 'rejected', 'eligible', 'withdrawn', 'invalidated')"
+        },
+        "description_decisions_review_ck": {
+          "name": "description_decisions_review_ck",
+          "value": "(\"description_decisions\".\"reviewer_ref\" is null and \"description_decisions\".\"review_reason\" is null)\n        or (\n          length(trim(\"description_decisions\".\"reviewer_ref\")) > 0\n          and length(trim(\"description_decisions\".\"review_reason\")) > 0\n        )"
+        },
+        "description_decisions_policy_ck": {
+          "name": "description_decisions_policy_ck",
+          "value": "length(trim(\"description_decisions\".\"policy_version\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.description_projection_heads": {
+      "name": "description_projection_heads",
+      "schema": "",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "projection_id": {
+          "name": "projection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "description_projection_heads_projection_uq": {
+          "name": "description_projection_heads_projection_uq",
+          "columns": [
+            {
+              "expression": "projection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "description_projection_heads_work_id_works_id_fk": {
+          "name": "description_projection_heads_work_id_works_id_fk",
+          "tableFrom": "description_projection_heads",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_projection_heads_projection_id_description_projections_id_fk": {
+          "name": "description_projection_heads_projection_id_description_projections_id_fk",
+          "tableFrom": "description_projection_heads",
+          "tableTo": "description_projections",
+          "columnsFrom": [
+            "projection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.description_projections": {
+      "name": "description_projections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_projection_id": {
+          "name": "previous_projection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projected_at": {
+          "name": "projected_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "description_projections_work_history_idx": {
+          "name": "description_projections_work_history_idx",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "projected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "description_projections_work_id_works_id_fk": {
+          "name": "description_projections_work_id_works_id_fk",
+          "tableFrom": "description_projections",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_projections_candidate_id_description_candidates_id_fk": {
+          "name": "description_projections_candidate_id_description_candidates_id_fk",
+          "tableFrom": "description_projections",
+          "tableTo": "description_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "description_projections_previous_projection_id_description_projections_id_fk": {
+          "name": "description_projections_previous_projection_id_description_projections_id_fk",
+          "tableFrom": "description_projections",
+          "tableTo": "description_projections",
+          "columnsFrom": [
+            "previous_projection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "description_projections_state_ck": {
+          "name": "description_projections_state_ck",
+          "value": "\"description_projections\".\"state\" in ('selected', 'withdrawn', 'invalidated', 'rolled_back')"
+        },
+        "description_projections_selection_ck": {
+          "name": "description_projections_selection_ck",
+          "value": "(\"description_projections\".\"state\" in ('selected', 'rolled_back') and \"description_projections\".\"candidate_id\" is not null)\n        or (\"description_projections\".\"state\" in ('withdrawn', 'invalidated') and \"description_projections\".\"candidate_id\" is null)"
+        },
+        "description_projections_nonempty_ck": {
+          "name": "description_projections_nonempty_ck",
+          "value": "length(trim(\"description_projections\".\"reason_code\")) > 0\n        and length(trim(\"description_projections\".\"actor_ref\")) > 0\n        and length(trim(\"description_projections\".\"policy_version\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.description_review_queue": {
+      "name": "description_review_queue",
+      "schema": "",
+      "columns": {
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_codes_json": {
+          "name": "reason_codes_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer_ref": {
+          "name": "reviewer_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "description_review_queue_active_idx": {
+          "name": "description_review_queue_active_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "queued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "description_review_queue_candidate_id_description_candidates_id_fk": {
+          "name": "description_review_queue_candidate_id_description_candidates_id_fk",
+          "tableFrom": "description_review_queue",
+          "tableTo": "description_candidates",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "description_review_queue_state_ck": {
+          "name": "description_review_queue_state_ck",
+          "value": "\"description_review_queue\".\"state\" in ('queued', 'claimed', 'completed', 'cancelled')"
+        },
+        "description_review_queue_values_ck": {
+          "name": "description_review_queue_values_ck",
+          "value": "\"description_review_queue\".\"priority\" >= 0\n        and (\"description_review_queue\".\"reviewer_ref\" is null or length(trim(\"description_review_queue\".\"reviewer_ref\")) > 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.edition_covers": {
+      "name": "edition_covers",
+      "schema": "",
+      "columns": {
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_asset_id": {
+          "name": "cover_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "edition_covers_position_uq": {
+          "name": "edition_covers_position_uq",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_covers_primary_uq": {
+          "name": "edition_covers_primary_uq",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"edition_covers\".\"is_primary\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_covers_owner_position_idx": {
+          "name": "edition_covers_owner_position_idx",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_covers_primary_lookup_idx": {
+          "name": "edition_covers_primary_lookup_idx",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "edition_covers_edition_id_editions_id_fk": {
+          "name": "edition_covers_edition_id_editions_id_fk",
+          "tableFrom": "edition_covers",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edition_covers_cover_asset_id_cover_assets_id_fk": {
+          "name": "edition_covers_cover_asset_id_cover_assets_id_fk",
+          "tableFrom": "edition_covers",
+          "tableTo": "cover_assets",
+          "columnsFrom": [
+            "cover_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edition_covers_pk": {
+          "name": "edition_covers_pk",
+          "columns": [
+            "edition_id",
+            "cover_asset_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "edition_covers_position_ck": {
+          "name": "edition_covers_position_ck",
+          "value": "\"edition_covers\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.edition_identifiers": {
+      "name": "edition_identifiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheme": {
+          "name": "scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_normalized": {
+          "name": "value_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_display": {
+          "name": "value_display",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "edition_identifiers_value_uq": {
+          "name": "edition_identifiers_value_uq",
+          "columns": [
+            {
+              "expression": "scheme",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_identifiers_primary_uq": {
+          "name": "edition_identifiers_primary_uq",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"edition_identifiers\".\"is_primary\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_identifiers_owner_idx": {
+          "name": "edition_identifiers_owner_idx",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "edition_identifiers_edition_id_editions_id_fk": {
+          "name": "edition_identifiers_edition_id_editions_id_fk",
+          "tableFrom": "edition_identifiers",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "edition_identifiers_scheme_ck": {
+          "name": "edition_identifiers_scheme_ck",
+          "value": "\"edition_identifiers\".\"scheme\" in ('isbn10', 'isbn13')"
+        },
+        "edition_identifiers_value_ck": {
+          "name": "edition_identifiers_value_ck",
+          "value": "length(trim(\"edition_identifiers\".\"value_normalized\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.edition_languages": {
+      "name": "edition_languages",
+      "schema": "",
+      "columns": {
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_tag": {
+          "name": "language_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "edition_languages_position_uq": {
+          "name": "edition_languages_position_uq",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_languages_owner_position_idx": {
+          "name": "edition_languages_owner_position_idx",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_languages_language_edition_idx": {
+          "name": "edition_languages_language_edition_idx",
+          "columns": [
+            {
+              "expression": "language_tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "edition_languages_edition_id_editions_id_fk": {
+          "name": "edition_languages_edition_id_editions_id_fk",
+          "tableFrom": "edition_languages",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edition_languages_language_tag_languages_tag_fk": {
+          "name": "edition_languages_language_tag_languages_tag_fk",
+          "tableFrom": "edition_languages",
+          "tableTo": "languages",
+          "columnsFrom": [
+            "language_tag"
+          ],
+          "columnsTo": [
+            "tag"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edition_languages_pk": {
+          "name": "edition_languages_pk",
+          "columns": [
+            "edition_id",
+            "language_tag"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "edition_languages_position_ck": {
+          "name": "edition_languages_position_ck",
+          "value": "\"edition_languages\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.edition_publishers": {
+      "name": "edition_publishers",
+      "schema": "",
+      "columns": {
+        "edition_id": {
+          "name": "edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publisher_id": {
+          "name": "publisher_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "edition_publishers_position_uq": {
+          "name": "edition_publishers_position_uq",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edition_publishers_owner_position_idx": {
+          "name": "edition_publishers_owner_position_idx",
+          "columns": [
+            {
+              "expression": "edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "edition_publishers_edition_id_editions_id_fk": {
+          "name": "edition_publishers_edition_id_editions_id_fk",
+          "tableFrom": "edition_publishers",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edition_publishers_publisher_id_publishers_id_fk": {
+          "name": "edition_publishers_publisher_id_publishers_id_fk",
+          "tableFrom": "edition_publishers",
+          "tableTo": "publishers",
+          "columnsFrom": [
+            "publisher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edition_publishers_pk": {
+          "name": "edition_publishers_pk",
+          "columns": [
+            "edition_id",
+            "publisher_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "edition_publishers_position_ck": {
+          "name": "edition_publishers_position_ck",
+          "value": "\"edition_publishers\".\"position\" >= 0"
+        },
+        "edition_publishers_role_ck": {
+          "name": "edition_publishers_role_ck",
+          "value": "\"edition_publishers\".\"role\" is null or \"edition_publishers\".\"role\" in ('publisher', 'co_publisher', 'imprint', 'distributor')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.editions": {
+      "name": "editions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_date": {
+          "name": "publication_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_precision": {
+          "name": "publication_precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_sort_date": {
+          "name": "publication_sort_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pages": {
+          "name": "pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cataloged_at": {
+          "name": "cataloged_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "editions_work_id_idx": {
+          "name": "editions_work_id_idx",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "editions_publication_sort_work_idx": {
+          "name": "editions_publication_sort_work_idx",
+          "columns": [
+            {
+              "expression": "publication_sort_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "editions_cataloged_work_idx": {
+          "name": "editions_cataloged_work_idx",
+          "columns": [
+            {
+              "expression": "cataloged_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "editions_work_id_works_id_fk": {
+          "name": "editions_work_id_works_id_fk",
+          "tableFrom": "editions",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "editions_title_ck": {
+          "name": "editions_title_ck",
+          "value": "\"editions\".\"title\" is null or length(trim(\"editions\".\"title\")) > 0"
+        },
+        "editions_subtitle_ck": {
+          "name": "editions_subtitle_ck",
+          "value": "\"editions\".\"subtitle\" is null or length(trim(\"editions\".\"subtitle\")) > 0"
+        },
+        "editions_format_ck": {
+          "name": "editions_format_ck",
+          "value": "\"editions\".\"format\" is null or \"editions\".\"format\" in ('hardcover', 'paperback', 'ebook', 'audiobook', 'other')"
+        },
+        "editions_pages_ck": {
+          "name": "editions_pages_ck",
+          "value": "\"editions\".\"pages\" is null or \"editions\".\"pages\" > 0"
+        },
+        "editions_publication_precision_ck": {
+          "name": "editions_publication_precision_ck",
+          "value": "\"editions\".\"publication_precision\" is null or \"editions\".\"publication_precision\" in ('year', 'month', 'day')"
+        },
+        "editions_publication_date_ck": {
+          "name": "editions_publication_date_ck",
+          "value": "(\n        \"editions\".\"publication_date\" is null\n        and \"editions\".\"publication_precision\" is null\n        and \"editions\".\"publication_sort_date\" is null\n      ) or (\n        \"editions\".\"publication_precision\" = 'year'\n        and length(\"editions\".\"publication_date\") = 4\n        and \"editions\".\"publication_sort_date\" = \"editions\".\"publication_date\" || '-01-01'\n      ) or (\n        \"editions\".\"publication_precision\" = 'month'\n        and length(\"editions\".\"publication_date\") = 7\n        and substring(\"editions\".\"publication_date\" from 5 for 1) = '-'\n        and \"editions\".\"publication_sort_date\" = \"editions\".\"publication_date\" || '-01'\n      ) or (\n        \"editions\".\"publication_precision\" = 'day'\n        and length(\"editions\".\"publication_date\") = 10\n        and substring(\"editions\".\"publication_date\" from 5 for 1) = '-'\n        and substring(\"editions\".\"publication_date\" from 8 for 1) = '-'\n        and \"editions\".\"publication_sort_date\" = \"editions\".\"publication_date\"\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.entity_aliases": {
+      "name": "entity_aliases",
+      "schema": "",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_id": {
+          "name": "from_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_id": {
+          "name": "to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "entity_aliases_target_idx": {
+          "name": "entity_aliases_target_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "entity_aliases_pk": {
+          "name": "entity_aliases_pk",
+          "columns": [
+            "entity_type",
+            "from_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "entity_aliases_ck": {
+          "name": "entity_aliases_ck",
+          "value": "\"entity_aliases\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset')\n        and \"entity_aliases\".\"from_id\" <> \"entity_aliases\".\"to_id\"\n        and length(trim(\"entity_aliases\".\"reason\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.field_observations": {
+      "name": "field_observations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_json": {
+          "name": "value_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comparison_hash": {
+          "name": "comparison_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provenance_kind": {
+          "name": "provenance_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_modified_at": {
+          "name": "source_modified_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retrieved_at": {
+          "name": "retrieved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mapping_confidence": {
+          "name": "mapping_confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "derivation_name": {
+          "name": "derivation_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "derivation_version": {
+          "name": "derivation_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_ids_json": {
+          "name": "parent_ids_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "field_observations_identity_uq": {
+          "name": "field_observations_identity_uq",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "field_observations_source_field_state_idx": {
+          "name": "field_observations_source_field_state_idx",
+          "columns": [
+            {
+              "expression": "source_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "field_observations_target_field_idx": {
+          "name": "field_observations_target_field_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "field_observations_source_record_id_source_records_id_fk": {
+          "name": "field_observations_source_record_id_source_records_id_fk",
+          "tableFrom": "field_observations",
+          "tableTo": "source_records",
+          "columnsFrom": [
+            "source_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "field_observations_target_ck": {
+          "name": "field_observations_target_ck",
+          "value": "\"field_observations\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and \"field_observations\".\"field_key\" in ('work.preferred_title', 'work.description', 'work.first_publication_date', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')"
+        },
+        "field_observations_hash_ck": {
+          "name": "field_observations_hash_ck",
+          "value": "length(\"field_observations\".\"comparison_hash\") = 64"
+        },
+        "field_observations_provenance_ck": {
+          "name": "field_observations_provenance_ck",
+          "value": "\"field_observations\".\"provenance_kind\" in ('curated', 'imported', 'derived', 'synthetic')"
+        },
+        "field_observations_state_ck": {
+          "name": "field_observations_state_ck",
+          "value": "\"field_observations\".\"state\" in ('active', 'stale', 'withdrawn', 'invalid')"
+        },
+        "field_observations_confidence_ck": {
+          "name": "field_observations_confidence_ck",
+          "value": "\"field_observations\".\"mapping_confidence\" between 0 and 1"
+        },
+        "field_observations_curated_ck": {
+          "name": "field_observations_curated_ck",
+          "value": "\"field_observations\".\"provenance_kind\" <> 'curated'\n        or (length(trim(\"field_observations\".\"actor_ref\")) > 0 and length(trim(\"field_observations\".\"reason\")) > 0)"
+        },
+        "field_observations_derived_ck": {
+          "name": "field_observations_derived_ck",
+          "value": "\"field_observations\".\"provenance_kind\" <> 'derived'\n        or (\n          length(trim(\"field_observations\".\"derivation_name\")) > 0\n          and length(trim(\"field_observations\".\"derivation_version\")) > 0\n          and \"field_observations\".\"parent_ids_json\" is not null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.field_resolution_heads": {
+      "name": "field_resolution_heads",
+      "schema": "",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution_id": {
+          "name": "resolution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "field_resolution_heads_resolution_uq": {
+          "name": "field_resolution_heads_resolution_uq",
+          "columns": [
+            {
+              "expression": "resolution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "field_resolution_heads_lookup_idx": {
+          "name": "field_resolution_heads_lookup_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "field_resolution_heads_resolution_id_field_resolutions_id_fk": {
+          "name": "field_resolution_heads_resolution_id_field_resolutions_id_fk",
+          "tableFrom": "field_resolution_heads",
+          "tableTo": "field_resolutions",
+          "columnsFrom": [
+            "resolution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "field_resolution_heads_pk": {
+          "name": "field_resolution_heads_pk",
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "field_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "field_resolution_heads_target_ck": {
+          "name": "field_resolution_heads_target_ck",
+          "value": "\"field_resolution_heads\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and \"field_resolution_heads\".\"field_key\" in ('work.preferred_title', 'work.description', 'work.first_publication_date', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.field_resolutions": {
+      "name": "field_resolutions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_observation_id": {
+          "name": "selected_observation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_resolution_id": {
+          "name": "previous_resolution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolver_version": {
+          "name": "resolver_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "field_resolutions_target_history_idx": {
+          "name": "field_resolutions_target_history_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "field_resolutions_selected_observation_id_field_observations_id_fk": {
+          "name": "field_resolutions_selected_observation_id_field_observations_id_fk",
+          "tableFrom": "field_resolutions",
+          "tableTo": "field_observations",
+          "columnsFrom": [
+            "selected_observation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "field_resolutions_previous_resolution_id_field_resolutions_id_fk": {
+          "name": "field_resolutions_previous_resolution_id_field_resolutions_id_fk",
+          "tableFrom": "field_resolutions",
+          "tableTo": "field_resolutions",
+          "columnsFrom": [
+            "previous_resolution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "field_resolutions_target_ck": {
+          "name": "field_resolutions_target_ck",
+          "value": "\"field_resolutions\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset') and \"field_resolutions\".\"field_key\" in ('work.preferred_title', 'work.description', 'work.first_publication_date', 'work.preferred_edition', 'work.authors', 'work.categories', 'edition.title', 'edition.subtitle', 'edition.format', 'edition.publication_date', 'edition.pages', 'edition.publishers', 'edition.languages', 'edition.identifiers', 'edition.covers', 'author.display_name', 'category.label', 'publisher.display_name', 'cover_asset.object_key', 'legacy.rating', 'legacy.ratings_count')"
+        },
+        "field_resolutions_state_ck": {
+          "name": "field_resolutions_state_ck",
+          "value": "\"field_resolutions\".\"state\" in ('present', 'missing', 'conflicting', 'stale', 'withdrawn')"
+        },
+        "field_resolutions_selection_ck": {
+          "name": "field_resolutions_selection_ck",
+          "value": "(\n        \"field_resolutions\".\"state\" in ('present', 'stale')\n        and \"field_resolutions\".\"selected_observation_id\" is not null\n      ) or (\n        \"field_resolutions\".\"state\" in ('missing', 'conflicting', 'withdrawn')\n        and \"field_resolutions\".\"selected_observation_id\" is null\n      )"
+        },
+        "field_resolutions_nonempty_ck": {
+          "name": "field_resolutions_nonempty_ck",
+          "value": "length(trim(\"field_resolutions\".\"reason\")) > 0\n        and length(trim(\"field_resolutions\".\"actor_ref\")) > 0\n        and length(trim(\"field_resolutions\".\"resolver_version\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.languages": {
+      "name": "languages",
+      "schema": "",
+      "columns": {
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "languages_nonempty_ck": {
+          "name": "languages_nonempty_ck",
+          "value": "length(trim(\"languages\".\"tag\")) > 0 and length(trim(\"languages\".\"label\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.metadata_sources": {
+      "name": "metadata_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terms_url": {
+          "name": "terms_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution_url": {
+          "name": "attribution_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_state": {
+          "name": "approval_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata_policy": {
+          "name": "metadata_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_policy": {
+          "name": "asset_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_policy": {
+          "name": "payload_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_interval_ms": {
+          "name": "refresh_interval_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "metadata_sources_key_uq": {
+          "name": "metadata_sources_key_uq",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "metadata_sources_nonempty_ck": {
+          "name": "metadata_sources_nonempty_ck",
+          "value": "length(trim(\"metadata_sources\".\"key\")) > 0 and length(trim(\"metadata_sources\".\"name\")) > 0"
+        },
+        "metadata_sources_approval_state_ck": {
+          "name": "metadata_sources_approval_state_ck",
+          "value": "\"metadata_sources\".\"approval_state\" in ('pending', 'approved', 'suspended', 'retired')"
+        },
+        "metadata_sources_payload_policy_ck": {
+          "name": "metadata_sources_payload_policy_ck",
+          "value": "\"metadata_sources\".\"payload_policy\" in ('none', 'selected_fields', 'full')"
+        },
+        "metadata_sources_approved_review_ck": {
+          "name": "metadata_sources_approved_review_ck",
+          "value": "\"metadata_sources\".\"approval_state\" <> 'approved' or \"metadata_sources\".\"reviewed_at\" is not null"
+        },
+        "metadata_sources_refresh_ck": {
+          "name": "metadata_sources_refresh_ck",
+          "value": "\"metadata_sources\".\"refresh_interval_ms\" is null or \"metadata_sources\".\"refresh_interval_ms\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.publishers": {
+      "name": "publishers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "publishers_name_nonempty_ck": {
+          "name": "publishers_name_nonempty_ck",
+          "value": "length(trim(\"publishers\".\"display_name\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.source_record_links": {
+      "name": "source_record_links",
+      "schema": "",
+      "columns": {
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_kind": {
+          "name": "match_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mapping_confidence": {
+          "name": "mapping_confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_ref": {
+          "name": "actor_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "source_record_links_entity_idx": {
+          "name": "source_record_links_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_record_links_source_record_id_source_records_id_fk": {
+          "name": "source_record_links_source_record_id_source_records_id_fk",
+          "tableFrom": "source_record_links",
+          "tableTo": "source_records",
+          "columnsFrom": [
+            "source_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "source_record_links_pk": {
+          "name": "source_record_links_pk",
+          "columns": [
+            "source_record_id",
+            "entity_type",
+            "entity_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "source_record_links_entity_type_ck": {
+          "name": "source_record_links_entity_type_ck",
+          "value": "\"source_record_links\".\"entity_type\" in ('work', 'edition', 'author', 'category', 'publisher', 'cover_asset')"
+        },
+        "source_record_links_match_kind_ck": {
+          "name": "source_record_links_match_kind_ck",
+          "value": "\"source_record_links\".\"match_kind\" in ('exact_identifier', 'source_relationship', 'curated', 'candidate')"
+        },
+        "source_record_links_state_ck": {
+          "name": "source_record_links_state_ck",
+          "value": "\"source_record_links\".\"state\" in ('active', 'candidate', 'rejected')"
+        },
+        "source_record_links_confidence_ck": {
+          "name": "source_record_links_confidence_ck",
+          "value": "\"source_record_links\".\"mapping_confidence\" between 0 and 1"
+        },
+        "source_record_links_actor_ck": {
+          "name": "source_record_links_actor_ck",
+          "value": "(\n        \"source_record_links\".\"match_kind\" <> 'curated' and \"source_record_links\".\"state\" <> 'rejected'\n      ) or (\n        length(trim(\"source_record_links\".\"actor_ref\")) > 0 and length(trim(\"source_record_links\".\"reason\")) > 0\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.source_records": {
+      "name": "source_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_modified_at": {
+          "name": "source_modified_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retrieved_at": {
+          "name": "retrieved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "importer_version": {
+          "name": "importer_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_row_hash": {
+          "name": "source_row_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "source_records_source_key_uq": {
+          "name": "source_records_source_key_uq",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "record_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_records_refresh_idx": {
+          "name": "source_records_refresh_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "retrieved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_records_source_id_metadata_sources_id_fk": {
+          "name": "source_records_source_id_metadata_sources_id_fk",
+          "tableFrom": "source_records",
+          "tableTo": "metadata_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "source_records_key_nonempty_ck": {
+          "name": "source_records_key_nonempty_ck",
+          "value": "length(trim(\"source_records\".\"record_key\")) > 0"
+        },
+        "source_records_state_ck": {
+          "name": "source_records_state_ck",
+          "value": "\"source_records\".\"state\" in ('active', 'withdrawn', 'deleted')"
+        },
+        "source_records_import_hash_ck": {
+          "name": "source_records_import_hash_ck",
+          "value": "(\"source_records\".\"importer_version\" is null and \"source_records\".\"source_row_hash\" is null)\n        or (length(trim(\"source_records\".\"importer_version\")) > 0 and length(\"source_records\".\"source_row_hash\") = 64)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.work_authors": {
+      "name": "work_authors",
+      "schema": "",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'author'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "work_authors_position_uq": {
+          "name": "work_authors_position_uq",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_authors_owner_position_idx": {
+          "name": "work_authors_owner_position_idx",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_authors_author_work_idx": {
+          "name": "work_authors_author_work_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "work_authors_work_id_works_id_fk": {
+          "name": "work_authors_work_id_works_id_fk",
+          "tableFrom": "work_authors",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_authors_author_id_authors_id_fk": {
+          "name": "work_authors_author_id_authors_id_fk",
+          "tableFrom": "work_authors",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "work_authors_pk": {
+          "name": "work_authors_pk",
+          "columns": [
+            "work_id",
+            "author_id",
+            "role"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "work_authors_role_ck": {
+          "name": "work_authors_role_ck",
+          "value": "\"work_authors\".\"role\" in ('author', 'editor', 'translator', 'illustrator')"
+        },
+        "work_authors_position_ck": {
+          "name": "work_authors_position_ck",
+          "value": "\"work_authors\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.work_categories": {
+      "name": "work_categories",
+      "schema": "",
+      "columns": {
+        "work_id": {
+          "name": "work_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "work_categories_position_uq": {
+          "name": "work_categories_position_uq",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_categories_primary_uq": {
+          "name": "work_categories_primary_uq",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"work_categories\".\"is_primary\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_categories_owner_position_idx": {
+          "name": "work_categories_owner_position_idx",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_categories_category_work_idx": {
+          "name": "work_categories_category_work_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "work_categories_work_id_works_id_fk": {
+          "name": "work_categories_work_id_works_id_fk",
+          "tableFrom": "work_categories",
+          "tableTo": "works",
+          "columnsFrom": [
+            "work_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_categories_category_id_categories_id_fk": {
+          "name": "work_categories_category_id_categories_id_fk",
+          "tableFrom": "work_categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "work_categories_pk": {
+          "name": "work_categories_pk",
+          "columns": [
+            "work_id",
+            "category_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "work_categories_position_ck": {
+          "name": "work_categories_position_ck",
+          "value": "\"work_categories\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.works": {
+      "name": "works",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "preferred_title": {
+          "name": "preferred_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_title": {
+          "name": "sort_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_publication_date": {
+          "name": "first_publication_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_publication_precision": {
+          "name": "first_publication_precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_publication_sort_date": {
+          "name": "first_publication_sort_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_edition_id": {
+          "name": "preferred_edition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "works_sort_title_id_idx": {
+          "name": "works_sort_title_id_idx",
+          "columns": [
+            {
+              "expression": "sort_title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "works_preferred_edition_idx": {
+          "name": "works_preferred_edition_idx",
+          "columns": [
+            {
+              "expression": "preferred_edition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "works_preferred_edition_id_editions_id_fk": {
+          "name": "works_preferred_edition_id_editions_id_fk",
+          "tableFrom": "works",
+          "tableTo": "editions",
+          "columnsFrom": [
+            "preferred_edition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "works_titles_nonempty_ck": {
+          "name": "works_titles_nonempty_ck",
+          "value": "length(trim(\"works\".\"preferred_title\")) > 0 and length(trim(\"works\".\"sort_title\")) > 0"
+        },
+        "works_first_publication_precision_ck": {
+          "name": "works_first_publication_precision_ck",
+          "value": "\"works\".\"first_publication_precision\" is null or \"works\".\"first_publication_precision\" in ('year', 'month', 'day')"
+        },
+        "works_first_publication_date_ck": {
+          "name": "works_first_publication_date_ck",
+          "value": "(\n        \"works\".\"first_publication_date\" is null\n        and \"works\".\"first_publication_precision\" is null\n        and \"works\".\"first_publication_sort_date\" is null\n      ) or (\n        \"works\".\"first_publication_date\" is not null\n        and \"works\".\"first_publication_precision\" is not null\n        and \"works\".\"first_publication_sort_date\" is not null\n        and (\n          (\n            \"works\".\"first_publication_precision\" = 'year'\n            and length(\"works\".\"first_publication_date\") = 4\n            and \"works\".\"first_publication_sort_date\" = \"works\".\"first_publication_date\" || '-01-01'\n          ) or (\n            \"works\".\"first_publication_precision\" = 'month'\n            and length(\"works\".\"first_publication_date\") = 7\n            and substring(\"works\".\"first_publication_date\" from 5 for 1) = '-'\n            and \"works\".\"first_publication_sort_date\" = \"works\".\"first_publication_date\" || '-01'\n          ) or (\n            \"works\".\"first_publication_precision\" = 'day'\n            and length(\"works\".\"first_publication_date\") = 10\n            and substring(\"works\".\"first_publication_date\" from 5 for 1) = '-'\n            and substring(\"works\".\"first_publication_date\" from 8 for 1) = '-'\n            and \"works\".\"first_publication_sort_date\" = \"works\".\"first_publication_date\"\n          )\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/pg/meta/_journal.json
+++ b/drizzle/pg/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1785319007333,
       "tag": "0009_moaning_catseye",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1785322085915,
+      "tag": "0010_clammy_cerebro",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "db:catalog:rebuild": "bunx tsx ./scripts/db/rebuild-catalog.ts",
     "db:catalog:enrichment-sample": "bunx tsx ./scripts/db/run-enrichment-sample.ts",
     "db:catalog:description-sample": "bunx tsx ./scripts/db/run-description-enrichment-sample.ts",
+    "db:catalog:cover-sample": "bunx tsx ./scripts/db/run-cover-enrichment-sample.ts",
     "lint": "bunx @biomejs/biome check --no-errors-on-unmatched .",
     "lint:fix": "bunx @biomejs/biome check --write --no-errors-on-unmatched .",
     "release": "semantic-release",

--- a/scripts/covers/fetch-covers.ts
+++ b/scripts/covers/fetch-covers.ts
@@ -13,12 +13,15 @@ import { spawn } from "node:child_process";
 import { mkdir, stat, writeFile } from "node:fs/promises";
 import { basename, join } from "node:path";
 import {
-  findOpenLibraryCandidates,
+  findEditionMatchedOpenLibraryCandidates,
   getOpenLibraryHeaders,
 } from "./helpers";
+import { assertOpenLibraryCoverPublishingAllowed } from "./policy";
 import { runCoverJobs } from "./run-cover-jobs";
 import baseCatalog from "../../artifacts/catalog";
 import type { LegacyCatalogArtifactRecord } from "../../artifacts/catalog/types";
+import { inspectCoverBytes } from "../../src/db/catalog/enrichment/covers/inspection";
+import type { CoverInspection } from "../../src/db/catalog/enrichment/covers/types";
 
 type Flags = {
   dryRun: boolean;
@@ -101,7 +104,11 @@ async function getSharpOnce(): Promise<any> {
   return sharpSingleton;
 }
 
-async function downloadCover(url: string, baseName: string, optimize: boolean): Promise<string> {
+async function downloadCover(
+  url: string,
+  baseName: string,
+  optimize: boolean,
+): Promise<{ localPath: string; inspection: CoverInspection }> {
   const res = await fetch(url, {
     redirect: "follow",
     headers: getOpenLibraryHeaders(),
@@ -109,23 +116,39 @@ async function downloadCover(url: string, baseName: string, optimize: boolean): 
   if (!res.ok) throw new Error(`download failed: ${res.status} ${res.statusText}`);
   const buf = Buffer.from(await res.arrayBuffer());
   let rel = "";
+  let output = buf;
   if (optimize) {
     const sharp = await getSharpOnce();
-    const webp = await sharp(buf).webp({ quality: 80 }).toBuffer();
+    output = await sharp(buf).webp({ quality: 80 }).toBuffer();
     const outPath = `public/covers/${baseName}.webp`;
+    const inspection = await inspectCoverBytes({
+      bytes: output,
+      inspectedAt: Date.now(),
+    });
+    if (inspection.decodeResult !== "decoded") {
+      throw new Error(`cover inspection failed: ${inspection.decodeResult}`);
+    }
     await mkdir(outPath.substring(0, outPath.lastIndexOf("/")), { recursive: true });
-    await writeFile(outPath, webp);
+    await writeFile(outPath, output);
     rel = `/covers/${basename(outPath)}`;
+    return { localPath: rel, inspection };
   } else {
     // Write original bytes with an inferred extension
     const ct = (res.headers.get("content-type") || "").toLowerCase();
     const ext = ct.includes("png") ? "png" : ct.includes("webp") ? "webp" : "jpg";
     const outPath = `public/covers/${baseName}.${ext}`;
+    const inspection = await inspectCoverBytes({
+      bytes: output,
+      inspectedAt: Date.now(),
+    });
+    if (inspection.decodeResult !== "decoded") {
+      throw new Error(`cover inspection failed: ${inspection.decodeResult}`);
+    }
     await mkdir(outPath.substring(0, outPath.lastIndexOf("/")), { recursive: true });
-    await writeFile(outPath, buf);
+    await writeFile(outPath, output);
     rel = `/covers/${basename(outPath)}`;
+    return { localPath: rel, inspection };
   }
-  return rel;
 }
 
 function isPlaceholder(cover: string | undefined): boolean {
@@ -153,6 +176,9 @@ async function main() {
   }
 
   const flags = parseFlags(process.argv.slice(2));
+  if (flags.uploadR2) {
+    assertOpenLibraryCoverPublishingAllowed();
+  }
   const all = baseCatalog;
   let candidates = all.filter((b) => (flags.onlyId ? b.id === flags.onlyId : true));
   if (!flags.force) {
@@ -194,16 +220,19 @@ async function main() {
     limited,
     flags.concurrency,
     async (book) => {
-      const candidates = await findOpenLibraryCandidates(book);
+      const candidates = findEditionMatchedOpenLibraryCandidates(book);
       let usedUrl: string | undefined;
       let localPath: string | undefined;
+      let inspection: CoverInspection | undefined;
       for (const candidate of candidates) {
         try {
-          localPath = await downloadCover(
+          const downloaded = await downloadCover(
             candidate,
             book.id,
             !flags.noOptimize,
           );
+          localPath = downloaded.localPath;
+          inspection = downloaded.inspection;
           usedUrl = candidate;
           break;
         } catch {
@@ -225,10 +254,13 @@ async function main() {
       }
       // eslint-disable-next-line no-console
       console.info(
-        "[covers] %s -> %s%s",
+        "[covers] %s -> %s%s%s",
         book.id,
         localPath,
         flags.uploadR2 && !flags.dryRun ? " [uploaded to R2]" : "",
+        inspection?.flags.length
+          ? ` [review:${inspection.flags.join(",")}]`
+          : " [inspection:clean]",
       );
     },
     (book, error) => {

--- a/scripts/covers/helpers.ts
+++ b/scripts/covers/helpers.ts
@@ -144,6 +144,18 @@ export function buildOpenLibraryCandidates(book: CoverLookupBook): string[] {
   return urls;
 }
 
+/**
+ * Candidates safe enough for byte inspection without pretending a fuzzy work
+ * search proves the selected edition. The Covers API ISBN relation is still
+ * candidate evidence; rights policy and decoded-byte inspection remain
+ * separate hard gates before any promotion.
+ */
+export function findEditionMatchedOpenLibraryCandidates(
+  book: CoverLookupBook,
+): string[] {
+  return buildOpenLibraryCandidates(book);
+}
+
 export function extractOpenLibrarySearchCandidates(
   book: CoverLookupBook,
   payload: OpenLibrarySearchResponse,

--- a/scripts/covers/policy.ts
+++ b/scripts/covers/policy.ts
@@ -1,0 +1,22 @@
+import {
+  authorizeField,
+  getAdapterManifest,
+} from "../../src/db/catalog/enrichment/policies";
+
+export const assertOpenLibraryCoverPublishingAllowed = (): void => {
+  const adapter = getAdapterManifest("open-library.covers");
+  const permission = authorizeField({
+    adapter,
+    fieldClass: "asset",
+    fieldKey: "edition.covers",
+  });
+  if (
+    !permission.cache ||
+    !permission.transform ||
+    !permission.display
+  ) {
+    throw new Error(
+      "Open Library cover publishing requires approved cache, transformation, and display permission",
+    );
+  }
+};

--- a/scripts/db/run-cover-enrichment-sample.ts
+++ b/scripts/db/run-cover-enrichment-sample.ts
@@ -1,0 +1,133 @@
+import {
+  recordedFiveCoverFixtures,
+  seedCoverFixturesSqlite,
+} from "@/db/catalog/enrichment/covers/fixtures";
+import {
+  createCoverCandidateSqlite,
+  getCoverSelectionSqlite,
+} from "@/db/catalog/enrichment/covers/repository";
+import { SAMPLE_BASELINE_IMPORT_RECORDS } from "@/db/catalog/enrichment/fixtures";
+import { ENRICHMENT_SAMPLE_MANIFEST } from "@/db/catalog/enrichment/sample-manifest";
+import { canonicalJson, hashCanonicalJson } from "@/db/catalog/identity";
+import { buildCatalogImportGraph } from "@/db/catalog/importer";
+import { resolveRebuildTarget } from "@/db/catalog/rebuild-safety";
+import {
+  openCatalogSqlite,
+  rebuildCatalogSqlite,
+} from "@/db/catalog/sqlite-rebuild";
+
+const rawTarget = process.argv
+  .find((argument) => argument.startsWith("--target="))
+  ?.slice("--target=".length);
+const target = resolveRebuildTarget({
+  rawTarget,
+  confirmDisposable: process.argv.includes("--confirm-disposable"),
+});
+if (target.driver !== "sqlite") {
+  throw new Error(
+    "The issue #134 cover proof currently accepts disposable SQLite targets only",
+  );
+}
+
+rebuildCatalogSqlite({
+  sqlitePath: target.path,
+  graph: buildCatalogImportGraph(SAMPLE_BASELINE_IMPORT_RECORDS),
+});
+const { raw } = openCatalogSqlite(target.path);
+try {
+  seedCoverFixturesSqlite(raw);
+  const publicBefore = canonicalJson({
+    assets: raw.prepare("select * from cover_assets order by id").all(),
+    relations: raw
+      .prepare(
+        "select * from edition_covers order by edition_id, cover_asset_id",
+      )
+      .all(),
+    heads: raw
+      .prepare(
+        `select entity_type, entity_id, field_key, resolution_id
+         from field_resolution_heads
+         order by entity_type, entity_id, field_key`,
+      )
+      .all(),
+  });
+  const editionIds = Object.fromEntries(
+    ENRICHMENT_SAMPLE_MANIFEST.works.map((work) => {
+      const edition = raw
+        .prepare(
+          "select preferred_edition_id as id from works where id = ?",
+        )
+        .get(work.workId) as { id: string };
+      return [work.workId, edition.id];
+    }),
+  );
+  const fixtures = recordedFiveCoverFixtures({ editionIds });
+  const results = fixtures.map((fixture) => {
+    const first = createCoverCandidateSqlite(raw, fixture);
+    const retry = createCoverCandidateSqlite(raw, fixture);
+    if (retry.changed || retry.candidateId !== first.candidateId) {
+      throw new Error("Cover inspection retry was not idempotent");
+    }
+    return {
+      title: fixture.title,
+      state: first.state,
+      gateCodes: first.gateCodes,
+      warningCodes: first.warningCodes,
+      selection: getCoverSelectionSqlite(raw, fixture.candidate.workId),
+    };
+  });
+  const publicAfter = canonicalJson({
+    assets: raw.prepare("select * from cover_assets order by id").all(),
+    relations: raw
+      .prepare(
+        "select * from edition_covers order by edition_id, cover_asset_id",
+      )
+      .all(),
+    heads: raw
+      .prepare(
+        `select entity_type, entity_id, field_key, resolution_id
+         from field_resolution_heads
+         order by entity_type, entity_id, field_key`,
+      )
+      .all(),
+  });
+  if (publicBefore !== publicAfter) {
+    throw new Error("Cover proof changed public cover projections");
+  }
+  const snapshot = raw
+    .prepare(
+      `select
+         c.work_id, c.representation_type, c.identity_match_kind,
+         c.permission_state, c.object_key, i.media_type, i.byte_size,
+         i.width, i.height, i.aspect_ratio, i.checksum, i.decode_result,
+         i.flags_json, i.quality_score, d.state, d.gate_codes_json,
+         d.warning_codes_json
+       from cover_candidates c
+       join cover_decision_heads h on h.candidate_id = c.id
+       join cover_decisions d on d.id = h.decision_id
+       join cover_inspections i on i.id = d.inspection_id
+       order by c.work_id, c.id`,
+    )
+    .all();
+  console.log(
+    JSON.stringify(
+      {
+        target: target.description,
+        manifest: `${ENRICHMENT_SAMPLE_MANIFEST.id}@${ENRICHMENT_SAMPLE_MANIFEST.version}`,
+        snapshotHash: hashCanonicalJson(snapshot),
+        results,
+        safeguards: {
+          catalogWideScan: false,
+          currentResolutionHeadWrites: false,
+          productionDataWrites: false,
+          providerCalls: false,
+          publicProjectionWrites: false,
+        },
+      },
+      null,
+      2,
+    ),
+  );
+} finally {
+  raw.close();
+}

--- a/src/db/catalog/cover-migration.test.ts
+++ b/src/db/catalog/cover-migration.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("cover inspection migrations", () => {
+  it("add only internal candidate, inspection, decision, and projection tables", () => {
+    for (const migrationPath of [
+      "drizzle/0008_aspiring_karma.sql",
+      "drizzle/pg/0010_clammy_cerebro.sql",
+    ]) {
+      const migration = readFileSync(path.resolve(migrationPath), "utf8");
+      expect(migration.match(/^CREATE TABLE/gm)).toHaveLength(6);
+      expect(migration).toContain("cover_candidates");
+      expect(migration).toContain("cover_inspections");
+      expect(migration).toContain("cover_decisions");
+      expect(migration).toContain("cover_projections");
+      expect(migration).toContain("transformation_history_json");
+      expect(migration).toContain("representation_type");
+      expect(migration).not.toMatch(
+        /update\s+(?:["`]?edition_covers|["`]?cover_assets|["`]?field_resolution_heads)/i,
+      );
+      expect(migration).not.toMatch(
+        /insert\s+into\s+(?:["`]?edition_covers|["`]?field_resolution_heads)/i,
+      );
+    }
+  });
+});

--- a/src/db/catalog/enrichment/covers/fixtures.ts
+++ b/src/db/catalog/enrichment/covers/fixtures.ts
@@ -1,0 +1,317 @@
+import type Database from "better-sqlite3";
+import postgres from "postgres";
+import { canonicalJson, deterministicCatalogId, sha256 } from "../../identity";
+import { ENRICHMENT_SAMPLE_MANIFEST } from "../sample-manifest";
+import { scoreCoverFlags } from "./inspection";
+import type {
+  CoverCandidateInput,
+  CoverFlagCode,
+  CoverInspection,
+} from "./types";
+import { COVER_INSPECTION_VERSION, COVER_POLICY_VERSION } from "./types";
+
+const RECORDED_AT = Date.UTC(2026, 6, 28, 16, 0, 0);
+export const COVER_FIXTURE_SOURCE_POLICY_VERSION =
+  "cover-recorded-fixture-policy-v1";
+export const COVER_FIXTURE_SOURCE_ID = deterministicCatalogId(
+  "metadata_source",
+  "cover-test",
+  "recorded-fixtures",
+);
+
+const sourceRecordId = (workId: string) =>
+  deterministicCatalogId("source_record", "cover-test", workId);
+
+const fixtureTechnical = [
+  {
+    bytes: Math.round(18.3 * 1024),
+    width: 500,
+    height: 500,
+    flags: [
+      "square_canvas",
+      "sidebars",
+      "extreme_aspect_ratio",
+      "extreme_crop",
+      "upscaling_risk",
+    ] as CoverFlagCode[],
+  },
+  {
+    bytes: Math.round(33.4 * 1024),
+    width: 327,
+    height: 500,
+    flags: [
+      "upscaling_risk",
+      "locale_conflict",
+      "adaptation_conflict",
+    ] as CoverFlagCode[],
+  },
+  {
+    bytes: Math.round(39.2 * 1024),
+    width: 331,
+    height: 500,
+    flags: ["upscaling_risk"] as CoverFlagCode[],
+  },
+  {
+    bytes: Math.round(34.2 * 1024),
+    width: 320,
+    height: 500,
+    flags: ["upscaling_risk"] as CoverFlagCode[],
+  },
+  {
+    bytes: Math.round(45.4 * 1024),
+    width: 330,
+    height: 500,
+    flags: ["upscaling_risk"] as CoverFlagCode[],
+  },
+] as const;
+
+export const recordedFiveCoverFixtures = (input: {
+  editionIds: Readonly<Record<string, string>>;
+}): Array<{
+  title: string;
+  candidate: CoverCandidateInput;
+  inspection: CoverInspection;
+}> =>
+  ENRICHMENT_SAMPLE_MANIFEST.works.map((work, index) => {
+    const technical = fixtureTechnical[index];
+    const isDune = work.title === "Dune";
+    const isMobyDick = work.title === "Moby-Dick";
+    const representationType = isDune
+      ? ("selected_edition" as const)
+      : ("work_representative" as const);
+    const identityMatchKind =
+      isDune || isMobyDick
+        ? ("conflicting" as const)
+        : ("title_creator_candidate" as const);
+    const checksum = sha256(
+      canonicalJson({
+        fixture: "recorded-five-cover-audit",
+        revision: "2026-07-28.v1",
+        workId: work.workId,
+        ...technical,
+      }),
+    );
+    return {
+      title: work.title,
+      candidate: {
+        workId: work.workId,
+        editionId: isDune ? input.editionIds[work.workId] : null,
+        sourceRecordId: sourceRecordId(work.workId),
+        representationType,
+        identityMatchKind,
+        identityEvidence: {
+          auditRevision: "docs/research/book-detail-enrichment.md@2026-07-28",
+          selectedEditionIdentifiers: work.exactIdentifiers,
+          finding: isDune
+            ? "square movie-tie-in treatment does not reliably match the stored ISBN"
+            : isMobyDick
+              ? "French Delcourt adaptation conflicts with the plain Melville work"
+              : "plausible work cover without strong stored edition identity",
+        },
+        permissionState: "pending",
+        rightsBasis: null,
+        attributionText: "Recorded Bukie cover audit fixture",
+        attributionUrl: null,
+        sourceUrl: `repository://legacy-catalog/${work.legacyRecordKey}/cover`,
+        sourceRevision: `recorded-cover-audit-2026-07-28:${work.legacyRecordKey}`,
+        sourcePolicyVersion: COVER_FIXTURE_SOURCE_POLICY_VERSION,
+        objectKey: `/covers/${work.legacyRecordKey}.webp`,
+        transformationHistory: [
+          {
+            operation: "legacy_webp_optimization",
+            version: "unknown",
+            parameters: { recordedFromExistingAsset: true },
+          },
+        ],
+        createdAt: RECORDED_AT + index,
+      },
+      inspection: {
+        mediaType: "image/webp",
+        byteSize: technical.bytes,
+        width: technical.width,
+        height: technical.height,
+        aspectRatio: technical.width / technical.height,
+        checksum,
+        decodeResult: "decoded",
+        flags: [...technical.flags].sort(),
+        qualityScore: scoreCoverFlags(technical.flags),
+        inspectionVersion: COVER_INSPECTION_VERSION,
+        inspectedAt: RECORDED_AT + index,
+      },
+    };
+  });
+
+export const approvedCoverFixture = (input: {
+  workId: string;
+  editionId: string;
+  suffix?: string;
+  qualityScore?: number;
+}): { candidate: CoverCandidateInput; inspection: CoverInspection } => {
+  const suffix = input.suffix ?? "primary";
+  const checksum = sha256(`approved-cover-fixture:${input.workId}:${suffix}`);
+  return {
+    candidate: {
+      workId: input.workId,
+      editionId: input.editionId,
+      sourceRecordId: sourceRecordId(input.workId),
+      representationType: "selected_edition",
+      identityMatchKind: "exact_isbn",
+      identityEvidence: { isbn13: "9780441172719", fixture: suffix },
+      permissionState: "approved",
+      rightsBasis: "Recorded test fixture permission",
+      attributionText: "Recorded cover fixture",
+      attributionUrl: "https://example.invalid/cover-fixture",
+      sourceUrl: `https://example.invalid/covers/${suffix}.webp`,
+      sourceRevision: `recorded-cover-audit-2026-07-28:${ENRICHMENT_SAMPLE_MANIFEST.works.find((work) => work.workId === input.workId)?.legacyRecordKey}`,
+      sourcePolicyVersion: COVER_FIXTURE_SOURCE_POLICY_VERSION,
+      objectKey: `/covers/candidates/${input.workId}-${suffix}.webp`,
+      transformationHistory: [],
+      createdAt: RECORDED_AT + 100,
+    },
+    inspection: {
+      mediaType: "image/webp",
+      byteSize: 72_000,
+      width: 600,
+      height: 900,
+      aspectRatio: 2 / 3,
+      checksum,
+      decodeResult: "decoded",
+      flags: [],
+      qualityScore: input.qualityScore ?? 90,
+      inspectionVersion: COVER_INSPECTION_VERSION,
+      inspectedAt: RECORDED_AT + 100,
+    },
+  };
+};
+
+const metadataPolicy = canonicalJson({
+  proposedEvidenceOnly: true,
+  sourcePolicyVersion: COVER_FIXTURE_SOURCE_POLICY_VERSION,
+});
+const assetPolicy = canonicalJson({
+  attribution: { required: true },
+  cache: true,
+  display: true,
+  fieldPermission: {
+    allowedFields: ["edition.covers"],
+    cache: true,
+    fetch: true,
+    transform: true,
+  },
+  proposedEvidenceOnly: true,
+  purgeOnWithdrawal: true,
+  sourcePolicyVersion: COVER_FIXTURE_SOURCE_POLICY_VERSION,
+});
+
+export const seedCoverFixturesSqlite = (
+  raw: InstanceType<typeof Database>,
+): void => {
+  raw
+    .prepare(
+      `insert into metadata_sources (
+         id, key, name, terms_url, attribution_url, reviewed_at, approval_state,
+         metadata_policy, asset_policy, payload_policy, refresh_interval_ms
+       ) values (?, 'cover_recorded_fixtures', 'Recorded cover inspection fixtures',
+         null, 'https://example.invalid/cover-fixture', ?, 'approved', ?, ?,
+         'selected_fields', null)`,
+    )
+    .run(COVER_FIXTURE_SOURCE_ID, RECORDED_AT, metadataPolicy, assetPolicy);
+  const sourceRecord = raw.prepare(
+    `insert into source_records (
+       id, source_id, record_key, source_revision, source_modified_at,
+       retrieved_at, payload_json, payload_hash, importer_version,
+       source_row_hash, state
+     ) values (?, ?, ?, ?, null, ?, null, null, 'cover-fixture-v1', ?, 'active')`,
+  );
+  const link = raw.prepare(
+    `insert into source_record_links (
+       source_record_id, entity_type, entity_id, match_kind,
+       mapping_confidence, state, actor_ref, reason, created_at
+     ) values (?, ?, ?, 'curated', 1, 'active',
+       'system:cover-fixture', 'Recorded deterministic cover fixture', ?)`,
+  );
+  for (const work of ENRICHMENT_SAMPLE_MANIFEST.works) {
+    const recordId = sourceRecordId(work.workId);
+    const edition = raw
+      .prepare("select preferred_edition_id as id from works where id = ?")
+      .get(work.workId) as { id: string };
+    const revision = `recorded-cover-audit-2026-07-28:${work.legacyRecordKey}`;
+    sourceRecord.run(
+      recordId,
+      COVER_FIXTURE_SOURCE_ID,
+      work.legacyRecordKey,
+      revision,
+      RECORDED_AT,
+      sha256(revision),
+    );
+    for (const [entityType, entityId] of [
+      ["work", work.workId],
+      ["edition", edition.id],
+    ] as const) {
+      link.run(recordId, entityType, entityId, RECORDED_AT);
+    }
+  }
+};
+
+export const seedCoverFixturesPostgres = async (url: string): Promise<void> => {
+  const client = postgres(url, { max: 1 });
+  try {
+    await client.unsafe(
+      `insert into metadata_sources (
+         id, key, name, terms_url, attribution_url, reviewed_at, approval_state,
+         metadata_policy, asset_policy, payload_policy, refresh_interval_ms
+       ) values ($1, 'cover_recorded_fixtures',
+         'Recorded cover inspection fixtures', null,
+         'https://example.invalid/cover-fixture', $2, 'approved',
+         $3::jsonb, $4::jsonb, 'selected_fields', null)`,
+      [
+        COVER_FIXTURE_SOURCE_ID,
+        RECORDED_AT,
+        JSON.parse(metadataPolicy),
+        JSON.parse(assetPolicy),
+      ],
+    );
+    for (const work of ENRICHMENT_SAMPLE_MANIFEST.works) {
+      const recordId = sourceRecordId(work.workId);
+      const edition = await client.unsafe(
+        "select preferred_edition_id as id from works where id = $1",
+        [work.workId],
+      );
+      const revision = `recorded-cover-audit-2026-07-28:${work.legacyRecordKey}`;
+      await client.unsafe(
+        `insert into source_records (
+           id, source_id, record_key, source_revision, source_modified_at,
+           retrieved_at, payload_json, payload_hash, importer_version,
+           source_row_hash, state
+         ) values ($1, $2, $3, $4, null, $5, null, null,
+           'cover-fixture-v1', $6, 'active')`,
+        [
+          recordId,
+          COVER_FIXTURE_SOURCE_ID,
+          work.legacyRecordKey,
+          revision,
+          RECORDED_AT,
+          sha256(revision),
+        ],
+      );
+      for (const [entityType, entityId] of [
+        ["work", work.workId],
+        ["edition", String(edition[0]?.id)],
+      ] as const) {
+        await client.unsafe(
+          `insert into source_record_links (
+             source_record_id, entity_type, entity_id, match_kind,
+             mapping_confidence, state, actor_ref, reason, created_at
+           ) values ($1, $2, $3, 'curated', 1, 'active',
+             'system:cover-fixture',
+             'Recorded deterministic cover fixture', $4)`,
+          [recordId, entityType, entityId, RECORDED_AT],
+        );
+      }
+    }
+  } finally {
+    await client.end({ timeout: 5_000 });
+  }
+};
+
+export const COVER_FIXTURE_POLICY_VERSION = COVER_POLICY_VERSION;

--- a/src/db/catalog/enrichment/covers/fixtures.ts
+++ b/src/db/catalog/enrichment/covers/fixtures.ts
@@ -195,12 +195,14 @@ const assetPolicy = canonicalJson({
   fieldPermission: {
     allowedFields: ["edition.covers"],
     cache: true,
+    display: true,
     fetch: true,
     transform: true,
   },
   proposedEvidenceOnly: true,
   purgeOnWithdrawal: true,
   sourcePolicyVersion: COVER_FIXTURE_SOURCE_POLICY_VERSION,
+  transform: true,
 });
 
 export const seedCoverFixturesSqlite = (

--- a/src/db/catalog/enrichment/covers/inspection.test.ts
+++ b/src/db/catalog/enrichment/covers/inspection.test.ts
@@ -1,0 +1,101 @@
+import { createHash } from "node:crypto";
+import sharp from "sharp";
+import { describe, expect, it } from "vitest";
+import { inspectCoverBytes } from "./inspection";
+
+const INSPECTED_AT = Date.UTC(2026, 6, 29, 10, 0, 0);
+
+describe("cover byte inspection", () => {
+  it("records usable technical metadata and stable square/sidebar/crop flags", async () => {
+    const bytes = await sharp(
+      Buffer.from(
+        `<svg width="500" height="500" xmlns="http://www.w3.org/2000/svg">
+           <rect width="500" height="500" fill="white"/>
+           <rect x="100" width="300" height="500" fill="#24202d"/>
+           <path d="M100 420 L250 80 L400 420 Z" fill="#d19035"/>
+         </svg>`,
+      ),
+    )
+      .webp({ quality: 80 })
+      .toBuffer();
+
+    const first = await inspectCoverBytes({ bytes, inspectedAt: INSPECTED_AT });
+    const retry = await inspectCoverBytes({ bytes, inspectedAt: INSPECTED_AT });
+
+    expect(first).toMatchObject({
+      mediaType: "image/webp",
+      byteSize: bytes.length,
+      width: 500,
+      height: 500,
+      aspectRatio: 1,
+      decodeResult: "decoded",
+    });
+    expect(first.checksum).toBe(
+      createHash("sha256").update(bytes).digest("hex"),
+    );
+    expect(first.flags).toEqual(
+      expect.arrayContaining([
+        "square_canvas",
+        "sidebars",
+        "extreme_aspect_ratio",
+        "extreme_crop",
+        "upscaling_risk",
+      ]),
+    );
+    expect(retry).toEqual(first);
+  });
+
+  it("records corruption without inventing dimensions", async () => {
+    const bytes = Buffer.from("not an image");
+
+    const result = await inspectCoverBytes({
+      bytes,
+      inspectedAt: INSPECTED_AT,
+    });
+
+    expect(result).toMatchObject({
+      mediaType: null,
+      byteSize: bytes.length,
+      width: null,
+      height: null,
+      aspectRatio: null,
+      decodeResult: "corrupt",
+      flags: ["corrupt"],
+      qualityScore: 0,
+    });
+  });
+
+  it("adds deterministic manual identity and quality-risk signals", async () => {
+    const bytes = await sharp({
+      create: {
+        width: 240,
+        height: 320,
+        channels: 3,
+        background: "#777777",
+      },
+    })
+      .png()
+      .toBuffer();
+
+    const result = await inspectCoverBytes({
+      bytes,
+      inspectedAt: INSPECTED_AT,
+      signals: {
+        adaptationConflict: true,
+        blurRisk: true,
+        localeConflict: true,
+      },
+    });
+
+    expect(result.flags).toEqual(
+      expect.arrayContaining([
+        "tiny_dimensions",
+        "blur_risk",
+        "upscaling_risk",
+        "locale_conflict",
+        "adaptation_conflict",
+      ]),
+    );
+    expect(result.qualityScore).toBeLessThan(50);
+  });
+});

--- a/src/db/catalog/enrichment/covers/inspection.ts
+++ b/src/db/catalog/enrichment/covers/inspection.ts
@@ -1,0 +1,197 @@
+import { createHash } from "node:crypto";
+import sharp from "sharp";
+import type {
+  CoverFlagCode,
+  CoverInspection,
+  CoverInspectionSignals,
+} from "./types";
+import { COVER_INSPECTION_VERSION } from "./types";
+
+const ALLOWED_MEDIA_TYPES = new Set([
+  "image/avif",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+]);
+const TARGET_ASPECT_RATIO = 2 / 3;
+
+const mediaTypeForFormat = (format: string | undefined): string | null => {
+  if (format === "jpg" || format === "jpeg") return "image/jpeg";
+  if (format === "png") return "image/png";
+  if (format === "webp") return "image/webp";
+  if (format === "avif" || format === "heif") return "image/avif";
+  return format ? `image/${format}` : null;
+};
+
+const meanRegion = (
+  pixels: Buffer,
+  width: number,
+  height: number,
+  startX: number,
+  endX: number,
+): number => {
+  let total = 0;
+  let count = 0;
+  for (let y = 0; y < height; y += 1) {
+    for (let x = startX; x < endX; x += 1) {
+      total += pixels[y * width + x] ?? 0;
+      count += 1;
+    }
+  }
+  return count === 0 ? 0 : total / count;
+};
+
+const detectsLightSidebars = async (bytes: Buffer): Promise<boolean> => {
+  const { data, info } = await sharp(bytes)
+    .resize({ width: 120, height: 180, fit: "fill" })
+    .removeAlpha()
+    .greyscale()
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+  const edgeWidth = Math.max(1, Math.floor(info.width * 0.1));
+  const centerStart = Math.floor(info.width * 0.3);
+  const centerEnd = Math.ceil(info.width * 0.7);
+  const left = meanRegion(data, info.width, info.height, 0, edgeWidth);
+  const right = meanRegion(
+    data,
+    info.width,
+    info.height,
+    info.width - edgeWidth,
+    info.width,
+  );
+  const center = meanRegion(
+    data,
+    info.width,
+    info.height,
+    centerStart,
+    centerEnd,
+  );
+  return left >= 238 && right >= 238 && (left + right) / 2 - center >= 22;
+};
+
+const advisoryScore = (flags: readonly CoverFlagCode[]): number => {
+  const penalties: Record<CoverFlagCode, number> = {
+    corrupt: 100,
+    tiny_dimensions: 30,
+    square_canvas: 18,
+    sidebars: 18,
+    extreme_aspect_ratio: 20,
+    extreme_crop: 16,
+    blur_risk: 18,
+    upscaling_risk: 10,
+    duplicate: 4,
+    locale_conflict: 30,
+    adaptation_conflict: 40,
+  };
+  return Math.max(
+    0,
+    100 - flags.reduce((total, flag) => total + penalties[flag], 0),
+  );
+};
+
+const sortedFlags = (flags: Iterable<CoverFlagCode>): CoverFlagCode[] =>
+  [...new Set(flags)].sort();
+
+export const inspectCoverBytes = async (input: {
+  bytes: Uint8Array;
+  inspectedAt: number;
+  signals?: CoverInspectionSignals;
+}): Promise<CoverInspection> => {
+  const bytes = Buffer.from(input.bytes);
+  const checksum = createHash("sha256").update(bytes).digest("hex");
+  try {
+    const image = sharp(bytes, { failOn: "error" });
+    const [metadata, stats, sidebars] = await Promise.all([
+      image.metadata(),
+      image.clone().stats(),
+      detectsLightSidebars(bytes),
+    ]);
+    const width = metadata.width ?? null;
+    const height = metadata.height ?? null;
+    const mediaType = mediaTypeForFormat(metadata.format);
+    if (
+      !width ||
+      !height ||
+      !mediaType ||
+      !ALLOWED_MEDIA_TYPES.has(mediaType)
+    ) {
+      const flags = sortedFlags([
+        ...(input.signals?.localeConflict ? ["locale_conflict" as const] : []),
+        ...(input.signals?.adaptationConflict
+          ? ["adaptation_conflict" as const]
+          : []),
+      ]);
+      return {
+        mediaType,
+        byteSize: bytes.length,
+        width: null,
+        height: null,
+        aspectRatio: null,
+        checksum,
+        decodeResult: "unsupported",
+        flags,
+        qualityScore: advisoryScore(flags),
+        inspectionVersion: COVER_INSPECTION_VERSION,
+        inspectedAt: input.inspectedAt,
+      };
+    }
+
+    const aspectRatio = width / height;
+    const cropLoss =
+      1 -
+      Math.min(
+        TARGET_ASPECT_RATIO / aspectRatio,
+        aspectRatio / TARGET_ASPECT_RATIO,
+      );
+    const flags = sortedFlags([
+      ...(width < 300 || height < 450 ? ["tiny_dimensions" as const] : []),
+      ...(aspectRatio >= 0.9 && aspectRatio <= 1.1
+        ? ["square_canvas" as const]
+        : []),
+      ...(sidebars || input.signals?.sidebars ? ["sidebars" as const] : []),
+      ...(aspectRatio < 0.45 || aspectRatio > 0.85
+        ? ["extreme_aspect_ratio" as const]
+        : []),
+      ...(cropLoss > 0.2 || input.signals?.extremeCrop
+        ? ["extreme_crop" as const]
+        : []),
+      ...(stats.sharpness < 1 || input.signals?.blurRisk
+        ? ["blur_risk" as const]
+        : []),
+      ...(width < 450 || height < 675 ? ["upscaling_risk" as const] : []),
+      ...(input.signals?.localeConflict ? ["locale_conflict" as const] : []),
+      ...(input.signals?.adaptationConflict
+        ? ["adaptation_conflict" as const]
+        : []),
+    ]);
+    return {
+      mediaType,
+      byteSize: bytes.length,
+      width,
+      height,
+      aspectRatio,
+      checksum,
+      decodeResult: "decoded",
+      flags,
+      qualityScore: advisoryScore(flags),
+      inspectionVersion: COVER_INSPECTION_VERSION,
+      inspectedAt: input.inspectedAt,
+    };
+  } catch {
+    return {
+      mediaType: null,
+      byteSize: bytes.length,
+      width: null,
+      height: null,
+      aspectRatio: null,
+      checksum,
+      decodeResult: "corrupt",
+      flags: ["corrupt"],
+      qualityScore: 0,
+      inspectionVersion: COVER_INSPECTION_VERSION,
+      inspectedAt: input.inspectedAt,
+    };
+  }
+};
+
+export const scoreCoverFlags = advisoryScore;

--- a/src/db/catalog/enrichment/covers/inspection.ts
+++ b/src/db/catalog/enrichment/covers/inspection.ts
@@ -79,7 +79,7 @@ const advisoryScore = (flags: readonly CoverFlagCode[]): number => {
     extreme_crop: 16,
     blur_risk: 18,
     upscaling_risk: 10,
-    duplicate: 4,
+    duplicate: 0,
     locale_conflict: 30,
     adaptation_conflict: 40,
   };

--- a/src/db/catalog/enrichment/covers/repository.pg.test.ts
+++ b/src/db/catalog/enrichment/covers/repository.pg.test.ts
@@ -14,6 +14,8 @@ import {
 import {
   createCoverCandidatePostgres,
   getCoverSelectionPostgres,
+  retryCoverWithdrawalPurgePostgres,
+  reviewCoverCandidatePostgres,
   rollbackCoverProjectionPostgres,
   withdrawCoverCandidatePostgres,
 } from "./repository.pg";
@@ -147,20 +149,56 @@ describe.skipIf(!isolatedUrl)(
         suffix: "pg-preferred",
         qualityScore: 95,
       });
+      preferred.inspection.flags = ["square_canvas"];
       const preferredResult = await createCoverCandidatePostgres({
         url: target.url,
         ...preferred,
       });
+      expect(preferredResult.state).toBe("review_required");
+      await expect(
+        reviewCoverCandidatePostgres({
+          url: target.url,
+          candidateId: preferredResult.candidateId,
+          reviewerRef: "user:pg-cover-reviewer",
+          decision: "approve",
+          reason: "Review the square-canvas fixture",
+          acknowledgedWarningCodes: [],
+          reviewedAt: NOW,
+        }),
+      ).rejects.toThrow("warnings not acknowledged");
+      await expect(
+        reviewCoverCandidatePostgres({
+          url: target.url,
+          candidateId: preferredResult.candidateId,
+          reviewerRef: "user:pg-cover-reviewer",
+          decision: "approve",
+          reason: "Reviewed the square-canvas fixture",
+          acknowledgedWarningCodes: ["square_canvas"],
+          reviewedAt: NOW + 1,
+        }),
+      ).resolves.toMatchObject({ state: "eligible" });
       const purge = vi.fn();
       await withdrawCoverCandidatePostgres({
         url: target.url,
         candidateId: preferredResult.candidateId,
         actorRef: "user:pg-cover-withdrawal",
         reason: "Postgres fixture withdrawal",
-        withdrawnAt: NOW,
+        withdrawnAt: NOW + 2,
         purgeAsset: purge,
       });
       expect(purge).toHaveBeenCalledWith(preferred.candidate.objectKey);
+      const repeatedPurge = vi.fn();
+      await expect(
+        withdrawCoverCandidatePostgres({
+          url: target.url,
+          candidateId: preferredResult.candidateId,
+          actorRef: "user:pg-cover-withdrawal",
+          reason: "Repeated Postgres fixture withdrawal",
+          withdrawnAt: NOW + 3,
+          purgeAsset: repeatedPurge,
+        }),
+      ).resolves.toMatchObject({ changed: false, state: "withdrawn" });
+      expect(repeatedPurge).not.toHaveBeenCalled();
       expect(
         await getCoverSelectionPostgres({
           url: target.url,
@@ -174,19 +212,55 @@ describe.skipIf(!isolatedUrl)(
         suffix: "pg-replacement",
         qualityScore: 99,
       });
-      await createCoverCandidatePostgres({ url: target.url, ...replacement });
+      const replacementResult = await createCoverCandidatePostgres({
+        url: target.url,
+        ...replacement,
+      });
       const rolledBack = await rollbackCoverProjectionPostgres({
         url: target.url,
         workId: work.workId,
         targetProjectionId: fallbackProjectionId,
         actorRef: "user:pg-rollback",
         reason: "Restore reviewed fallback",
-        rolledBackAt: NOW + 1,
+        rolledBackAt: NOW + 4,
       });
       expect(rolledBack.selection).toMatchObject({
         candidateId: fallbackResult.candidateId,
         state: "rolled_back",
       });
+      await expect(
+        rollbackCoverProjectionPostgres({
+          url: target.url,
+          workId: work.workId,
+          targetProjectionId: fallbackProjectionId,
+          actorRef: "user:pg-rollback",
+          reason: "Repeated reviewed fallback rollback",
+          rolledBackAt: NOW + 5,
+        }),
+      ).resolves.toMatchObject({ changed: false });
+
+      const failedPurge = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("pg purge failed"));
+      await expect(
+        withdrawCoverCandidatePostgres({
+          url: target.url,
+          candidateId: replacementResult.candidateId,
+          actorRef: "user:pg-cover-withdrawal",
+          reason: "Exercise Postgres purge retry",
+          withdrawnAt: NOW + 6,
+          purgeAsset: failedPurge,
+        }),
+      ).rejects.toThrow("pg purge failed");
+      const retryPurge = vi.fn();
+      await expect(
+        retryCoverWithdrawalPurgePostgres({
+          url: target.url,
+          candidateId: replacementResult.candidateId,
+          purgeAsset: retryPurge,
+        }),
+      ).resolves.toBe(true);
+      expect(retryPurge).toHaveBeenCalledWith(replacement.candidate.objectKey);
 
       const finalClient = postgres(target.url, { max: 1 });
       try {
@@ -207,6 +281,188 @@ describe.skipIf(!isolatedUrl)(
       } finally {
         await finalClient.end({ timeout: 5_000 });
       }
+    });
+
+    it("enforces hard gates and canonicalizes duplicates independently of arrival order", async () => {
+      const target = resolveRebuildTarget({
+        rawTarget: `postgres:${isolatedUrl}`,
+        confirmDisposable: true,
+        env: { NODE_ENV: "test" },
+      });
+      if (target.driver !== "postgres") {
+        throw new Error("Expected an isolated Postgres target");
+      }
+      const rebuild = async () => {
+        await rebuildCatalogPostgres({
+          url: target.url,
+          graph: buildCatalogImportGraph(SAMPLE_BASELINE_IMPORT_RECORDS),
+        });
+        await seedCoverFixturesPostgres(target.url);
+        const client = postgres(target.url, { max: 1 });
+        try {
+          const workId = ENRICHMENT_SAMPLE_MANIFEST.works[0].workId;
+          const edition = await client.unsafe(
+            "select preferred_edition_id as id from works where id = $1",
+            [workId],
+          );
+          return { workId, editionId: String(edition[0]?.id) };
+        } finally {
+          await client.end({ timeout: 5_000 });
+        }
+      };
+
+      const identifiers = await rebuild();
+      const policyClient = postgres(target.url, { max: 1 });
+      let originalPolicy: Record<string, unknown> = {};
+      try {
+        const source = await policyClient.unsafe(
+          `select asset_policy as policy from metadata_sources
+           where key = 'cover_recorded_fixtures'`,
+        );
+        originalPolicy = source[0]?.policy as Record<string, unknown>;
+        const fieldPermission = {
+          ...(originalPolicy.fieldPermission as Record<string, unknown>),
+          cache: false,
+          transform: false,
+        };
+        await policyClient.unsafe(
+          `update metadata_sources set asset_policy = $1::jsonb
+           where key = 'cover_recorded_fixtures'`,
+          [
+            {
+              ...originalPolicy,
+              cache: false,
+              transform: false,
+              fieldPermission,
+            },
+          ],
+        );
+      } finally {
+        await policyClient.end({ timeout: 5_000 });
+      }
+      const deniedPolicy = approvedCoverFixture({
+        ...identifiers,
+        suffix: "pg-denied-cache-transform",
+      });
+      deniedPolicy.candidate.transformationHistory = [
+        {
+          operation: "webp",
+          version: "1",
+          parameters: { quality: 80 },
+        },
+      ];
+      await expect(
+        createCoverCandidatePostgres({
+          url: target.url,
+          ...deniedPolicy,
+        }),
+      ).resolves.toMatchObject({
+        state: "rejected",
+        gateCodes: expect.arrayContaining(["source_policy_ineligible"]),
+      });
+
+      const tupleClient = postgres(target.url, { max: 1 });
+      try {
+        await tupleClient.unsafe(
+          `update metadata_sources set asset_policy = $1::jsonb
+           where key = 'cover_recorded_fixtures'`,
+          [originalPolicy as postgres.JSONValue],
+        );
+        await tupleClient.unsafe(
+          `update source_record_links set match_kind = 'candidate'
+           where entity_type = 'edition' and entity_id = $1`,
+          [identifiers.editionId],
+        );
+      } finally {
+        await tupleClient.end({ timeout: 5_000 });
+      }
+      const selfApprovedTuple = approvedCoverFixture({
+        ...identifiers,
+        suffix: "pg-self-approved-tuple",
+      });
+      selfApprovedTuple.candidate.identityMatchKind =
+        "approved_strong_edition_tuple";
+      selfApprovedTuple.candidate.identityEvidence = {
+        policyApproved: true,
+        title: "Unverified title",
+        publisher: "Unverified publisher",
+      };
+      await expect(
+        createCoverCandidatePostgres({
+          url: target.url,
+          ...selfApprovedTuple,
+        }),
+      ).resolves.toMatchObject({
+        state: "review_required",
+        gateCodes: expect.arrayContaining(["identity_evidence_ineligible"]),
+      });
+
+      const duplicateMaps = async (
+        reverse: boolean,
+      ): Promise<{
+        flags: Record<string, unknown>;
+        states: Record<string, unknown>;
+        winner: string | null;
+      }> => {
+        const current = await rebuild();
+        const first = approvedCoverFixture({
+          ...current,
+          suffix: "pg-duplicate-a",
+        });
+        const second = approvedCoverFixture({
+          ...current,
+          suffix: "pg-duplicate-b",
+        });
+        second.inspection.checksum = first.inspection.checksum;
+        const candidateIds: string[] = [];
+        for (const fixture of reverse ? [second, first] : [first, second]) {
+          candidateIds.push(
+            (
+              await createCoverCandidatePostgres({
+                url: target.url,
+                ...fixture,
+              })
+            ).candidateId,
+          );
+        }
+        const client = postgres(target.url, { max: 1 });
+        try {
+          const inspections = await client.unsafe(
+            `select candidate_id as id, flags_json as flags
+             from cover_inspections where checksum = $1 order by candidate_id`,
+            [first.inspection.checksum],
+          );
+          const decisions = await client.unsafe(
+            `select h.candidate_id as id, d.state,
+                    d.warning_codes_json as warnings
+             from cover_decision_heads h
+             join cover_decisions d on d.id = h.decision_id
+             where h.candidate_id in ($1, $2)
+             order by h.candidate_id`,
+            candidateIds,
+          );
+          return {
+            flags: Object.fromEntries(
+              inspections.map((row) => [String(row.id), row.flags]),
+            ),
+            states: Object.fromEntries(
+              decisions.map((row) => [
+                String(row.id),
+                { state: row.state, warnings: row.warnings },
+              ]),
+            ),
+            winner: (
+              await getCoverSelectionPostgres({
+                url: target.url,
+                workId: current.workId,
+              })
+            ).candidateId,
+          };
+        } finally {
+          await client.end({ timeout: 5_000 });
+        }
+      };
+      expect(await duplicateMaps(true)).toEqual(await duplicateMaps(false));
     });
   },
 );

--- a/src/db/catalog/enrichment/covers/repository.pg.test.ts
+++ b/src/db/catalog/enrichment/covers/repository.pg.test.ts
@@ -1,0 +1,212 @@
+import postgres from "postgres";
+import { describe, expect, it, vi } from "vitest";
+import { PLACEHOLDER_COVER } from "../../../../media/covers";
+import { buildCatalogImportGraph } from "../../importer";
+import { rebuildCatalogPostgres } from "../../postgres-rebuild";
+import { resolveRebuildTarget } from "../../rebuild-safety";
+import { SAMPLE_BASELINE_IMPORT_RECORDS } from "../fixtures";
+import { ENRICHMENT_SAMPLE_MANIFEST } from "../sample-manifest";
+import {
+  approvedCoverFixture,
+  recordedFiveCoverFixtures,
+  seedCoverFixturesPostgres,
+} from "./fixtures";
+import {
+  createCoverCandidatePostgres,
+  getCoverSelectionPostgres,
+  rollbackCoverProjectionPostgres,
+  withdrawCoverCandidatePostgres,
+} from "./repository.pg";
+
+const isolatedUrl = process.env.CATALOG_TEST_POSTGRES_URL;
+const NOW = Date.UTC(2026, 6, 29, 14, 0, 0);
+
+describe.skipIf(!isolatedUrl)(
+  "Postgres edition-matched cover lifecycle",
+  () => {
+    it("matches SQLite fixtures, idempotency, rollback, withdrawal, and public isolation", async () => {
+      const target = resolveRebuildTarget({
+        rawTarget: `postgres:${isolatedUrl}`,
+        confirmDisposable: true,
+        env: { NODE_ENV: "test" },
+      });
+      if (target.driver !== "postgres") {
+        throw new Error("Expected an isolated Postgres target");
+      }
+      await rebuildCatalogPostgres({
+        url: target.url,
+        graph: buildCatalogImportGraph(SAMPLE_BASELINE_IMPORT_RECORDS),
+      });
+      await seedCoverFixturesPostgres(target.url);
+      const client = postgres(target.url, { max: 1 });
+      const editionIds: Record<string, string> = {};
+      let publicBefore: unknown;
+      try {
+        for (const work of ENRICHMENT_SAMPLE_MANIFEST.works) {
+          const rows = await client.unsafe(
+            "select preferred_edition_id as id from works where id = $1",
+            [work.workId],
+          );
+          editionIds[work.workId] = String(rows[0]?.id);
+        }
+        publicBefore = (
+          await client.unsafe(
+            `select
+             (select count(*)::int from edition_covers) as relations,
+             (select count(*)::int from field_resolution_heads
+               where field_key = 'edition.covers') as heads`,
+          )
+        )[0];
+      } finally {
+        await client.end({ timeout: 5_000 });
+      }
+
+      const recorded = recordedFiveCoverFixtures({ editionIds });
+      const results = [];
+      for (const fixture of recorded) {
+        results.push({
+          title: fixture.title,
+          result: await createCoverCandidatePostgres({
+            url: target.url,
+            ...fixture,
+          }),
+        });
+      }
+      expect(results.find((row) => row.title === "Dune")?.result).toMatchObject(
+        {
+          state: "rejected",
+          gateCodes: expect.arrayContaining(["identity_conflict"]),
+          warningCodes: expect.arrayContaining(["square_canvas", "sidebars"]),
+        },
+      );
+      expect(
+        results.find((row) => row.title === "Moby-Dick")?.result,
+      ).toMatchObject({
+        state: "rejected",
+        gateCodes: expect.arrayContaining([
+          "locale_conflict",
+          "adaptation_conflict",
+        ]),
+      });
+      expect(
+        await getCoverSelectionPostgres({
+          url: target.url,
+          workId: recorded[2].candidate.workId,
+        }),
+      ).toMatchObject({
+        candidateId: null,
+        objectKey: PLACEHOLDER_COVER,
+        publicDisplayEligible: false,
+      });
+
+      const work = ENRICHMENT_SAMPLE_MANIFEST.works[0];
+      const fallback = approvedCoverFixture({
+        workId: work.workId,
+        editionId: editionIds[work.workId],
+        suffix: "pg-fallback",
+        qualityScore: 80,
+      });
+      const fallbackResult = await createCoverCandidatePostgres({
+        url: target.url,
+        ...fallback,
+      });
+      const retry = await createCoverCandidatePostgres({
+        url: target.url,
+        ...fallback,
+      });
+      expect(retry).toMatchObject({
+        candidateId: fallbackResult.candidateId,
+        changed: false,
+      });
+      await expect(
+        createCoverCandidatePostgres({
+          url: target.url,
+          ...approvedCoverFixture({
+            workId: work.workId,
+            editionId: editionIds[work.workId],
+            suffix: "pg-failed",
+          }),
+          failAfter: "decision",
+        }),
+      ).rejects.toThrow("Forced Postgres cover decision failure");
+
+      const historyClient = postgres(target.url, { max: 1 });
+      let fallbackProjectionId: string;
+      try {
+        const row = await historyClient.unsafe(
+          "select projection_id as id from cover_projection_heads where work_id = $1",
+          [work.workId],
+        );
+        fallbackProjectionId = String(row[0]?.id);
+      } finally {
+        await historyClient.end({ timeout: 5_000 });
+      }
+      const preferred = approvedCoverFixture({
+        workId: work.workId,
+        editionId: editionIds[work.workId],
+        suffix: "pg-preferred",
+        qualityScore: 95,
+      });
+      const preferredResult = await createCoverCandidatePostgres({
+        url: target.url,
+        ...preferred,
+      });
+      const purge = vi.fn();
+      await withdrawCoverCandidatePostgres({
+        url: target.url,
+        candidateId: preferredResult.candidateId,
+        actorRef: "user:pg-cover-withdrawal",
+        reason: "Postgres fixture withdrawal",
+        withdrawnAt: NOW,
+        purgeAsset: purge,
+      });
+      expect(purge).toHaveBeenCalledWith(preferred.candidate.objectKey);
+      expect(
+        await getCoverSelectionPostgres({
+          url: target.url,
+          workId: work.workId,
+        }),
+      ).toMatchObject({ candidateId: fallbackResult.candidateId });
+
+      const replacement = approvedCoverFixture({
+        workId: work.workId,
+        editionId: editionIds[work.workId],
+        suffix: "pg-replacement",
+        qualityScore: 99,
+      });
+      await createCoverCandidatePostgres({ url: target.url, ...replacement });
+      const rolledBack = await rollbackCoverProjectionPostgres({
+        url: target.url,
+        workId: work.workId,
+        targetProjectionId: fallbackProjectionId,
+        actorRef: "user:pg-rollback",
+        reason: "Restore reviewed fallback",
+        rolledBackAt: NOW + 1,
+      });
+      expect(rolledBack.selection).toMatchObject({
+        candidateId: fallbackResult.candidateId,
+        state: "rolled_back",
+      });
+
+      const finalClient = postgres(target.url, { max: 1 });
+      try {
+        const publicAfter = (
+          await finalClient.unsafe(
+            `select
+             (select count(*)::int from edition_covers) as relations,
+             (select count(*)::int from field_resolution_heads
+               where field_key = 'edition.covers') as heads`,
+          )
+        )[0];
+        expect(publicAfter).toEqual(publicBefore);
+        expect(
+          await finalClient.unsafe(
+            "select count(*)::int as count from cover_candidates",
+          ),
+        ).toEqual([expect.objectContaining({ count: 8 })]);
+      } finally {
+        await finalClient.end({ timeout: 5_000 });
+      }
+    });
+  },
+);

--- a/src/db/catalog/enrichment/covers/repository.pg.ts
+++ b/src/db/catalog/enrichment/covers/repository.pg.ts
@@ -1,0 +1,872 @@
+import postgres from "postgres";
+import { PLACEHOLDER_COVER } from "../../../../media/covers";
+import {
+  canonicalJson,
+  deterministicCatalogId,
+  hashCanonicalJson,
+} from "../../identity";
+import { coverCandidateIdentity, coverInspectionIdentity } from "./repository";
+import type {
+  CoverCandidateInput,
+  CoverCandidateResult,
+  CoverFlagCode,
+  CoverGateCode,
+  CoverInspection,
+  CoverSelection,
+} from "./types";
+import { COVER_POLICY_VERSION } from "./types";
+import {
+  type CoverSourceContext,
+  coverPolicyRequiresPurge,
+  validateCoverCandidate,
+} from "./validation";
+
+type PgSql = postgres.Sql | postgres.TransactionSql;
+
+type CandidateRow = {
+  id: string;
+  workId: string;
+  editionId: string | null;
+  sourceRecordId: string;
+  representationType: "selected_edition" | "work_representative";
+  identityMatchKind: CoverCandidateInput["identityMatchKind"];
+  identityEvidence: Record<string, unknown>;
+  permissionState: CoverCandidateInput["permissionState"];
+  rightsBasis: string | null;
+  attributionText: string | null;
+  attributionUrl: string | null;
+  sourceUrl: string;
+  sourceRevision: string;
+  sourcePolicyVersion: string;
+  objectKey: string;
+  transformationHistory: CoverCandidateInput["transformationHistory"];
+  createdAt: number;
+};
+
+type InspectionRow = {
+  id: string;
+  candidateId: string;
+  mediaType: string | null;
+  byteSize: number;
+  width: number | null;
+  height: number | null;
+  aspectRatio: number | null;
+  checksum: string;
+  decodeResult: CoverInspection["decodeResult"];
+  flags: CoverFlagCode[];
+  qualityScore: number;
+  inspectionVersion: string;
+  inspectedAt: number;
+};
+
+type DecisionRow = {
+  id: string;
+  inspectionId: string;
+  state: CoverCandidateResult["state"];
+  gateCodes: CoverGateCode[];
+  warningCodes: CoverFlagCode[];
+  purgeState: "not_required" | "pending" | "completed" | "failed";
+};
+
+type ProjectionRow = {
+  id: string;
+  candidateId: string | null;
+  state: CoverSelection["state"];
+};
+
+const rows = <T>(value: unknown): T[] => value as T[];
+const uniqueSorted = <T extends string>(values: readonly T[]): T[] =>
+  [...new Set(values)].sort();
+const jsonValue = <T>(value: unknown): T =>
+  (typeof value === "string" ? JSON.parse(value) : value) as T;
+
+const loadCandidate = async (
+  sql: PgSql,
+  candidateId: string,
+): Promise<CandidateRow | undefined> => {
+  const row = rows<CandidateRow>(
+    await sql.unsafe(
+      `select
+         id, work_id as "workId", edition_id as "editionId",
+         source_record_id as "sourceRecordId",
+         representation_type as "representationType",
+         identity_match_kind as "identityMatchKind",
+         identity_evidence_json as "identityEvidence",
+         permission_state as "permissionState", rights_basis as "rightsBasis",
+         attribution_text as "attributionText",
+         attribution_url as "attributionUrl", source_url as "sourceUrl",
+         source_revision as "sourceRevision",
+         source_policy_version as "sourcePolicyVersion",
+         object_key as "objectKey",
+         transformation_history_json as "transformationHistory",
+         created_at as "createdAt"
+       from cover_candidates where id = $1`,
+      [candidateId],
+    ),
+  )[0];
+  return row
+    ? {
+        ...row,
+        identityEvidence: jsonValue(row.identityEvidence),
+        transformationHistory: jsonValue(row.transformationHistory),
+      }
+    : undefined;
+};
+
+const loadDecision = async (
+  sql: PgSql,
+  candidateId: string,
+): Promise<DecisionRow | undefined> => {
+  const row = rows<DecisionRow>(
+    await sql.unsafe(
+      `select
+         d.id, d.inspection_id as "inspectionId", d.state,
+         d.gate_codes_json as "gateCodes",
+         d.warning_codes_json as "warningCodes",
+         d.purge_state as "purgeState"
+       from cover_decision_heads h
+       join cover_decisions d on d.id = h.decision_id
+       where h.candidate_id = $1`,
+      [candidateId],
+    ),
+  )[0];
+  return row
+    ? {
+        ...row,
+        gateCodes: jsonValue(row.gateCodes),
+        warningCodes: jsonValue(row.warningCodes),
+      }
+    : undefined;
+};
+
+const loadInspection = async (
+  sql: PgSql,
+  inspectionId: string,
+): Promise<InspectionRow> => {
+  const row = rows<InspectionRow>(
+    await sql.unsafe(
+      `select
+         id, candidate_id as "candidateId", media_type as "mediaType",
+         byte_size as "byteSize", width, height, aspect_ratio as "aspectRatio",
+         checksum, decode_result as "decodeResult", flags_json as flags,
+         quality_score as "qualityScore",
+         inspection_version as "inspectionVersion",
+         inspected_at as "inspectedAt"
+       from cover_inspections where id = $1`,
+      [inspectionId],
+    ),
+  )[0];
+  return { ...row, flags: jsonValue(row.flags) };
+};
+
+const candidateInput = (row: CandidateRow): CoverCandidateInput => ({
+  workId: row.workId,
+  editionId: row.editionId,
+  sourceRecordId: row.sourceRecordId,
+  representationType: row.representationType,
+  identityMatchKind: row.identityMatchKind,
+  identityEvidence: row.identityEvidence,
+  permissionState: row.permissionState,
+  rightsBasis: row.rightsBasis,
+  attributionText: row.attributionText,
+  attributionUrl: row.attributionUrl,
+  sourceUrl: row.sourceUrl,
+  sourceRevision: row.sourceRevision,
+  sourcePolicyVersion: row.sourcePolicyVersion,
+  objectKey: row.objectKey,
+  transformationHistory: row.transformationHistory,
+  createdAt: row.createdAt,
+});
+
+const inspectionInput = (row: InspectionRow): CoverInspection => ({
+  mediaType: row.mediaType,
+  byteSize: row.byteSize,
+  width: row.width,
+  height: row.height,
+  aspectRatio: row.aspectRatio,
+  checksum: row.checksum,
+  decodeResult: row.decodeResult,
+  flags: row.flags,
+  qualityScore: row.qualityScore,
+  inspectionVersion: row.inspectionVersion,
+  inspectedAt: row.inspectedAt,
+});
+
+const sourceContext = async (
+  sql: PgSql,
+  candidate: CoverCandidateInput,
+): Promise<CoverSourceContext | undefined> => {
+  const targetType =
+    candidate.representationType === "selected_edition" ? "edition" : "work";
+  const targetId = candidate.editionId ?? candidate.workId;
+  return rows<CoverSourceContext>(
+    await sql.unsafe(
+      `select
+         sr.source_revision as "sourceRevision",
+         sr.state as "sourceRecordState",
+         s.approval_state as "sourceApproval",
+         sl.state as "sourceLinkState",
+         sl.match_kind as "sourceLinkMatchKind",
+         s.metadata_policy as "metadataPolicy",
+         s.asset_policy as "assetPolicy"
+       from source_records sr
+       join metadata_sources s on s.id = sr.source_id
+       left join source_record_links sl
+         on sl.source_record_id = sr.id
+        and sl.entity_type = $1
+        and sl.entity_id = $2
+       where sr.id = $3`,
+      [targetType, targetId, candidate.sourceRecordId],
+    ),
+  )[0];
+};
+
+const currentValidation = async (
+  sql: PgSql,
+  candidate: CoverCandidateInput,
+  inspection: CoverInspection,
+) => {
+  const editionRows =
+    candidate.editionId === null
+      ? [{ present: 1 }]
+      : rows<{ present: number }>(
+          await sql.unsafe(
+            `select 1 as present from editions
+             where id = $1 and work_id = $2`,
+            [candidate.editionId, candidate.workId],
+          ),
+        );
+  const source = await sourceContext(sql, candidate);
+  let identityVerified = false;
+  if (candidate.identityMatchKind === "exact_isbn" && candidate.editionId) {
+    for (const scheme of ["isbn10", "isbn13"]) {
+      const value = candidate.identityEvidence[scheme];
+      if (
+        typeof value === "string" &&
+        rows(
+          await sql.unsafe(
+            `select 1 from edition_identifiers
+             where edition_id = $1 and scheme = $2 and value_normalized = $3`,
+            [candidate.editionId, scheme, value],
+          ),
+        ).length > 0
+      ) {
+        identityVerified = true;
+      }
+    }
+  } else if (
+    candidate.identityMatchKind === "provider_edition_relation" ||
+    candidate.identityMatchKind === "provider_work_relation"
+  ) {
+    identityVerified = source?.sourceLinkMatchKind === "source_relationship";
+  } else if (candidate.identityMatchKind === "approved_strong_edition_tuple") {
+    identityVerified = candidate.identityEvidence.policyApproved === true;
+  } else if (candidate.identityMatchKind === "curated_work_relation") {
+    identityVerified = source?.sourceLinkMatchKind === "curated";
+  }
+  return validateCoverCandidate({
+    candidate,
+    inspection,
+    source,
+    editionBelongsToWork: editionRows.length > 0,
+    identityEvidenceVerified: identityVerified,
+  });
+};
+
+const appendDecision = async (
+  sql: PgSql,
+  input: {
+    candidateId: string;
+    inspectionId: string;
+    state: CoverCandidateResult["state"];
+    gateCodes: readonly CoverGateCode[];
+    warningCodes: readonly CoverFlagCode[];
+    reviewerRef?: string | null;
+    reason?: string | null;
+    purgeState?: DecisionRow["purgeState"];
+    decidedAt: number;
+  },
+): Promise<{ id: string; changed: boolean }> => {
+  const previous = await loadDecision(sql, input.candidateId);
+  const gateCodes = uniqueSorted(input.gateCodes);
+  const warningCodes = uniqueSorted(input.warningCodes);
+  const purgeState = input.purgeState ?? "not_required";
+  if (
+    previous &&
+    previous.inspectionId === input.inspectionId &&
+    previous.state === input.state &&
+    canonicalJson(previous.gateCodes) === canonicalJson(gateCodes) &&
+    canonicalJson(previous.warningCodes) === canonicalJson(warningCodes) &&
+    previous.purgeState === purgeState
+  ) {
+    return { id: previous.id, changed: false };
+  }
+  const id = deterministicCatalogId(
+    "cover_decision",
+    input.candidateId,
+    hashCanonicalJson({
+      inspectionId: input.inspectionId,
+      state: input.state,
+      gateCodes,
+      warningCodes,
+      reviewerRef: input.reviewerRef ?? null,
+      reason: input.reason ?? null,
+      previousDecisionId: previous?.id ?? null,
+      policyVersion: COVER_POLICY_VERSION,
+      decidedAt: input.decidedAt,
+    }),
+  );
+  await sql.unsafe(
+    `insert into cover_decisions (
+       id, candidate_id, inspection_id, state, gate_codes_json,
+       warning_codes_json, reviewer_ref, review_reason, purge_state,
+       previous_decision_id, policy_version, decided_at
+     ) values ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7, $8, $9, $10, $11, $12)`,
+    [
+      id,
+      input.candidateId,
+      input.inspectionId,
+      input.state,
+      gateCodes,
+      warningCodes,
+      input.reviewerRef ?? null,
+      input.reason ?? null,
+      purgeState,
+      previous?.id ?? null,
+      COVER_POLICY_VERSION,
+      input.decidedAt,
+    ],
+  );
+  await sql.unsafe(
+    `insert into cover_decision_heads (candidate_id, decision_id)
+     values ($1, $2)
+     on conflict(candidate_id) do update set decision_id = excluded.decision_id`,
+    [input.candidateId, id],
+  );
+  return { id, changed: true };
+};
+
+const identityPriority = (
+  kind: CoverCandidateInput["identityMatchKind"],
+): number =>
+  ({
+    exact_isbn: 7,
+    provider_edition_relation: 6,
+    approved_strong_edition_tuple: 5,
+    curated_work_relation: 4,
+    provider_work_relation: 3,
+    title_creator_candidate: 1,
+    conflicting: 0,
+  })[kind];
+
+const eligibleCandidates = async (
+  sql: PgSql,
+  workId: string,
+): Promise<Array<{ candidate: CandidateRow; inspection: InspectionRow }>> => {
+  const candidates = rows<CandidateRow & { inspectionId: string }>(
+    await sql.unsafe(
+      `select
+         c.id, c.work_id as "workId", c.edition_id as "editionId",
+         c.source_record_id as "sourceRecordId",
+         c.representation_type as "representationType",
+         c.identity_match_kind as "identityMatchKind",
+         c.identity_evidence_json as "identityEvidence",
+         c.permission_state as "permissionState",
+         c.rights_basis as "rightsBasis",
+         c.attribution_text as "attributionText",
+         c.attribution_url as "attributionUrl", c.source_url as "sourceUrl",
+         c.source_revision as "sourceRevision",
+         c.source_policy_version as "sourcePolicyVersion",
+         c.object_key as "objectKey",
+         c.transformation_history_json as "transformationHistory",
+         c.created_at as "createdAt", d.inspection_id as "inspectionId"
+       from cover_candidates c
+       join cover_decision_heads h on h.candidate_id = c.id
+       join cover_decisions d on d.id = h.decision_id and d.state = 'eligible'
+       where c.work_id = $1`,
+      [workId],
+    ),
+  );
+  const eligible: Array<{
+    candidate: CandidateRow;
+    inspection: InspectionRow;
+  }> = [];
+  for (const candidateRow of candidates) {
+    const candidate: CandidateRow = {
+      ...candidateRow,
+      identityEvidence: jsonValue(candidateRow.identityEvidence),
+      transformationHistory: jsonValue(candidateRow.transformationHistory),
+    };
+    const inspection = await loadInspection(sql, candidateRow.inspectionId);
+    const validation = await currentValidation(
+      sql,
+      candidateInput(candidate),
+      inspectionInput(inspection),
+    );
+    if (validation.gateCodes.length === 0) {
+      eligible.push({ candidate, inspection });
+    }
+  }
+  return eligible.sort((left, right) => {
+    const representation =
+      Number(right.candidate.representationType === "selected_edition") -
+      Number(left.candidate.representationType === "selected_edition");
+    if (representation !== 0) return representation;
+    const identity =
+      identityPriority(right.candidate.identityMatchKind) -
+      identityPriority(left.candidate.identityMatchKind);
+    if (identity !== 0) return identity;
+    const normalizedRight =
+      right.inspection.qualityScore +
+      (right.inspection.flags.includes("duplicate") ? 4 : 0);
+    const normalizedLeft =
+      left.inspection.qualityScore +
+      (left.inspection.flags.includes("duplicate") ? 4 : 0);
+    if (normalizedRight !== normalizedLeft)
+      return normalizedRight - normalizedLeft;
+    const area =
+      (right.inspection.width ?? 0) * (right.inspection.height ?? 0) -
+      (left.inspection.width ?? 0) * (left.inspection.height ?? 0);
+    return (
+      area ||
+      left.inspection.checksum.localeCompare(right.inspection.checksum) ||
+      left.candidate.id.localeCompare(right.candidate.id)
+    );
+  });
+};
+
+const loadProjection = async (
+  sql: PgSql,
+  workId: string,
+): Promise<ProjectionRow | undefined> =>
+  rows<ProjectionRow>(
+    await sql.unsafe(
+      `select p.id, p.candidate_id as "candidateId", p.state
+       from cover_projection_heads h
+       join cover_projections p on p.id = h.projection_id
+       where h.work_id = $1`,
+      [workId],
+    ),
+  )[0];
+
+const appendProjection = async (
+  sql: PgSql,
+  input: {
+    workId: string;
+    candidateId: string | null;
+    state: CoverSelection["state"];
+    reasonCode: string;
+    actorRef: string;
+    projectedAt: number;
+  },
+): Promise<{ row: ProjectionRow; changed: boolean }> => {
+  const previous = await loadProjection(sql, input.workId);
+  if (
+    previous?.candidateId === input.candidateId &&
+    previous.state === input.state
+  ) {
+    return { row: previous, changed: false };
+  }
+  const id = deterministicCatalogId(
+    "cover_projection",
+    input.workId,
+    hashCanonicalJson({
+      candidateId: input.candidateId,
+      state: input.state,
+      previousProjectionId: previous?.id ?? null,
+      reasonCode: input.reasonCode,
+      policyVersion: COVER_POLICY_VERSION,
+    }),
+  );
+  await sql.unsafe(
+    `insert into cover_projections (
+       id, work_id, candidate_id, state, previous_projection_id,
+       reason_code, actor_ref, policy_version, projected_at
+     ) values ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+    [
+      id,
+      input.workId,
+      input.candidateId,
+      input.state,
+      previous?.id ?? null,
+      input.reasonCode,
+      input.actorRef,
+      COVER_POLICY_VERSION,
+      input.projectedAt,
+    ],
+  );
+  await sql.unsafe(
+    `insert into cover_projection_heads (work_id, projection_id)
+     values ($1, $2)
+     on conflict(work_id) do update set projection_id = excluded.projection_id`,
+    [input.workId, id],
+  );
+  return {
+    row: { id, candidateId: input.candidateId, state: input.state },
+    changed: true,
+  };
+};
+
+const recompute = async (
+  sql: PgSql,
+  input: {
+    workId: string;
+    actorRef: string;
+    reasonCode: string;
+    projectedAt: number;
+    emptyState?: "placeholder" | "withdrawn";
+  },
+): Promise<{ selection: CoverSelection; changed: boolean }> => {
+  const winner = (await eligibleCandidates(sql, input.workId))[0];
+  const projection = await appendProjection(sql, {
+    workId: input.workId,
+    candidateId: winner?.candidate.id ?? null,
+    state: winner ? "selected" : (input.emptyState ?? "placeholder"),
+    reasonCode: input.reasonCode,
+    actorRef: input.actorRef,
+    projectedAt: input.projectedAt,
+  });
+  return {
+    selection: {
+      workId: input.workId,
+      candidateId: winner?.candidate.id ?? null,
+      objectKey: winner?.candidate.objectKey ?? PLACEHOLDER_COVER,
+      representationType: winner?.candidate.representationType ?? null,
+      editionId: winner?.candidate.editionId ?? null,
+      publicDisplayEligible: false,
+      state: projection.row.state,
+    },
+    changed: projection.changed,
+  };
+};
+
+export const createCoverCandidatePostgres = async (input: {
+  url: string;
+  candidate: CoverCandidateInput;
+  inspection: CoverInspection;
+  actorRef?: string;
+  failAfter?: "candidate" | "inspection" | "decision" | "projection";
+}): Promise<CoverCandidateResult> => {
+  const client = postgres(input.url, { max: 1 });
+  const candidateId = coverCandidateIdentity(input.candidate);
+  const inspectionId = coverInspectionIdentity(candidateId, input.inspection);
+  try {
+    const existing = await loadDecision(client, candidateId);
+    if (existing?.inspectionId === inspectionId) {
+      return {
+        candidateId,
+        inspectionId,
+        decisionId: existing.id,
+        state: existing.state,
+        gateCodes: existing.gateCodes,
+        warningCodes: existing.warningCodes,
+        changed: false,
+      };
+    }
+    return await client.begin(async (sql) => {
+      await sql.unsafe(
+        `insert into cover_candidates (
+           id, work_id, edition_id, source_record_id, representation_type,
+           identity_match_kind, identity_evidence_json, permission_state,
+           rights_basis, attribution_text, attribution_url, source_url,
+           source_revision, source_policy_version, object_key,
+           transformation_history_json, created_at
+         ) values (
+           $1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9, $10, $11, $12,
+           $13, $14, $15, $16::jsonb, $17
+         ) on conflict(id) do nothing`,
+        [
+          candidateId,
+          input.candidate.workId,
+          input.candidate.editionId,
+          input.candidate.sourceRecordId,
+          input.candidate.representationType,
+          input.candidate.identityMatchKind,
+          input.candidate.identityEvidence as postgres.JSONValue,
+          input.candidate.permissionState,
+          input.candidate.rightsBasis,
+          input.candidate.attributionText,
+          input.candidate.attributionUrl,
+          input.candidate.sourceUrl,
+          input.candidate.sourceRevision,
+          input.candidate.sourcePolicyVersion,
+          input.candidate.objectKey,
+          [...input.candidate.transformationHistory],
+          input.candidate.createdAt,
+        ],
+      );
+      if (input.failAfter === "candidate") {
+        throw new Error("Forced Postgres cover candidate failure");
+      }
+      const duplicate = rows<{ candidateId: string }>(
+        await sql.unsafe(
+          `select candidate_id as "candidateId"
+           from cover_inspections
+           where checksum = $1 and candidate_id <> $2
+           order by candidate_id asc limit 1`,
+          [input.inspection.checksum, candidateId],
+        ),
+      )[0];
+      const flags = uniqueSorted([
+        ...input.inspection.flags,
+        ...(duplicate ? (["duplicate"] as const) : []),
+      ]);
+      const inspection = {
+        ...input.inspection,
+        flags,
+        qualityScore: duplicate
+          ? Math.max(0, input.inspection.qualityScore - 4)
+          : input.inspection.qualityScore,
+      };
+      await sql.unsafe(
+        `insert into cover_inspections (
+           id, candidate_id, media_type, byte_size, width, height, aspect_ratio,
+           checksum, decode_result, flags_json, quality_score,
+           duplicate_of_candidate_id, inspection_version, inspected_at
+         ) values (
+           $1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11, $12, $13, $14
+         ) on conflict(candidate_id, checksum, inspection_version) do nothing`,
+        [
+          inspectionId,
+          candidateId,
+          inspection.mediaType,
+          inspection.byteSize,
+          inspection.width,
+          inspection.height,
+          inspection.aspectRatio,
+          inspection.checksum,
+          inspection.decodeResult,
+          inspection.flags,
+          inspection.qualityScore,
+          duplicate?.candidateId ?? null,
+          inspection.inspectionVersion,
+          inspection.inspectedAt,
+        ],
+      );
+      if (input.failAfter === "inspection") {
+        throw new Error("Forced Postgres cover inspection failure");
+      }
+      const validation = await currentValidation(
+        sql,
+        input.candidate,
+        inspection,
+      );
+      const state: CoverCandidateResult["state"] = validation.hardRejected
+        ? "rejected"
+        : validation.gateCodes.length > 0 ||
+            validation.warningCodes.some((warning) => warning !== "duplicate")
+          ? "review_required"
+          : "eligible";
+      const decision = await appendDecision(sql, {
+        candidateId,
+        inspectionId,
+        state,
+        gateCodes: validation.gateCodes,
+        warningCodes: validation.warningCodes,
+        decidedAt: inspection.inspectedAt,
+      });
+      if (input.failAfter === "decision") {
+        throw new Error("Forced Postgres cover decision failure");
+      }
+      await recompute(sql, {
+        workId: input.candidate.workId,
+        actorRef: input.actorRef ?? "system:cover-inspection",
+        reasonCode: "candidate_inspected",
+        projectedAt: inspection.inspectedAt,
+      });
+      if (input.failAfter === "projection") {
+        throw new Error("Forced Postgres cover projection failure");
+      }
+      return {
+        candidateId,
+        inspectionId,
+        decisionId: decision.id,
+        state,
+        gateCodes: validation.gateCodes,
+        warningCodes: validation.warningCodes,
+        changed: true,
+      };
+    });
+  } finally {
+    await client.end({ timeout: 5_000 });
+  }
+};
+
+export const getCoverSelectionPostgres = async (input: {
+  url: string;
+  workId: string;
+}): Promise<CoverSelection> => {
+  const client = postgres(input.url, { max: 1 });
+  try {
+    const projection = await loadProjection(client, input.workId);
+    if (!projection?.candidateId) {
+      return {
+        workId: input.workId,
+        candidateId: null,
+        objectKey: PLACEHOLDER_COVER,
+        representationType: null,
+        editionId: null,
+        publicDisplayEligible: false,
+        state: projection?.state ?? "placeholder",
+      };
+    }
+    const candidate = await loadCandidate(client, projection.candidateId);
+    const decision = await loadDecision(client, projection.candidateId);
+    const currentlyEligible =
+      candidate &&
+      decision?.state === "eligible" &&
+      (
+        await currentValidation(
+          client,
+          candidateInput(candidate),
+          inspectionInput(await loadInspection(client, decision.inspectionId)),
+        )
+      ).gateCodes.length === 0;
+    if (!currentlyEligible || !candidate) {
+      return {
+        workId: input.workId,
+        candidateId: null,
+        objectKey: PLACEHOLDER_COVER,
+        representationType: null,
+        editionId: null,
+        publicDisplayEligible: false,
+        state: "placeholder",
+      };
+    }
+    return {
+      workId: input.workId,
+      candidateId: candidate.id,
+      objectKey: candidate.objectKey,
+      representationType: candidate.representationType,
+      editionId: candidate.editionId,
+      publicDisplayEligible: false,
+      state: projection.state,
+    };
+  } finally {
+    await client.end({ timeout: 5_000 });
+  }
+};
+
+export const withdrawCoverCandidatePostgres = async (input: {
+  url: string;
+  candidateId: string;
+  actorRef: string;
+  reason: string;
+  withdrawnAt: number;
+  purgeAsset?: (objectKey: string) => void | Promise<void>;
+}): Promise<CoverCandidateResult> => {
+  const client = postgres(input.url, { max: 1 });
+  try {
+    const candidateRow = await loadCandidate(client, input.candidateId);
+    const previous = await loadDecision(client, input.candidateId);
+    if (!candidateRow || !previous)
+      throw new Error("Cover candidate not found");
+    const candidate = candidateInput(candidateRow);
+    const context = await sourceContext(client, candidate);
+    const purgeRequired = coverPolicyRequiresPurge(context?.assetPolicy);
+    const decision = await client.begin(async (sql) => {
+      const appended = await appendDecision(sql, {
+        candidateId: input.candidateId,
+        inspectionId: previous.inspectionId,
+        state: "withdrawn",
+        gateCodes: previous.gateCodes,
+        warningCodes: previous.warningCodes,
+        reviewerRef: input.actorRef,
+        reason: input.reason,
+        purgeState: purgeRequired ? "pending" : "not_required",
+        decidedAt: input.withdrawnAt,
+      });
+      const remaining = await eligibleCandidates(sql, candidate.workId);
+      await recompute(sql, {
+        workId: candidate.workId,
+        actorRef: input.actorRef,
+        reasonCode: "candidate_withdrawn",
+        projectedAt: input.withdrawnAt,
+        emptyState: remaining.length > 0 ? "placeholder" : "withdrawn",
+      });
+      return appended;
+    });
+    if (purgeRequired) {
+      try {
+        if (!input.purgeAsset) {
+          throw new Error("Cover withdrawal requires an asset purge callback");
+        }
+        await input.purgeAsset(candidate.objectKey);
+        await client.unsafe(
+          "update cover_decisions set purge_state = 'completed' where id = $1",
+          [decision.id],
+        );
+      } catch (error) {
+        await client.unsafe(
+          "update cover_decisions set purge_state = 'failed' where id = $1",
+          [decision.id],
+        );
+        throw error;
+      }
+    }
+    return {
+      candidateId: input.candidateId,
+      inspectionId: previous.inspectionId,
+      decisionId: decision.id,
+      state: "withdrawn",
+      gateCodes: previous.gateCodes,
+      warningCodes: previous.warningCodes,
+      changed: decision.changed,
+    };
+  } finally {
+    await client.end({ timeout: 5_000 });
+  }
+};
+
+export const rollbackCoverProjectionPostgres = async (input: {
+  url: string;
+  workId: string;
+  targetProjectionId: string;
+  actorRef: string;
+  reason: string;
+  rolledBackAt: number;
+}): Promise<{ selection: CoverSelection; changed: boolean }> => {
+  const client = postgres(input.url, { max: 1 });
+  try {
+    return await client.begin(async (sql) => {
+      const target = rows<ProjectionRow>(
+        await sql.unsafe(
+          `select id, candidate_id as "candidateId", state
+           from cover_projections where id = $1 and work_id = $2`,
+          [input.targetProjectionId, input.workId],
+        ),
+      )[0];
+      if (!target?.candidateId) {
+        throw new Error("Rollback target does not select a cover candidate");
+      }
+      const eligible = (await eligibleCandidates(sql, input.workId)).some(
+        (row) => row.candidate.id === target.candidateId,
+      );
+      if (!eligible) throw new Error("Rollback target is no longer eligible");
+      const projection = await appendProjection(sql, {
+        workId: input.workId,
+        candidateId: target.candidateId,
+        state: "rolled_back",
+        reasonCode: input.reason,
+        actorRef: input.actorRef,
+        projectedAt: input.rolledBackAt,
+      });
+      const candidate = await loadCandidate(sql, target.candidateId);
+      if (!candidate) throw new Error("Rollback candidate not found");
+      return {
+        selection: {
+          workId: input.workId,
+          candidateId: candidate.id,
+          objectKey: candidate.objectKey,
+          representationType: candidate.representationType,
+          editionId: candidate.editionId,
+          publicDisplayEligible: false,
+          state: projection.row.state,
+        },
+        changed: projection.changed,
+      };
+    });
+  } finally {
+    await client.end({ timeout: 5_000 });
+  }
+};

--- a/src/db/catalog/enrichment/covers/repository.pg.ts
+++ b/src/db/catalog/enrichment/covers/repository.pg.ts
@@ -260,7 +260,9 @@ const currentValidation = async (
   ) {
     identityVerified = source?.sourceLinkMatchKind === "source_relationship";
   } else if (candidate.identityMatchKind === "approved_strong_edition_tuple") {
-    identityVerified = candidate.identityEvidence.policyApproved === true;
+    identityVerified =
+      candidate.identityEvidence.policyApproved === true &&
+      source?.sourceLinkMatchKind === "curated";
   } else if (candidate.identityMatchKind === "curated_work_relation") {
     identityVerified = source?.sourceLinkMatchKind === "curated";
   }
@@ -346,6 +348,112 @@ const appendDecision = async (
   return { id, changed: true };
 };
 
+const decisionStateForValidation = (validation: {
+  hardRejected: boolean;
+  gateCodes: readonly CoverGateCode[];
+  warningCodes: readonly CoverFlagCode[];
+}): CoverCandidateResult["state"] =>
+  validation.hardRejected
+    ? "rejected"
+    : validation.gateCodes.length > 0 || validation.warningCodes.length > 0
+      ? "review_required"
+      : "eligible";
+
+const normalizeDuplicateGroup = async (
+  sql: PgSql,
+  input: {
+    candidateId: string;
+    checksum: string;
+    decidedAt: number;
+    inspectionId: string;
+  },
+): Promise<{ inspection: CoverInspection; affectedWorkIds: string[] }> => {
+  const group = rows<InspectionRow & { workId: string }>(
+    await sql.unsafe(
+      `select
+         i.id, i.candidate_id as "candidateId", i.media_type as "mediaType",
+         i.byte_size as "byteSize", i.width, i.height,
+         i.aspect_ratio as "aspectRatio", i.checksum,
+         i.decode_result as "decodeResult", i.flags_json as flags,
+         i.quality_score as "qualityScore",
+         i.inspection_version as "inspectionVersion",
+         i.inspected_at as "inspectedAt", c.work_id as "workId"
+       from cover_inspections i
+       join cover_candidates c on c.id = i.candidate_id
+       left join cover_decision_heads h on h.candidate_id = i.candidate_id
+       left join cover_decisions d on d.id = h.decision_id
+       where i.checksum = $1
+         and (
+           (i.candidate_id = $2 and i.id = $3)
+           or (i.candidate_id <> $2 and d.inspection_id = i.id)
+         )
+       order by i.candidate_id asc, i.id asc`,
+      [input.checksum, input.candidateId, input.inspectionId],
+    ),
+  ).map((row) => ({
+    ...row,
+    flags: jsonValue<CoverFlagCode[]>(row.flags),
+  }));
+  const canonicalCandidateId = group[0]?.candidateId;
+  const affectedWorkIds = new Set<string>();
+
+  for (const row of group) {
+    const baseFlags = row.flags.filter((flag) => flag !== "duplicate");
+    const isDuplicate = row.candidateId !== canonicalCandidateId;
+    const flags = uniqueSorted([
+      ...baseFlags,
+      ...(isDuplicate ? (["duplicate"] as const) : []),
+    ]);
+    await sql.unsafe(
+      `update cover_inspections
+       set flags_json = $1::jsonb, duplicate_of_candidate_id = $2
+       where id = $3`,
+      [flags, isDuplicate ? canonicalCandidateId : null, row.id],
+    );
+
+    if (row.candidateId === input.candidateId) continue;
+    const previous = await loadDecision(sql, row.candidateId);
+    const candidate = await loadCandidate(sql, row.candidateId);
+    if (
+      !previous ||
+      !candidate ||
+      !["eligible", "review_required"].includes(previous.state)
+    ) {
+      continue;
+    }
+    const inspection = inspectionInput({ ...row, flags });
+    const validation = await currentValidation(
+      sql,
+      candidateInput(candidate),
+      inspection,
+    );
+    await appendDecision(sql, {
+      candidateId: row.candidateId,
+      inspectionId: row.id,
+      state: decisionStateForValidation(validation),
+      gateCodes: validation.gateCodes,
+      warningCodes: validation.warningCodes,
+      decidedAt: input.decidedAt,
+    });
+    affectedWorkIds.add(row.workId);
+  }
+
+  const current = group.find((row) => row.id === input.inspectionId);
+  if (!current) throw new Error("Cover inspection not found after insert");
+  return {
+    inspection: inspectionInput({
+      ...current,
+      flags: uniqueSorted([
+        ...current.flags.filter((flag) => flag !== "duplicate"),
+        ...(current.candidateId !== canonicalCandidateId
+          ? (["duplicate"] as const)
+          : []),
+      ]),
+    }),
+    affectedWorkIds: [...affectedWorkIds],
+  };
+};
+
 const identityPriority = (
   kind: CoverCandidateInput["identityMatchKind"],
 ): number =>
@@ -416,14 +524,9 @@ const eligibleCandidates = async (
       identityPriority(right.candidate.identityMatchKind) -
       identityPriority(left.candidate.identityMatchKind);
     if (identity !== 0) return identity;
-    const normalizedRight =
-      right.inspection.qualityScore +
-      (right.inspection.flags.includes("duplicate") ? 4 : 0);
-    const normalizedLeft =
-      left.inspection.qualityScore +
-      (left.inspection.flags.includes("duplicate") ? 4 : 0);
-    if (normalizedRight !== normalizedLeft)
-      return normalizedRight - normalizedLeft;
+    if (right.inspection.qualityScore !== left.inspection.qualityScore) {
+      return right.inspection.qualityScore - left.inspection.qualityScore;
+    }
     const area =
       (right.inspection.width ?? 0) * (right.inspection.height ?? 0) -
       (left.inspection.width ?? 0) * (left.inspection.height ?? 0);
@@ -598,25 +701,11 @@ export const createCoverCandidatePostgres = async (input: {
       if (input.failAfter === "candidate") {
         throw new Error("Forced Postgres cover candidate failure");
       }
-      const duplicate = rows<{ candidateId: string }>(
-        await sql.unsafe(
-          `select candidate_id as "candidateId"
-           from cover_inspections
-           where checksum = $1 and candidate_id <> $2
-           order by candidate_id asc limit 1`,
-          [input.inspection.checksum, candidateId],
-        ),
-      )[0];
-      const flags = uniqueSorted([
-        ...input.inspection.flags,
-        ...(duplicate ? (["duplicate"] as const) : []),
-      ]);
-      const inspection = {
+      const inspectionToStore = {
         ...input.inspection,
-        flags,
-        qualityScore: duplicate
-          ? Math.max(0, input.inspection.qualityScore - 4)
-          : input.inspection.qualityScore,
+        flags: uniqueSorted(
+          input.inspection.flags.filter((flag) => flag !== "duplicate"),
+        ),
       };
       await sql.unsafe(
         `insert into cover_inspections (
@@ -629,34 +718,36 @@ export const createCoverCandidatePostgres = async (input: {
         [
           inspectionId,
           candidateId,
-          inspection.mediaType,
-          inspection.byteSize,
-          inspection.width,
-          inspection.height,
-          inspection.aspectRatio,
-          inspection.checksum,
-          inspection.decodeResult,
-          inspection.flags,
-          inspection.qualityScore,
-          duplicate?.candidateId ?? null,
-          inspection.inspectionVersion,
-          inspection.inspectedAt,
+          inspectionToStore.mediaType,
+          inspectionToStore.byteSize,
+          inspectionToStore.width,
+          inspectionToStore.height,
+          inspectionToStore.aspectRatio,
+          inspectionToStore.checksum,
+          inspectionToStore.decodeResult,
+          inspectionToStore.flags,
+          inspectionToStore.qualityScore,
+          null,
+          inspectionToStore.inspectionVersion,
+          inspectionToStore.inspectedAt,
         ],
       );
       if (input.failAfter === "inspection") {
         throw new Error("Forced Postgres cover inspection failure");
       }
+      const duplicateNormalization = await normalizeDuplicateGroup(sql, {
+        candidateId,
+        checksum: input.inspection.checksum,
+        decidedAt: input.inspection.inspectedAt,
+        inspectionId,
+      });
+      const inspection = duplicateNormalization.inspection;
       const validation = await currentValidation(
         sql,
         input.candidate,
         inspection,
       );
-      const state: CoverCandidateResult["state"] = validation.hardRejected
-        ? "rejected"
-        : validation.gateCodes.length > 0 ||
-            validation.warningCodes.some((warning) => warning !== "duplicate")
-          ? "review_required"
-          : "eligible";
+      const state = decisionStateForValidation(validation);
       const decision = await appendDecision(sql, {
         candidateId,
         inspectionId,
@@ -668,12 +759,17 @@ export const createCoverCandidatePostgres = async (input: {
       if (input.failAfter === "decision") {
         throw new Error("Forced Postgres cover decision failure");
       }
-      await recompute(sql, {
-        workId: input.candidate.workId,
-        actorRef: input.actorRef ?? "system:cover-inspection",
-        reasonCode: "candidate_inspected",
-        projectedAt: inspection.inspectedAt,
-      });
+      for (const workId of uniqueSorted([
+        input.candidate.workId,
+        ...duplicateNormalization.affectedWorkIds,
+      ])) {
+        await recompute(sql, {
+          workId,
+          actorRef: input.actorRef ?? "system:cover-inspection",
+          reasonCode: "candidate_inspected",
+          projectedAt: inspection.inspectedAt,
+        });
+      }
       if (input.failAfter === "projection") {
         throw new Error("Forced Postgres cover projection failure");
       }
@@ -685,6 +781,77 @@ export const createCoverCandidatePostgres = async (input: {
         gateCodes: validation.gateCodes,
         warningCodes: validation.warningCodes,
         changed: true,
+      };
+    });
+  } finally {
+    await client.end({ timeout: 5_000 });
+  }
+};
+
+export const reviewCoverCandidatePostgres = async (input: {
+  url: string;
+  candidateId: string;
+  reviewerRef: string;
+  decision: "approve" | "reject";
+  reason: string;
+  acknowledgedWarningCodes: readonly CoverFlagCode[];
+  reviewedAt: number;
+}): Promise<CoverCandidateResult> => {
+  const client = postgres(input.url, { max: 1 });
+  try {
+    const candidateRow = await loadCandidate(client, input.candidateId);
+    const previous = await loadDecision(client, input.candidateId);
+    if (!candidateRow || !previous)
+      throw new Error("Cover candidate not found");
+    const candidate = candidateInput(candidateRow);
+    const inspection = inspectionInput(
+      await loadInspection(client, previous.inspectionId),
+    );
+    const validation = await currentValidation(client, candidate, inspection);
+    if (input.decision === "approve") {
+      if (validation.gateCodes.length > 0) {
+        throw new Error(
+          `Cover hard gates cannot be overridden: ${validation.gateCodes.join(", ")}`,
+        );
+      }
+      const missing = validation.warningCodes.filter(
+        (warning) => !input.acknowledgedWarningCodes.includes(warning),
+      );
+      if (missing.length > 0) {
+        throw new Error(
+          `Cover warnings not acknowledged: ${missing.join(", ")}`,
+        );
+      }
+    }
+    return await client.begin(async (sql) => {
+      const state: CoverCandidateResult["state"] =
+        input.decision === "approve" ? "eligible" : "rejected";
+      const gateCodes =
+        input.decision === "approve" ? [] : validation.gateCodes;
+      const decision = await appendDecision(sql, {
+        candidateId: input.candidateId,
+        inspectionId: previous.inspectionId,
+        state,
+        gateCodes,
+        warningCodes: validation.warningCodes,
+        reviewerRef: input.reviewerRef,
+        reason: input.reason,
+        decidedAt: input.reviewedAt,
+      });
+      await recompute(sql, {
+        workId: candidate.workId,
+        actorRef: input.reviewerRef,
+        reasonCode: `review_${input.decision}`,
+        projectedAt: input.reviewedAt,
+      });
+      return {
+        candidateId: input.candidateId,
+        inspectionId: previous.inspectionId,
+        decisionId: decision.id,
+        state,
+        gateCodes,
+        warningCodes: validation.warningCodes,
+        changed: decision.changed,
       };
     });
   } finally {
@@ -761,6 +928,17 @@ export const withdrawCoverCandidatePostgres = async (input: {
     const previous = await loadDecision(client, input.candidateId);
     if (!candidateRow || !previous)
       throw new Error("Cover candidate not found");
+    if (previous.state === "withdrawn" && previous.purgeState !== "failed") {
+      return {
+        candidateId: input.candidateId,
+        inspectionId: previous.inspectionId,
+        decisionId: previous.id,
+        state: "withdrawn",
+        gateCodes: previous.gateCodes,
+        warningCodes: previous.warningCodes,
+        changed: false,
+      };
+    }
     const candidate = candidateInput(candidateRow);
     const context = await sourceContext(client, candidate);
     const purgeRequired = coverPolicyRequiresPurge(context?.assetPolicy);
@@ -818,6 +996,43 @@ export const withdrawCoverCandidatePostgres = async (input: {
   }
 };
 
+export const retryCoverWithdrawalPurgePostgres = async (input: {
+  url: string;
+  candidateId: string;
+  purgeAsset: (objectKey: string) => void | Promise<void>;
+}): Promise<boolean> => {
+  const client = postgres(input.url, { max: 1 });
+  try {
+    const candidate = await loadCandidate(client, input.candidateId);
+    const decision = await loadDecision(client, input.candidateId);
+    if (!candidate || !decision || decision.state !== "withdrawn") {
+      throw new Error("Withdrawn cover candidate not found");
+    }
+    if (
+      decision.purgeState === "completed" ||
+      decision.purgeState === "not_required"
+    ) {
+      return false;
+    }
+    try {
+      await input.purgeAsset(candidate.objectKey);
+      await client.unsafe(
+        "update cover_decisions set purge_state = 'completed' where id = $1",
+        [decision.id],
+      );
+      return true;
+    } catch (error) {
+      await client.unsafe(
+        "update cover_decisions set purge_state = 'failed' where id = $1",
+        [decision.id],
+      );
+      throw error;
+    }
+  } finally {
+    await client.end({ timeout: 5_000 });
+  }
+};
+
 export const rollbackCoverProjectionPostgres = async (input: {
   url: string;
   workId: string;
@@ -843,6 +1058,23 @@ export const rollbackCoverProjectionPostgres = async (input: {
         (row) => row.candidate.id === target.candidateId,
       );
       if (!eligible) throw new Error("Rollback target is no longer eligible");
+      const current = await loadProjection(sql, input.workId);
+      if (current?.candidateId === target.candidateId) {
+        const candidate = await loadCandidate(sql, target.candidateId);
+        if (!candidate) throw new Error("Rollback candidate not found");
+        return {
+          selection: {
+            workId: input.workId,
+            candidateId: candidate.id,
+            objectKey: candidate.objectKey,
+            representationType: candidate.representationType,
+            editionId: candidate.editionId,
+            publicDisplayEligible: false,
+            state: current.state,
+          },
+          changed: false,
+        };
+      }
       const projection = await appendProjection(sql, {
         workId: input.workId,
         candidateId: target.candidateId,

--- a/src/db/catalog/enrichment/covers/repository.test.ts
+++ b/src/db/catalog/enrichment/covers/repository.test.ts
@@ -1,0 +1,424 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PLACEHOLDER_COVER } from "../../../../media/covers";
+import { buildCatalogImportGraph } from "../../importer";
+import { openCatalogSqlite, rebuildCatalogSqlite } from "../../sqlite-rebuild";
+import { SAMPLE_BASELINE_IMPORT_RECORDS } from "../fixtures";
+import { ENRICHMENT_SAMPLE_MANIFEST } from "../sample-manifest";
+import {
+  approvedCoverFixture,
+  recordedFiveCoverFixtures,
+  seedCoverFixturesSqlite,
+} from "./fixtures";
+import {
+  createCoverCandidateSqlite,
+  getCoverSelectionSqlite,
+  retryCoverWithdrawalPurgeSqlite,
+  reviewCoverCandidateSqlite,
+  rollbackCoverProjectionSqlite,
+  withdrawCoverCandidateSqlite,
+} from "./repository";
+
+const NOW = Date.UTC(2026, 6, 29, 12, 0, 0);
+
+describe("SQLite edition-matched cover lifecycle", () => {
+  let directory: string;
+  let raw: ReturnType<typeof openCatalogSqlite>["raw"];
+  let editionIds: Record<string, string>;
+
+  beforeEach(() => {
+    directory = mkdtempSync(path.join(tmpdir(), "bukie-covers-test-"));
+    const sqlitePath = path.join(directory, "covers.sqlite");
+    rebuildCatalogSqlite({
+      sqlitePath,
+      graph: buildCatalogImportGraph(SAMPLE_BASELINE_IMPORT_RECORDS),
+    });
+    raw = openCatalogSqlite(sqlitePath).raw;
+    seedCoverFixturesSqlite(raw);
+    editionIds = Object.fromEntries(
+      ENRICHMENT_SAMPLE_MANIFEST.works.map((work) => {
+        const row = raw
+          .prepare("select preferred_edition_id as id from works where id = ?")
+          .get(work.workId) as { id: string };
+        return [work.workId, row.id];
+      }),
+    );
+  });
+
+  afterEach(() => {
+    raw.close();
+    rmSync(directory, { recursive: true, force: true });
+  });
+
+  it("re-evaluates all five recorded covers with the documented review reasons", () => {
+    const fixtures = recordedFiveCoverFixtures({ editionIds });
+    const results = fixtures.map((fixture) => ({
+      title: fixture.title,
+      result: createCoverCandidateSqlite(raw, fixture),
+    }));
+
+    expect(results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: "Dune",
+          result: expect.objectContaining({
+            state: "rejected",
+            gateCodes: expect.arrayContaining(["identity_conflict"]),
+            warningCodes: expect.arrayContaining([
+              "square_canvas",
+              "sidebars",
+              "extreme_crop",
+            ]),
+          }),
+        }),
+        expect.objectContaining({
+          title: "Moby-Dick",
+          result: expect.objectContaining({
+            state: "rejected",
+            gateCodes: expect.arrayContaining([
+              "identity_conflict",
+              "locale_conflict",
+              "adaptation_conflict",
+            ]),
+          }),
+        }),
+      ]),
+    );
+    for (const title of [
+      "The City and the Stars",
+      "Born a Crime",
+      "Faithful Place",
+    ]) {
+      expect(results.find((row) => row.title === title)?.result).toMatchObject({
+        state: "review_required",
+        gateCodes: expect.arrayContaining([
+          "identity_evidence_ineligible",
+          "rights_evidence_incomplete",
+        ]),
+        warningCodes: ["upscaling_risk"],
+      });
+    }
+    for (const fixture of fixtures) {
+      expect(
+        getCoverSelectionSqlite(raw, fixture.candidate.workId),
+      ).toMatchObject({
+        candidateId: null,
+        objectKey: PLACEHOLDER_COVER,
+        publicDisplayEligible: false,
+      });
+    }
+    expect(
+      raw
+        .prepare(
+          `select count(*) as count from cover_inspections
+           where media_type is not null and byte_size > 0 and width > 0
+             and height > 0 and aspect_ratio > 0 and length(checksum) = 64`,
+        )
+        .get(),
+    ).toEqual({ count: 5 });
+  });
+
+  it("is idempotent and rolls back a failed inspection transaction", () => {
+    const work = ENRICHMENT_SAMPLE_MANIFEST.works[0];
+    const fixture = approvedCoverFixture({
+      workId: work.workId,
+      editionId: editionIds[work.workId],
+    });
+    const first = createCoverCandidateSqlite(raw, fixture);
+    const retry = createCoverCandidateSqlite(raw, fixture);
+
+    expect(first.state).toBe("eligible");
+    expect(retry).toMatchObject({
+      candidateId: first.candidateId,
+      inspectionId: first.inspectionId,
+      decisionId: first.decisionId,
+      changed: false,
+    });
+    expect(
+      raw.prepare("select count(*) as count from cover_candidates").get(),
+    ).toEqual({ count: 1 });
+
+    const failed = approvedCoverFixture({
+      workId: work.workId,
+      editionId: editionIds[work.workId],
+      suffix: "forced-failure",
+    });
+    expect(() =>
+      createCoverCandidateSqlite(raw, {
+        ...failed,
+        failAfter: "decision",
+      }),
+    ).toThrow("Forced SQLite cover decision failure");
+    expect(
+      raw.prepare("select count(*) as count from cover_candidates").get(),
+    ).toEqual({ count: 1 });
+  });
+
+  it("keeps scores advisory and requires warning acknowledgement", () => {
+    const work = ENRICHMENT_SAMPLE_MANIFEST.works[0];
+    const fixture = approvedCoverFixture({
+      workId: work.workId,
+      editionId: editionIds[work.workId],
+      suffix: "square-warning",
+      qualityScore: 100,
+    });
+    fixture.inspection.flags = ["square_canvas"];
+    const created = createCoverCandidateSqlite(raw, fixture);
+
+    expect(created.state).toBe("review_required");
+    expect(getCoverSelectionSqlite(raw, work.workId).objectKey).toBe(
+      PLACEHOLDER_COVER,
+    );
+    expect(() =>
+      reviewCoverCandidateSqlite(raw, {
+        candidateId: created.candidateId,
+        reviewerRef: "user:cover-reviewer",
+        decision: "approve",
+        reason: "Reviewed crop in the diagnostic fixture",
+        acknowledgedWarningCodes: [],
+        reviewedAt: NOW,
+      }),
+    ).toThrow("warnings not acknowledged");
+
+    reviewCoverCandidateSqlite(raw, {
+      candidateId: created.candidateId,
+      reviewerRef: "user:cover-reviewer",
+      decision: "approve",
+      reason: "Reviewed crop in the diagnostic fixture",
+      acknowledgedWarningCodes: ["square_canvas"],
+      reviewedAt: NOW + 1,
+    });
+    expect(getCoverSelectionSqlite(raw, work.workId)).toMatchObject({
+      candidateId: created.candidateId,
+      representationType: "selected_edition",
+      editionId: editionIds[work.workId],
+      publicDisplayEligible: false,
+    });
+  });
+
+  it("chooses deterministically and prefers exact selected-edition evidence", () => {
+    const work = ENRICHMENT_SAMPLE_MANIFEST.works[0];
+    const exact = approvedCoverFixture({
+      workId: work.workId,
+      editionId: editionIds[work.workId],
+      suffix: "exact-low-score",
+      qualityScore: 70,
+    });
+    const representative = approvedCoverFixture({
+      workId: work.workId,
+      editionId: editionIds[work.workId],
+      suffix: "work-high-score",
+      qualityScore: 100,
+    });
+    representative.candidate.editionId = null;
+    representative.candidate.representationType = "work_representative";
+    representative.candidate.identityMatchKind = "curated_work_relation";
+
+    createCoverCandidateSqlite(raw, representative);
+    const exactResult = createCoverCandidateSqlite(raw, exact);
+
+    expect(getCoverSelectionSqlite(raw, work.workId)).toMatchObject({
+      candidateId: exactResult.candidateId,
+      representationType: "selected_edition",
+      objectKey: exact.candidate.objectKey,
+    });
+  });
+
+  it("flags duplicate bytes without allowing arrival order to choose the winner", () => {
+    const work = ENRICHMENT_SAMPLE_MANIFEST.works[0];
+    const first = approvedCoverFixture({
+      workId: work.workId,
+      editionId: editionIds[work.workId],
+      suffix: "duplicate-a",
+    });
+    const second = approvedCoverFixture({
+      workId: work.workId,
+      editionId: editionIds[work.workId],
+      suffix: "duplicate-b",
+    });
+    second.inspection.checksum = first.inspection.checksum;
+    createCoverCandidateSqlite(raw, first);
+    const duplicate = createCoverCandidateSqlite(raw, second);
+
+    expect(duplicate.warningCodes).toContain("duplicate");
+    expect(
+      raw
+        .prepare(
+          `select duplicate_of_candidate_id as duplicateOf
+           from cover_inspections where candidate_id = ?`,
+        )
+        .get(duplicate.candidateId),
+    ).toEqual({ duplicateOf: expect.any(String) });
+    const forwardWinner = getCoverSelectionSqlite(raw, work.workId).candidateId;
+
+    const reversePath = path.join(directory, "covers-reverse.sqlite");
+    rebuildCatalogSqlite({
+      sqlitePath: reversePath,
+      graph: buildCatalogImportGraph(SAMPLE_BASELINE_IMPORT_RECORDS),
+    });
+    const reverse = openCatalogSqlite(reversePath).raw;
+    try {
+      seedCoverFixturesSqlite(reverse);
+      createCoverCandidateSqlite(reverse, second);
+      createCoverCandidateSqlite(reverse, first);
+      expect(getCoverSelectionSqlite(reverse, work.workId).candidateId).toBe(
+        forwardWinner,
+      );
+    } finally {
+      reverse.close();
+    }
+  });
+
+  it("withdraws, purges, recomputes fallback, retries purge, and rolls back", async () => {
+    const work = ENRICHMENT_SAMPLE_MANIFEST.works[0];
+    const fallback = approvedCoverFixture({
+      workId: work.workId,
+      editionId: editionIds[work.workId],
+      suffix: "fallback",
+      qualityScore: 80,
+    });
+    const preferred = approvedCoverFixture({
+      workId: work.workId,
+      editionId: editionIds[work.workId],
+      suffix: "preferred",
+      qualityScore: 95,
+    });
+    const fallbackResult = createCoverCandidateSqlite(raw, fallback);
+    const fallbackProjection = raw
+      .prepare(
+        "select projection_id as id from cover_projection_heads where work_id = ?",
+      )
+      .get(work.workId) as { id: string };
+    const preferredResult = createCoverCandidateSqlite(raw, preferred);
+    const purge = vi.fn();
+
+    await withdrawCoverCandidateSqlite(raw, {
+      candidateId: preferredResult.candidateId,
+      actorRef: "user:cover-withdrawal",
+      reason: "Fixture rights withdrawal",
+      withdrawnAt: NOW,
+      purgeAsset: purge,
+    });
+    expect(purge).toHaveBeenCalledWith(preferred.candidate.objectKey);
+    expect(getCoverSelectionSqlite(raw, work.workId).candidateId).toBe(
+      fallbackResult.candidateId,
+    );
+
+    const replacement = approvedCoverFixture({
+      workId: work.workId,
+      editionId: editionIds[work.workId],
+      suffix: "replacement",
+      qualityScore: 99,
+    });
+    const replacementResult = createCoverCandidateSqlite(raw, replacement);
+    const rolledBack = rollbackCoverProjectionSqlite(raw, {
+      workId: work.workId,
+      targetProjectionId: fallbackProjection.id,
+      actorRef: "user:rollback-reviewer",
+      reason: "Restore reviewed fallback",
+      rolledBackAt: NOW + 1,
+    });
+    expect(rolledBack.selection).toMatchObject({
+      candidateId: fallbackResult.candidateId,
+      state: "rolled_back",
+    });
+
+    const failedPurge = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("purge failed"));
+    await expect(
+      withdrawCoverCandidateSqlite(raw, {
+        candidateId: fallbackResult.candidateId,
+        actorRef: "user:cover-withdrawal",
+        reason: "Withdraw fallback fixture",
+        withdrawnAt: NOW + 2,
+        purgeAsset: failedPurge,
+      }),
+    ).rejects.toThrow("purge failed");
+    const retryPurge = vi.fn();
+    await expect(
+      retryCoverWithdrawalPurgeSqlite(raw, {
+        candidateId: fallbackResult.candidateId,
+        purgeAsset: retryPurge,
+      }),
+    ).resolves.toBe(true);
+    expect(retryPurge).toHaveBeenCalledWith(fallback.candidate.objectKey);
+
+    await withdrawCoverCandidateSqlite(raw, {
+      candidateId: replacementResult.candidateId,
+      actorRef: "user:cover-withdrawal",
+      reason: "Withdraw final eligible fixture",
+      withdrawnAt: NOW + 3,
+      purgeAsset: vi.fn(),
+    });
+    expect(getCoverSelectionSqlite(raw, work.workId)).toMatchObject({
+      candidateId: null,
+      objectKey: PLACEHOLDER_COVER,
+      state: "withdrawn",
+    });
+  });
+
+  it("does not advance public cover relations or resolution heads", () => {
+    const work = ENRICHMENT_SAMPLE_MANIFEST.works[0];
+    const before = {
+      relations: raw
+        .prepare("select count(*) as count from edition_covers")
+        .get(),
+      heads: raw
+        .prepare(
+          `select count(*) as count from field_resolution_heads
+           where field_key = 'edition.covers'`,
+        )
+        .get(),
+    };
+    createCoverCandidateSqlite(
+      raw,
+      approvedCoverFixture({
+        workId: work.workId,
+        editionId: editionIds[work.workId],
+      }),
+    );
+
+    expect(
+      raw.prepare("select count(*) as count from edition_covers").get(),
+    ).toEqual(before.relations);
+    expect(
+      raw
+        .prepare(
+          `select count(*) as count from field_resolution_heads
+           where field_key = 'edition.covers'`,
+        )
+        .get(),
+    ).toEqual(before.heads);
+  });
+
+  it("fails closed when the current asset source policy is suspended", () => {
+    const work = ENRICHMENT_SAMPLE_MANIFEST.works[0];
+    createCoverCandidateSqlite(
+      raw,
+      approvedCoverFixture({
+        workId: work.workId,
+        editionId: editionIds[work.workId],
+        suffix: "policy-suspension",
+      }),
+    );
+    expect(
+      getCoverSelectionSqlite(raw, work.workId).candidateId,
+    ).not.toBeNull();
+
+    raw
+      .prepare(
+        `update metadata_sources set approval_state = 'suspended'
+         where key = 'cover_recorded_fixtures'`,
+      )
+      .run();
+
+    expect(getCoverSelectionSqlite(raw, work.workId)).toMatchObject({
+      candidateId: null,
+      objectKey: PLACEHOLDER_COVER,
+      publicDisplayEligible: false,
+    });
+  });
+});

--- a/src/db/catalog/enrichment/covers/repository.test.ts
+++ b/src/db/catalog/enrichment/covers/repository.test.ts
@@ -196,6 +196,109 @@ describe("SQLite edition-matched cover lifecycle", () => {
       editionId: editionIds[work.workId],
       publicDisplayEligible: false,
     });
+    const rejected = reviewCoverCandidateSqlite(raw, {
+      candidateId: created.candidateId,
+      reviewerRef: "user:cover-reviewer",
+      decision: "reject",
+      reason: "Square canvas is not suitable after visual review",
+      acknowledgedWarningCodes: [],
+      reviewedAt: NOW + 2,
+    });
+    expect(rejected).toMatchObject({
+      state: "rejected",
+      gateCodes: [],
+      warningCodes: ["square_canvas"],
+    });
+  });
+
+  it("enforces cache, transformation, and curated tuple approval gates", () => {
+    const work = ENRICHMENT_SAMPLE_MANIFEST.works[0];
+    const source = raw
+      .prepare(
+        `select asset_policy as policy from metadata_sources
+         where key = 'cover_recorded_fixtures'`,
+      )
+      .get() as { policy: string };
+    const policy = JSON.parse(source.policy) as {
+      cache: boolean;
+      transform: boolean;
+      fieldPermission: { cache: boolean; transform: boolean };
+    };
+    policy.cache = false;
+    policy.transform = false;
+    policy.fieldPermission.cache = false;
+    policy.fieldPermission.transform = false;
+    raw
+      .prepare(
+        `update metadata_sources set asset_policy = ?
+         where key = 'cover_recorded_fixtures'`,
+      )
+      .run(JSON.stringify(policy));
+    const deniedPolicy = approvedCoverFixture({
+      workId: work.workId,
+      editionId: editionIds[work.workId],
+      suffix: "denied-cache-transform",
+    });
+    deniedPolicy.candidate.transformationHistory = [
+      {
+        operation: "webp",
+        version: "1",
+        parameters: { quality: 80 },
+      },
+    ];
+    expect(createCoverCandidateSqlite(raw, deniedPolicy)).toMatchObject({
+      state: "rejected",
+      gateCodes: expect.arrayContaining(["source_policy_ineligible"]),
+    });
+
+    policy.cache = true;
+    policy.transform = true;
+    policy.fieldPermission.cache = true;
+    policy.fieldPermission.transform = true;
+    raw
+      .prepare(
+        `update metadata_sources set asset_policy = ?
+         where key = 'cover_recorded_fixtures'`,
+      )
+      .run(JSON.stringify(policy));
+    const approvedTuple = approvedCoverFixture({
+      workId: work.workId,
+      editionId: editionIds[work.workId],
+      suffix: "curated-tuple",
+    });
+    approvedTuple.candidate.identityMatchKind = "approved_strong_edition_tuple";
+    approvedTuple.candidate.identityEvidence = {
+      policyApproved: true,
+      title: "Dune",
+      publisher: "Ace",
+    };
+    expect(createCoverCandidateSqlite(raw, approvedTuple).state).toBe(
+      "eligible",
+    );
+
+    raw
+      .prepare(
+        `update source_record_links set match_kind = 'candidate'
+         where source_record_id = ? and entity_type = 'edition'
+           and entity_id = ?`,
+      )
+      .run(approvedTuple.candidate.sourceRecordId, editionIds[work.workId]);
+    const selfApprovedTuple = approvedCoverFixture({
+      workId: work.workId,
+      editionId: editionIds[work.workId],
+      suffix: "self-approved-tuple",
+    });
+    selfApprovedTuple.candidate.identityMatchKind =
+      "approved_strong_edition_tuple";
+    selfApprovedTuple.candidate.identityEvidence = {
+      policyApproved: true,
+      title: "Unverified title",
+      publisher: "Unverified publisher",
+    };
+    expect(createCoverCandidateSqlite(raw, selfApprovedTuple)).toMatchObject({
+      state: "review_required",
+      gateCodes: expect.arrayContaining(["identity_evidence_ineligible"]),
+    });
   });
 
   it("chooses deterministically and prefers exact selected-edition evidence", () => {
@@ -242,6 +345,7 @@ describe("SQLite edition-matched cover lifecycle", () => {
     createCoverCandidateSqlite(raw, first);
     const duplicate = createCoverCandidateSqlite(raw, second);
 
+    expect(duplicate.state).toBe("review_required");
     expect(duplicate.warningCodes).toContain("duplicate");
     expect(
       raw
@@ -266,6 +370,35 @@ describe("SQLite edition-matched cover lifecycle", () => {
       expect(getCoverSelectionSqlite(reverse, work.workId).candidateId).toBe(
         forwardWinner,
       );
+      const flagsByCandidate = (database: typeof raw) =>
+        Object.fromEntries(
+          (
+            database
+              .prepare(
+                `select candidate_id as "candidateId", flags_json as "flagsJson"
+                 from cover_inspections where checksum = ?
+                 order by candidate_id`,
+              )
+              .all(first.inspection.checksum) as Array<{
+              candidateId: string;
+              flagsJson: string;
+            }>
+          ).map((row) => [row.candidateId, JSON.parse(row.flagsJson)]),
+        );
+      expect(flagsByCandidate(reverse)).toEqual(flagsByCandidate(raw));
+      expect(
+        reverse
+          .prepare(
+            `select d.state, d.warning_codes_json as "warningCodesJson"
+             from cover_decision_heads h
+             join cover_decisions d on d.id = h.decision_id
+             where h.candidate_id = ?`,
+          )
+          .get(duplicate.candidateId),
+      ).toEqual({
+        state: "review_required",
+        warningCodesJson: '["duplicate"]',
+      });
     } finally {
       reverse.close();
     }
@@ -302,6 +435,17 @@ describe("SQLite edition-matched cover lifecycle", () => {
       purgeAsset: purge,
     });
     expect(purge).toHaveBeenCalledWith(preferred.candidate.objectKey);
+    const repeatedPurge = vi.fn();
+    await expect(
+      withdrawCoverCandidateSqlite(raw, {
+        candidateId: preferredResult.candidateId,
+        actorRef: "user:cover-withdrawal",
+        reason: "Repeated fixture rights withdrawal",
+        withdrawnAt: NOW + 1,
+        purgeAsset: repeatedPurge,
+      }),
+    ).resolves.toMatchObject({ changed: false, state: "withdrawn" });
+    expect(repeatedPurge).not.toHaveBeenCalled();
     expect(getCoverSelectionSqlite(raw, work.workId).candidateId).toBe(
       fallbackResult.candidateId,
     );

--- a/src/db/catalog/enrichment/covers/repository.ts
+++ b/src/db/catalog/enrichment/covers/repository.ts
@@ -275,7 +275,10 @@ const identityEvidenceVerified = (
     return source?.sourceLinkMatchKind === "source_relationship";
   }
   if (candidate.identityMatchKind === "approved_strong_edition_tuple") {
-    return candidate.identityEvidence.policyApproved === true;
+    return (
+      candidate.identityEvidence.policyApproved === true &&
+      source?.sourceLinkMatchKind === "curated"
+    );
   }
   if (candidate.identityMatchKind === "curated_work_relation") {
     return source?.sourceLinkMatchKind === "curated";
@@ -388,6 +391,127 @@ const appendDecision = (
   return { id, changed: true };
 };
 
+const decisionStateForValidation = (validation: {
+  hardRejected: boolean;
+  gateCodes: readonly CoverGateCode[];
+  warningCodes: readonly CoverFlagCode[];
+}): CoverCandidateResult["state"] =>
+  validation.hardRejected
+    ? "rejected"
+    : validation.gateCodes.length > 0 || validation.warningCodes.length > 0
+      ? "review_required"
+      : "eligible";
+
+const normalizeDuplicateGroup = (
+  raw: SqliteDatabase,
+  input: {
+    candidateId: string;
+    checksum: string;
+    decidedAt: number;
+    inspectionId: string;
+  },
+): { inspection: CoverInspection; affectedWorkIds: string[] } => {
+  const group = raw
+    .prepare(
+      `select
+         i.id, i.candidate_id as "candidateId", i.media_type as "mediaType",
+         i.byte_size as "byteSize", i.width, i.height,
+         i.aspect_ratio as "aspectRatio", i.checksum,
+         i.decode_result as "decodeResult", i.flags_json as "flagsJson",
+         i.quality_score as "qualityScore",
+         i.inspection_version as "inspectionVersion",
+         i.inspected_at as "inspectedAt", c.work_id as "workId"
+       from cover_inspections i
+       join cover_candidates c on c.id = i.candidate_id
+       left join cover_decision_heads h on h.candidate_id = i.candidate_id
+       left join cover_decisions d on d.id = h.decision_id
+       where i.checksum = ?
+         and (
+           (i.candidate_id = ? and i.id = ?)
+           or (i.candidate_id <> ? and d.inspection_id = i.id)
+         )
+       order by i.candidate_id asc, i.id asc`,
+    )
+    .all(
+      input.checksum,
+      input.candidateId,
+      input.inspectionId,
+      input.candidateId,
+    ) as Array<InspectionRow & { workId: string }>;
+  const canonicalCandidateId = group[0]?.candidateId;
+  const affectedWorkIds = new Set<string>();
+
+  for (const row of group) {
+    const baseFlags = parseJson<CoverFlagCode[]>(row.flagsJson).filter(
+      (flag) => flag !== "duplicate",
+    );
+    const isDuplicate = row.candidateId !== canonicalCandidateId;
+    const flags = uniqueSorted([
+      ...baseFlags,
+      ...(isDuplicate ? (["duplicate"] as const) : []),
+    ]);
+    raw
+      .prepare(
+        `update cover_inspections
+         set flags_json = ?, duplicate_of_candidate_id = ?
+         where id = ?`,
+      )
+      .run(
+        canonicalJson(flags),
+        isDuplicate ? canonicalCandidateId : null,
+        row.id,
+      );
+
+    if (row.candidateId === input.candidateId) continue;
+    const previous = loadDecision(raw, row.candidateId);
+    const candidateRow = loadCandidate(raw, row.candidateId);
+    if (
+      !previous ||
+      !candidateRow ||
+      !["eligible", "review_required"].includes(previous.state)
+    ) {
+      continue;
+    }
+    const inspection = inspectionFromRow({
+      ...row,
+      flagsJson: canonicalJson(flags),
+    });
+    const validation = currentValidation(
+      raw,
+      candidateFromRow(candidateRow),
+      inspection,
+    );
+    appendDecision(raw, {
+      candidateId: row.candidateId,
+      inspectionId: row.id,
+      state: decisionStateForValidation(validation),
+      gateCodes: validation.gateCodes,
+      warningCodes: validation.warningCodes,
+      decidedAt: input.decidedAt,
+    });
+    affectedWorkIds.add(row.workId);
+  }
+
+  const current = group.find((row) => row.id === input.inspectionId);
+  if (!current) throw new Error("Cover inspection not found after insert");
+  return {
+    inspection: inspectionFromRow({
+      ...current,
+      flagsJson: canonicalJson(
+        uniqueSorted([
+          ...parseJson<CoverFlagCode[]>(current.flagsJson).filter(
+            (flag) => flag !== "duplicate",
+          ),
+          ...(current.candidateId !== canonicalCandidateId
+            ? (["duplicate"] as const)
+            : []),
+        ]),
+      ),
+    }),
+    affectedWorkIds: [...affectedWorkIds],
+  };
+};
+
 const identityPriority = (
   kind: CoverCandidateInput["identityMatchKind"],
 ): number =>
@@ -481,22 +605,8 @@ const eligibleCandidates = (
       identityPriority(right.candidate.identityMatchKind) -
       identityPriority(left.candidate.identityMatchKind);
     if (identity !== 0) return identity;
-    const normalizedRightScore =
-      right.inspection.qualityScore +
-      (parseJson<CoverFlagCode[]>(right.inspection.flagsJson).includes(
-        "duplicate",
-      )
-        ? 4
-        : 0);
-    const normalizedLeftScore =
-      left.inspection.qualityScore +
-      (parseJson<CoverFlagCode[]>(left.inspection.flagsJson).includes(
-        "duplicate",
-      )
-        ? 4
-        : 0);
-    if (normalizedRightScore !== normalizedLeftScore) {
-      return normalizedRightScore - normalizedLeftScore;
+    if (right.inspection.qualityScore !== left.inspection.qualityScore) {
+      return right.inspection.qualityScore - left.inspection.qualityScore;
     }
     const area =
       (right.inspection.width ?? 0) * (right.inspection.height ?? 0) -
@@ -679,26 +789,11 @@ export const createCoverCandidateSqlite = (
     if (input.failAfter === "candidate") {
       throw new Error("Forced SQLite cover candidate failure");
     }
-    const duplicate = raw
-      .prepare(
-        `select candidate_id as "candidateId"
-         from cover_inspections
-         where checksum = ? and candidate_id <> ?
-         order by candidate_id asc limit 1`,
-      )
-      .get(input.inspection.checksum, candidateId) as
-      | { candidateId: string }
-      | undefined;
-    const flags = uniqueSorted([
-      ...input.inspection.flags,
-      ...(duplicate ? (["duplicate"] as const) : []),
-    ]);
-    const inspection = {
+    const inspectionToStore = {
       ...input.inspection,
-      flags,
-      qualityScore: duplicate
-        ? Math.max(0, input.inspection.qualityScore - 4)
-        : input.inspection.qualityScore,
+      flags: uniqueSorted(
+        input.inspection.flags.filter((flag) => flag !== "duplicate"),
+      ),
     };
     raw
       .prepare(
@@ -712,29 +807,31 @@ export const createCoverCandidateSqlite = (
       .run(
         inspectionId,
         candidateId,
-        inspection.mediaType,
-        inspection.byteSize,
-        inspection.width,
-        inspection.height,
-        inspection.aspectRatio,
-        inspection.checksum,
-        inspection.decodeResult,
-        canonicalJson(inspection.flags),
-        inspection.qualityScore,
-        duplicate?.candidateId ?? null,
-        inspection.inspectionVersion,
-        inspection.inspectedAt,
+        inspectionToStore.mediaType,
+        inspectionToStore.byteSize,
+        inspectionToStore.width,
+        inspectionToStore.height,
+        inspectionToStore.aspectRatio,
+        inspectionToStore.checksum,
+        inspectionToStore.decodeResult,
+        canonicalJson(inspectionToStore.flags),
+        inspectionToStore.qualityScore,
+        null,
+        inspectionToStore.inspectionVersion,
+        inspectionToStore.inspectedAt,
       );
     if (input.failAfter === "inspection") {
       throw new Error("Forced SQLite cover inspection failure");
     }
+    const duplicateNormalization = normalizeDuplicateGroup(raw, {
+      candidateId,
+      checksum: input.inspection.checksum,
+      decidedAt: input.inspection.inspectedAt,
+      inspectionId,
+    });
+    const inspection = duplicateNormalization.inspection;
     const validation = currentValidation(raw, input.candidate, inspection);
-    const state: CoverCandidateResult["state"] = validation.hardRejected
-      ? "rejected"
-      : validation.gateCodes.length > 0 ||
-          validation.warningCodes.some((warning) => warning !== "duplicate")
-        ? "review_required"
-        : "eligible";
+    const state = decisionStateForValidation(validation);
     const decision = appendDecision(raw, {
       candidateId,
       inspectionId,
@@ -746,12 +843,17 @@ export const createCoverCandidateSqlite = (
     if (input.failAfter === "decision") {
       throw new Error("Forced SQLite cover decision failure");
     }
-    recomputeCoverSelectionSqlite(raw, {
-      workId: input.candidate.workId,
-      actorRef: input.actorRef ?? "system:cover-inspection",
-      reasonCode: "candidate_inspected",
-      projectedAt: input.inspection.inspectedAt,
-    });
+    for (const workId of uniqueSorted([
+      input.candidate.workId,
+      ...duplicateNormalization.affectedWorkIds,
+    ])) {
+      recomputeCoverSelectionSqlite(raw, {
+        workId,
+        actorRef: input.actorRef ?? "system:cover-inspection",
+        reasonCode: "candidate_inspected",
+        projectedAt: input.inspection.inspectedAt,
+      });
+    }
     if (input.failAfter === "projection") {
       throw new Error("Forced SQLite cover projection failure");
     }
@@ -805,13 +907,7 @@ export const reviewCoverCandidateSqlite = (
       candidateId: input.candidateId,
       inspectionId: previous.inspectionId,
       state,
-      gateCodes:
-        input.decision === "approve"
-          ? []
-          : uniqueSorted([
-              ...validation.gateCodes,
-              "identity_evidence_ineligible",
-            ]),
+      gateCodes: input.decision === "approve" ? [] : validation.gateCodes,
       warningCodes: validation.warningCodes,
       reviewerRef: input.reviewerRef,
       reason: input.reason,
@@ -828,13 +924,7 @@ export const reviewCoverCandidateSqlite = (
       inspectionId: previous.inspectionId,
       decisionId: decision.id,
       state,
-      gateCodes:
-        input.decision === "approve"
-          ? []
-          : uniqueSorted([
-              ...validation.gateCodes,
-              "identity_evidence_ineligible",
-            ]),
+      gateCodes: input.decision === "approve" ? [] : validation.gateCodes,
       warningCodes: validation.warningCodes,
       changed: decision.changed,
     };

--- a/src/db/catalog/enrichment/covers/repository.ts
+++ b/src/db/catalog/enrichment/covers/repository.ts
@@ -1,0 +1,1049 @@
+import type Database from "better-sqlite3";
+import { PLACEHOLDER_COVER } from "../../../../media/covers";
+import {
+  canonicalJson,
+  deterministicCatalogId,
+  hashCanonicalJson,
+} from "../../identity";
+import type {
+  CoverCandidateInput,
+  CoverCandidateResult,
+  CoverFlagCode,
+  CoverGateCode,
+  CoverInspection,
+  CoverSelection,
+} from "./types";
+import { COVER_POLICY_VERSION } from "./types";
+import {
+  type CoverSourceContext,
+  coverPolicyRequiresPurge,
+  validateCoverCandidate,
+} from "./validation";
+
+type SqliteDatabase = InstanceType<typeof Database>;
+
+type CandidateRow = {
+  id: string;
+  workId: string;
+  editionId: string | null;
+  sourceRecordId: string;
+  representationType: "selected_edition" | "work_representative";
+  identityMatchKind: CoverCandidateInput["identityMatchKind"];
+  identityEvidenceJson: string;
+  permissionState: CoverCandidateInput["permissionState"];
+  rightsBasis: string | null;
+  attributionText: string | null;
+  attributionUrl: string | null;
+  sourceUrl: string;
+  sourceRevision: string;
+  sourcePolicyVersion: string;
+  objectKey: string;
+  transformationHistoryJson: string;
+  createdAt: number;
+};
+
+type InspectionRow = {
+  id: string;
+  candidateId: string;
+  mediaType: string | null;
+  byteSize: number;
+  width: number | null;
+  height: number | null;
+  aspectRatio: number | null;
+  checksum: string;
+  decodeResult: CoverInspection["decodeResult"];
+  flagsJson: string;
+  qualityScore: number;
+  inspectionVersion: string;
+  inspectedAt: number;
+};
+
+type DecisionRow = {
+  id: string;
+  candidateId: string;
+  inspectionId: string;
+  state: CoverCandidateResult["state"];
+  gateCodesJson: string;
+  warningCodesJson: string;
+  purgeState: "not_required" | "pending" | "completed" | "failed";
+};
+
+type ProjectionRow = {
+  id: string;
+  workId: string;
+  candidateId: string | null;
+  state: CoverSelection["state"];
+};
+
+const parseJson = <T>(value: string): T => JSON.parse(value) as T;
+const uniqueSorted = <T extends string>(values: readonly T[]): T[] =>
+  [...new Set(values)].sort();
+
+export const coverCandidateIdentity = (
+  candidate: CoverCandidateInput,
+): string =>
+  deterministicCatalogId(
+    "cover_candidate",
+    candidate.sourceRecordId,
+    hashCanonicalJson({
+      workId: candidate.workId,
+      editionId: candidate.editionId,
+      representationType: candidate.representationType,
+      identityMatchKind: candidate.identityMatchKind,
+      identityEvidence: candidate.identityEvidence,
+      permissionState: candidate.permissionState,
+      rightsBasis: candidate.rightsBasis,
+      attributionText: candidate.attributionText,
+      attributionUrl: candidate.attributionUrl,
+      sourceUrl: candidate.sourceUrl,
+      sourceRevision: candidate.sourceRevision,
+      sourcePolicyVersion: candidate.sourcePolicyVersion,
+      objectKey: candidate.objectKey,
+      transformationHistory: candidate.transformationHistory,
+    }),
+  );
+
+export const coverInspectionIdentity = (
+  candidateId: string,
+  inspection: Pick<CoverInspection, "checksum" | "inspectionVersion">,
+): string =>
+  deterministicCatalogId(
+    "cover_inspection",
+    candidateId,
+    `${inspection.checksum}:${inspection.inspectionVersion}`,
+  );
+
+const candidateFromRow = (row: CandidateRow): CoverCandidateInput => ({
+  workId: row.workId,
+  editionId: row.editionId,
+  sourceRecordId: row.sourceRecordId,
+  representationType: row.representationType,
+  identityMatchKind: row.identityMatchKind,
+  identityEvidence: parseJson(row.identityEvidenceJson),
+  permissionState: row.permissionState,
+  rightsBasis: row.rightsBasis,
+  attributionText: row.attributionText,
+  attributionUrl: row.attributionUrl,
+  sourceUrl: row.sourceUrl,
+  sourceRevision: row.sourceRevision,
+  sourcePolicyVersion: row.sourcePolicyVersion,
+  objectKey: row.objectKey,
+  transformationHistory: parseJson(row.transformationHistoryJson),
+  createdAt: row.createdAt,
+});
+
+const inspectionFromRow = (row: InspectionRow): CoverInspection => ({
+  mediaType: row.mediaType,
+  byteSize: row.byteSize,
+  width: row.width,
+  height: row.height,
+  aspectRatio: row.aspectRatio,
+  checksum: row.checksum,
+  decodeResult: row.decodeResult,
+  flags: parseJson(row.flagsJson),
+  qualityScore: row.qualityScore,
+  inspectionVersion: row.inspectionVersion,
+  inspectedAt: row.inspectedAt,
+});
+
+const loadCandidate = (
+  raw: SqliteDatabase,
+  candidateId: string,
+): CandidateRow | undefined =>
+  raw
+    .prepare(
+      `select
+         id, work_id as "workId", edition_id as "editionId",
+         source_record_id as "sourceRecordId",
+         representation_type as "representationType",
+         identity_match_kind as "identityMatchKind",
+         identity_evidence_json as "identityEvidenceJson",
+         permission_state as "permissionState", rights_basis as "rightsBasis",
+         attribution_text as "attributionText",
+         attribution_url as "attributionUrl", source_url as "sourceUrl",
+         source_revision as "sourceRevision",
+         source_policy_version as "sourcePolicyVersion",
+         object_key as "objectKey",
+         transformation_history_json as "transformationHistoryJson",
+         created_at as "createdAt"
+       from cover_candidates where id = ?`,
+    )
+    .get(candidateId) as CandidateRow | undefined;
+
+const loadInspection = (
+  raw: SqliteDatabase,
+  inspectionId: string,
+): InspectionRow =>
+  raw
+    .prepare(
+      `select
+         id, candidate_id as "candidateId", media_type as "mediaType",
+         byte_size as "byteSize", width, height, aspect_ratio as "aspectRatio",
+         checksum, decode_result as "decodeResult", flags_json as "flagsJson",
+         quality_score as "qualityScore",
+         inspection_version as "inspectionVersion",
+         inspected_at as "inspectedAt"
+       from cover_inspections where id = ?`,
+    )
+    .get(inspectionId) as InspectionRow;
+
+const loadDecision = (
+  raw: SqliteDatabase,
+  candidateId: string,
+): DecisionRow | undefined =>
+  raw
+    .prepare(
+      `select
+         d.id, d.candidate_id as "candidateId",
+         d.inspection_id as "inspectionId", d.state,
+         d.gate_codes_json as "gateCodesJson",
+         d.warning_codes_json as "warningCodesJson",
+         d.purge_state as "purgeState"
+       from cover_decision_heads h
+       join cover_decisions d on d.id = h.decision_id
+       where h.candidate_id = ?`,
+    )
+    .get(candidateId) as DecisionRow | undefined;
+
+const sourceContext = (
+  raw: SqliteDatabase,
+  candidate: CoverCandidateInput,
+): CoverSourceContext | undefined => {
+  const targetType =
+    candidate.representationType === "selected_edition" ? "edition" : "work";
+  const targetId = candidate.editionId ?? candidate.workId;
+  return raw
+    .prepare(
+      `select
+         sr.source_revision as "sourceRevision",
+         sr.state as "sourceRecordState",
+         s.approval_state as "sourceApproval",
+         sl.state as "sourceLinkState",
+         sl.match_kind as "sourceLinkMatchKind",
+         s.metadata_policy as "metadataPolicy",
+         s.asset_policy as "assetPolicy"
+       from source_records sr
+       join metadata_sources s on s.id = sr.source_id
+       left join source_record_links sl
+         on sl.source_record_id = sr.id
+        and sl.entity_type = ?
+        and sl.entity_id = ?
+       where sr.id = ?`,
+    )
+    .get(targetType, targetId, candidate.sourceRecordId) as
+    | CoverSourceContext
+    | undefined;
+};
+
+const editionBelongsToWork = (
+  raw: SqliteDatabase,
+  candidate: CoverCandidateInput,
+): boolean =>
+  candidate.editionId === null ||
+  Boolean(
+    raw
+      .prepare("select 1 from editions where id = ? and work_id = ?")
+      .get(candidate.editionId, candidate.workId),
+  );
+
+const identityEvidenceVerified = (
+  raw: SqliteDatabase,
+  candidate: CoverCandidateInput,
+  source: CoverSourceContext | undefined,
+): boolean => {
+  if (candidate.identityMatchKind === "exact_isbn" && candidate.editionId) {
+    const evidence = candidate.identityEvidence;
+    return ["isbn10", "isbn13"].some((scheme) => {
+      const value = evidence[scheme];
+      return (
+        typeof value === "string" &&
+        Boolean(
+          raw
+            .prepare(
+              `select 1 from edition_identifiers
+               where edition_id = ? and scheme = ? and value_normalized = ?`,
+            )
+            .get(candidate.editionId, scheme, value),
+        )
+      );
+    });
+  }
+  if (
+    candidate.identityMatchKind === "provider_edition_relation" ||
+    candidate.identityMatchKind === "provider_work_relation"
+  ) {
+    return source?.sourceLinkMatchKind === "source_relationship";
+  }
+  if (candidate.identityMatchKind === "approved_strong_edition_tuple") {
+    return candidate.identityEvidence.policyApproved === true;
+  }
+  if (candidate.identityMatchKind === "curated_work_relation") {
+    return source?.sourceLinkMatchKind === "curated";
+  }
+  return false;
+};
+
+const currentValidation = (
+  raw: SqliteDatabase,
+  candidate: CoverCandidateInput,
+  inspection: CoverInspection,
+) => {
+  const source = sourceContext(raw, candidate);
+  return validateCoverCandidate({
+    candidate,
+    inspection,
+    source,
+    editionBelongsToWork: editionBelongsToWork(raw, candidate),
+    identityEvidenceVerified: identityEvidenceVerified(raw, candidate, source),
+  });
+};
+
+const decisionIdentity = (input: {
+  candidateId: string;
+  inspectionId: string;
+  state: CoverCandidateResult["state"];
+  gateCodes: readonly CoverGateCode[];
+  warningCodes: readonly CoverFlagCode[];
+  reviewerRef: string | null;
+  reason: string | null;
+  previousDecisionId: string | null;
+  decidedAt: number;
+}): string =>
+  deterministicCatalogId(
+    "cover_decision",
+    input.candidateId,
+    hashCanonicalJson({
+      ...input,
+      policyVersion: COVER_POLICY_VERSION,
+    }),
+  );
+
+const appendDecision = (
+  raw: SqliteDatabase,
+  input: {
+    candidateId: string;
+    inspectionId: string;
+    state: CoverCandidateResult["state"];
+    gateCodes: readonly CoverGateCode[];
+    warningCodes: readonly CoverFlagCode[];
+    reviewerRef?: string | null;
+    reason?: string | null;
+    purgeState?: DecisionRow["purgeState"];
+    decidedAt: number;
+  },
+): { id: string; changed: boolean } => {
+  const previous = loadDecision(raw, input.candidateId);
+  const gateCodes = uniqueSorted(input.gateCodes);
+  const warningCodes = uniqueSorted(input.warningCodes);
+  if (
+    previous &&
+    previous.inspectionId === input.inspectionId &&
+    previous.state === input.state &&
+    previous.gateCodesJson === canonicalJson(gateCodes) &&
+    previous.warningCodesJson === canonicalJson(warningCodes) &&
+    previous.purgeState === (input.purgeState ?? "not_required")
+  ) {
+    return { id: previous.id, changed: false };
+  }
+  const id = decisionIdentity({
+    candidateId: input.candidateId,
+    inspectionId: input.inspectionId,
+    state: input.state,
+    gateCodes,
+    warningCodes,
+    reviewerRef: input.reviewerRef ?? null,
+    reason: input.reason ?? null,
+    previousDecisionId: previous?.id ?? null,
+    decidedAt: input.decidedAt,
+  });
+  raw
+    .prepare(
+      `insert into cover_decisions (
+         id, candidate_id, inspection_id, state, gate_codes_json,
+         warning_codes_json, reviewer_ref, review_reason, purge_state,
+         previous_decision_id, policy_version, decided_at
+       ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      id,
+      input.candidateId,
+      input.inspectionId,
+      input.state,
+      canonicalJson(gateCodes),
+      canonicalJson(warningCodes),
+      input.reviewerRef ?? null,
+      input.reason ?? null,
+      input.purgeState ?? "not_required",
+      previous?.id ?? null,
+      COVER_POLICY_VERSION,
+      input.decidedAt,
+    );
+  raw
+    .prepare(
+      `insert into cover_decision_heads (candidate_id, decision_id)
+       values (?, ?)
+       on conflict(candidate_id) do update set decision_id = excluded.decision_id`,
+    )
+    .run(input.candidateId, id);
+  return { id, changed: true };
+};
+
+const identityPriority = (
+  kind: CoverCandidateInput["identityMatchKind"],
+): number =>
+  ({
+    exact_isbn: 7,
+    provider_edition_relation: 6,
+    approved_strong_edition_tuple: 5,
+    curated_work_relation: 4,
+    provider_work_relation: 3,
+    title_creator_candidate: 1,
+    conflicting: 0,
+  })[kind];
+
+const eligibleCandidates = (
+  raw: SqliteDatabase,
+  workId: string,
+): Array<{
+  candidate: CandidateRow;
+  inspection: InspectionRow;
+}> => {
+  const rows = raw
+    .prepare(
+      `select
+         c.id, c.work_id as "workId", c.edition_id as "editionId",
+         c.source_record_id as "sourceRecordId",
+         c.representation_type as "representationType",
+         c.identity_match_kind as "identityMatchKind",
+         c.identity_evidence_json as "identityEvidenceJson",
+         c.permission_state as "permissionState",
+         c.rights_basis as "rightsBasis",
+         c.attribution_text as "attributionText",
+         c.attribution_url as "attributionUrl", c.source_url as "sourceUrl",
+         c.source_revision as "sourceRevision",
+         c.source_policy_version as "sourcePolicyVersion",
+         c.object_key as "objectKey",
+         c.transformation_history_json as "transformationHistoryJson",
+         c.created_at as "createdAt",
+         i.id as "inspectionId", i.media_type as "mediaType",
+         i.byte_size as "byteSize", i.width, i.height,
+         i.aspect_ratio as "aspectRatio", i.checksum,
+         i.decode_result as "decodeResult", i.flags_json as "flagsJson",
+         i.quality_score as "qualityScore",
+         i.inspection_version as "inspectionVersion",
+         i.inspected_at as "inspectedAt"
+       from cover_candidates c
+       join cover_decision_heads dh on dh.candidate_id = c.id
+       join cover_decisions d on d.id = dh.decision_id and d.state = 'eligible'
+       join cover_inspections i on i.id = d.inspection_id
+       where c.work_id = ?`,
+    )
+    .all(workId) as Array<
+    CandidateRow &
+      Omit<InspectionRow, "id" | "candidateId"> & { inspectionId: string }
+  >;
+  const eligible: Array<{
+    candidate: CandidateRow;
+    inspection: InspectionRow;
+  }> = [];
+  for (const row of rows) {
+    const candidate = candidateFromRow(row);
+    const inspectionRow: InspectionRow = {
+      id: row.inspectionId,
+      candidateId: row.id,
+      mediaType: row.mediaType,
+      byteSize: row.byteSize,
+      width: row.width,
+      height: row.height,
+      aspectRatio: row.aspectRatio,
+      checksum: row.checksum,
+      decodeResult: row.decodeResult,
+      flagsJson: row.flagsJson,
+      qualityScore: row.qualityScore,
+      inspectionVersion: row.inspectionVersion,
+      inspectedAt: row.inspectedAt,
+    };
+    const validation = currentValidation(
+      raw,
+      candidate,
+      inspectionFromRow(inspectionRow),
+    );
+    if (validation.gateCodes.length === 0) {
+      eligible.push({ candidate: row, inspection: inspectionRow });
+    }
+  }
+  return eligible.sort((left, right) => {
+    const representation =
+      Number(right.candidate.representationType === "selected_edition") -
+      Number(left.candidate.representationType === "selected_edition");
+    if (representation !== 0) return representation;
+    const identity =
+      identityPriority(right.candidate.identityMatchKind) -
+      identityPriority(left.candidate.identityMatchKind);
+    if (identity !== 0) return identity;
+    const normalizedRightScore =
+      right.inspection.qualityScore +
+      (parseJson<CoverFlagCode[]>(right.inspection.flagsJson).includes(
+        "duplicate",
+      )
+        ? 4
+        : 0);
+    const normalizedLeftScore =
+      left.inspection.qualityScore +
+      (parseJson<CoverFlagCode[]>(left.inspection.flagsJson).includes(
+        "duplicate",
+      )
+        ? 4
+        : 0);
+    if (normalizedRightScore !== normalizedLeftScore) {
+      return normalizedRightScore - normalizedLeftScore;
+    }
+    const area =
+      (right.inspection.width ?? 0) * (right.inspection.height ?? 0) -
+      (left.inspection.width ?? 0) * (left.inspection.height ?? 0);
+    if (area !== 0) return area;
+    const checksum = left.inspection.checksum.localeCompare(
+      right.inspection.checksum,
+    );
+    return checksum || left.candidate.id.localeCompare(right.candidate.id);
+  });
+};
+
+const loadProjection = (
+  raw: SqliteDatabase,
+  workId: string,
+): ProjectionRow | undefined =>
+  raw
+    .prepare(
+      `select p.id, p.work_id as "workId", p.candidate_id as "candidateId",
+              p.state
+       from cover_projection_heads h
+       join cover_projections p on p.id = h.projection_id
+       where h.work_id = ?`,
+    )
+    .get(workId) as ProjectionRow | undefined;
+
+const appendProjection = (
+  raw: SqliteDatabase,
+  input: {
+    workId: string;
+    candidateId: string | null;
+    state: CoverSelection["state"];
+    reasonCode: string;
+    actorRef: string;
+    projectedAt: number;
+  },
+): { row: ProjectionRow; changed: boolean } => {
+  const previous = loadProjection(raw, input.workId);
+  if (
+    previous?.candidateId === input.candidateId &&
+    previous.state === input.state
+  ) {
+    return { row: previous, changed: false };
+  }
+  const id = deterministicCatalogId(
+    "cover_projection",
+    input.workId,
+    hashCanonicalJson({
+      candidateId: input.candidateId,
+      state: input.state,
+      previousProjectionId: previous?.id ?? null,
+      reasonCode: input.reasonCode,
+      policyVersion: COVER_POLICY_VERSION,
+    }),
+  );
+  raw
+    .prepare(
+      `insert into cover_projections (
+         id, work_id, candidate_id, state, previous_projection_id,
+         reason_code, actor_ref, policy_version, projected_at
+       ) values (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      id,
+      input.workId,
+      input.candidateId,
+      input.state,
+      previous?.id ?? null,
+      input.reasonCode,
+      input.actorRef,
+      COVER_POLICY_VERSION,
+      input.projectedAt,
+    );
+  raw
+    .prepare(
+      `insert into cover_projection_heads (work_id, projection_id)
+       values (?, ?)
+       on conflict(work_id) do update set projection_id = excluded.projection_id`,
+    )
+    .run(input.workId, id);
+  return {
+    row: {
+      id,
+      workId: input.workId,
+      candidateId: input.candidateId,
+      state: input.state,
+    },
+    changed: true,
+  };
+};
+
+export const recomputeCoverSelectionSqlite = (
+  raw: SqliteDatabase,
+  input: {
+    workId: string;
+    actorRef: string;
+    reasonCode: string;
+    projectedAt: number;
+    emptyState?: "placeholder" | "withdrawn";
+  },
+): { selection: CoverSelection; changed: boolean } => {
+  const winner = eligibleCandidates(raw, input.workId)[0];
+  const projection = appendProjection(raw, {
+    workId: input.workId,
+    candidateId: winner?.candidate.id ?? null,
+    state: winner ? "selected" : (input.emptyState ?? "placeholder"),
+    reasonCode: input.reasonCode,
+    actorRef: input.actorRef,
+    projectedAt: input.projectedAt,
+  });
+  return {
+    selection: {
+      workId: input.workId,
+      candidateId: winner?.candidate.id ?? null,
+      objectKey: winner?.candidate.objectKey ?? PLACEHOLDER_COVER,
+      representationType: winner?.candidate.representationType ?? null,
+      editionId: winner?.candidate.editionId ?? null,
+      publicDisplayEligible: false,
+      state: projection.row.state,
+    },
+    changed: projection.changed,
+  };
+};
+
+export const createCoverCandidateSqlite = (
+  raw: SqliteDatabase,
+  input: {
+    candidate: CoverCandidateInput;
+    inspection: CoverInspection;
+    actorRef?: string;
+    failAfter?: "candidate" | "inspection" | "decision" | "projection";
+  },
+): CoverCandidateResult => {
+  const candidateId = coverCandidateIdentity(input.candidate);
+  const inspectionId = coverInspectionIdentity(candidateId, input.inspection);
+  const existing = loadDecision(raw, candidateId);
+  if (existing && existing.inspectionId === inspectionId) {
+    return {
+      candidateId,
+      inspectionId,
+      decisionId: existing.id,
+      state: existing.state,
+      gateCodes: parseJson(existing.gateCodesJson),
+      warningCodes: parseJson(existing.warningCodesJson),
+      changed: false,
+    };
+  }
+
+  return raw.transaction(() => {
+    raw
+      .prepare(
+        `insert into cover_candidates (
+           id, work_id, edition_id, source_record_id, representation_type,
+           identity_match_kind, identity_evidence_json, permission_state,
+           rights_basis, attribution_text, attribution_url, source_url,
+           source_revision, source_policy_version, object_key,
+           transformation_history_json, created_at
+         ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         on conflict(id) do nothing`,
+      )
+      .run(
+        candidateId,
+        input.candidate.workId,
+        input.candidate.editionId,
+        input.candidate.sourceRecordId,
+        input.candidate.representationType,
+        input.candidate.identityMatchKind,
+        canonicalJson(input.candidate.identityEvidence),
+        input.candidate.permissionState,
+        input.candidate.rightsBasis,
+        input.candidate.attributionText,
+        input.candidate.attributionUrl,
+        input.candidate.sourceUrl,
+        input.candidate.sourceRevision,
+        input.candidate.sourcePolicyVersion,
+        input.candidate.objectKey,
+        canonicalJson(input.candidate.transformationHistory),
+        input.candidate.createdAt,
+      );
+    if (input.failAfter === "candidate") {
+      throw new Error("Forced SQLite cover candidate failure");
+    }
+    const duplicate = raw
+      .prepare(
+        `select candidate_id as "candidateId"
+         from cover_inspections
+         where checksum = ? and candidate_id <> ?
+         order by candidate_id asc limit 1`,
+      )
+      .get(input.inspection.checksum, candidateId) as
+      | { candidateId: string }
+      | undefined;
+    const flags = uniqueSorted([
+      ...input.inspection.flags,
+      ...(duplicate ? (["duplicate"] as const) : []),
+    ]);
+    const inspection = {
+      ...input.inspection,
+      flags,
+      qualityScore: duplicate
+        ? Math.max(0, input.inspection.qualityScore - 4)
+        : input.inspection.qualityScore,
+    };
+    raw
+      .prepare(
+        `insert into cover_inspections (
+           id, candidate_id, media_type, byte_size, width, height, aspect_ratio,
+           checksum, decode_result, flags_json, quality_score,
+           duplicate_of_candidate_id, inspection_version, inspected_at
+         ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         on conflict(candidate_id, checksum, inspection_version) do nothing`,
+      )
+      .run(
+        inspectionId,
+        candidateId,
+        inspection.mediaType,
+        inspection.byteSize,
+        inspection.width,
+        inspection.height,
+        inspection.aspectRatio,
+        inspection.checksum,
+        inspection.decodeResult,
+        canonicalJson(inspection.flags),
+        inspection.qualityScore,
+        duplicate?.candidateId ?? null,
+        inspection.inspectionVersion,
+        inspection.inspectedAt,
+      );
+    if (input.failAfter === "inspection") {
+      throw new Error("Forced SQLite cover inspection failure");
+    }
+    const validation = currentValidation(raw, input.candidate, inspection);
+    const state: CoverCandidateResult["state"] = validation.hardRejected
+      ? "rejected"
+      : validation.gateCodes.length > 0 ||
+          validation.warningCodes.some((warning) => warning !== "duplicate")
+        ? "review_required"
+        : "eligible";
+    const decision = appendDecision(raw, {
+      candidateId,
+      inspectionId,
+      state,
+      gateCodes: validation.gateCodes,
+      warningCodes: validation.warningCodes,
+      decidedAt: input.inspection.inspectedAt,
+    });
+    if (input.failAfter === "decision") {
+      throw new Error("Forced SQLite cover decision failure");
+    }
+    recomputeCoverSelectionSqlite(raw, {
+      workId: input.candidate.workId,
+      actorRef: input.actorRef ?? "system:cover-inspection",
+      reasonCode: "candidate_inspected",
+      projectedAt: input.inspection.inspectedAt,
+    });
+    if (input.failAfter === "projection") {
+      throw new Error("Forced SQLite cover projection failure");
+    }
+    return {
+      candidateId,
+      inspectionId,
+      decisionId: decision.id,
+      state,
+      gateCodes: validation.gateCodes,
+      warningCodes: validation.warningCodes,
+      changed: true,
+    };
+  })();
+};
+
+export const reviewCoverCandidateSqlite = (
+  raw: SqliteDatabase,
+  input: {
+    candidateId: string;
+    reviewerRef: string;
+    decision: "approve" | "reject";
+    reason: string;
+    acknowledgedWarningCodes: readonly CoverFlagCode[];
+    reviewedAt: number;
+  },
+): CoverCandidateResult => {
+  const candidateRow = loadCandidate(raw, input.candidateId);
+  const previous = loadDecision(raw, input.candidateId);
+  if (!candidateRow || !previous) throw new Error("Cover candidate not found");
+  const inspectionRow = loadInspection(raw, previous.inspectionId);
+  const candidate = candidateFromRow(candidateRow);
+  const inspection = inspectionFromRow(inspectionRow);
+  const validation = currentValidation(raw, candidate, inspection);
+  if (input.decision === "approve") {
+    if (validation.gateCodes.length > 0) {
+      throw new Error(
+        `Cover hard gates cannot be overridden: ${validation.gateCodes.join(", ")}`,
+      );
+    }
+    const missing = validation.warningCodes.filter(
+      (warning) => !input.acknowledgedWarningCodes.includes(warning),
+    );
+    if (missing.length > 0) {
+      throw new Error(`Cover warnings not acknowledged: ${missing.join(", ")}`);
+    }
+  }
+  return raw.transaction(() => {
+    const state: CoverCandidateResult["state"] =
+      input.decision === "approve" ? "eligible" : "rejected";
+    const decision = appendDecision(raw, {
+      candidateId: input.candidateId,
+      inspectionId: previous.inspectionId,
+      state,
+      gateCodes:
+        input.decision === "approve"
+          ? []
+          : uniqueSorted([
+              ...validation.gateCodes,
+              "identity_evidence_ineligible",
+            ]),
+      warningCodes: validation.warningCodes,
+      reviewerRef: input.reviewerRef,
+      reason: input.reason,
+      decidedAt: input.reviewedAt,
+    });
+    recomputeCoverSelectionSqlite(raw, {
+      workId: candidate.workId,
+      actorRef: input.reviewerRef,
+      reasonCode: `review_${input.decision}`,
+      projectedAt: input.reviewedAt,
+    });
+    return {
+      candidateId: input.candidateId,
+      inspectionId: previous.inspectionId,
+      decisionId: decision.id,
+      state,
+      gateCodes:
+        input.decision === "approve"
+          ? []
+          : uniqueSorted([
+              ...validation.gateCodes,
+              "identity_evidence_ineligible",
+            ]),
+      warningCodes: validation.warningCodes,
+      changed: decision.changed,
+    };
+  })();
+};
+
+export const getCoverSelectionSqlite = (
+  raw: SqliteDatabase,
+  workId: string,
+): CoverSelection => {
+  const projection = loadProjection(raw, workId);
+  if (!projection?.candidateId) {
+    return {
+      workId,
+      candidateId: null,
+      objectKey: PLACEHOLDER_COVER,
+      representationType: null,
+      editionId: null,
+      publicDisplayEligible: false,
+      state: projection?.state ?? "placeholder",
+    };
+  }
+  const candidate = loadCandidate(raw, projection.candidateId);
+  const decision = loadDecision(raw, projection.candidateId);
+  const currentlyEligible =
+    candidate &&
+    decision?.state === "eligible" &&
+    currentValidation(
+      raw,
+      candidateFromRow(candidate),
+      inspectionFromRow(loadInspection(raw, decision.inspectionId)),
+    ).gateCodes.length === 0;
+  if (!currentlyEligible || !candidate) {
+    return {
+      workId,
+      candidateId: null,
+      objectKey: PLACEHOLDER_COVER,
+      representationType: null,
+      editionId: null,
+      publicDisplayEligible: false,
+      state: "placeholder",
+    };
+  }
+  return {
+    workId,
+    candidateId: candidate.id,
+    objectKey: candidate.objectKey,
+    representationType: candidate.representationType,
+    editionId: candidate.editionId,
+    publicDisplayEligible: false,
+    state: projection.state,
+  };
+};
+
+export const withdrawCoverCandidateSqlite = async (
+  raw: SqliteDatabase,
+  input: {
+    candidateId: string;
+    actorRef: string;
+    reason: string;
+    withdrawnAt: number;
+    purgeAsset?: (objectKey: string) => void | Promise<void>;
+  },
+): Promise<CoverCandidateResult> => {
+  const candidateRow = loadCandidate(raw, input.candidateId);
+  const previous = loadDecision(raw, input.candidateId);
+  if (!candidateRow || !previous) throw new Error("Cover candidate not found");
+  if (previous.state === "withdrawn" && previous.purgeState !== "failed") {
+    return {
+      candidateId: input.candidateId,
+      inspectionId: previous.inspectionId,
+      decisionId: previous.id,
+      state: "withdrawn",
+      gateCodes: parseJson(previous.gateCodesJson),
+      warningCodes: parseJson(previous.warningCodesJson),
+      changed: false,
+    };
+  }
+  const candidate = candidateFromRow(candidateRow);
+  const context = sourceContext(raw, candidate);
+  const purgeRequired = coverPolicyRequiresPurge(context?.assetPolicy);
+  const result = raw.transaction(() => {
+    const decision = appendDecision(raw, {
+      candidateId: input.candidateId,
+      inspectionId: previous.inspectionId,
+      state: "withdrawn",
+      gateCodes: parseJson(previous.gateCodesJson),
+      warningCodes: parseJson(previous.warningCodesJson),
+      reviewerRef: input.actorRef,
+      reason: input.reason,
+      purgeState: purgeRequired ? "pending" : "not_required",
+      decidedAt: input.withdrawnAt,
+    });
+    const remaining = eligibleCandidates(raw, candidate.workId);
+    recomputeCoverSelectionSqlite(raw, {
+      workId: candidate.workId,
+      actorRef: input.actorRef,
+      reasonCode: "candidate_withdrawn",
+      projectedAt: input.withdrawnAt,
+      emptyState: remaining.length > 0 ? "placeholder" : "withdrawn",
+    });
+    return decision;
+  })();
+  if (purgeRequired) {
+    try {
+      if (!input.purgeAsset) {
+        throw new Error("Cover withdrawal requires an asset purge callback");
+      }
+      await input.purgeAsset(candidate.objectKey);
+      raw
+        .prepare(
+          "update cover_decisions set purge_state = 'completed' where id = ?",
+        )
+        .run(result.id);
+    } catch (error) {
+      raw
+        .prepare(
+          "update cover_decisions set purge_state = 'failed' where id = ?",
+        )
+        .run(result.id);
+      throw error;
+    }
+  }
+  const current = loadDecision(raw, input.candidateId) as DecisionRow;
+  return {
+    candidateId: input.candidateId,
+    inspectionId: current.inspectionId,
+    decisionId: current.id,
+    state: "withdrawn",
+    gateCodes: parseJson(current.gateCodesJson),
+    warningCodes: parseJson(current.warningCodesJson),
+    changed: result.changed,
+  };
+};
+
+export const retryCoverWithdrawalPurgeSqlite = async (
+  raw: SqliteDatabase,
+  input: {
+    candidateId: string;
+    purgeAsset: (objectKey: string) => void | Promise<void>;
+  },
+): Promise<boolean> => {
+  const candidate = loadCandidate(raw, input.candidateId);
+  const decision = loadDecision(raw, input.candidateId);
+  if (!candidate || !decision || decision.state !== "withdrawn") {
+    throw new Error("Withdrawn cover candidate not found");
+  }
+  if (
+    decision.purgeState === "completed" ||
+    decision.purgeState === "not_required"
+  ) {
+    return false;
+  }
+  try {
+    await input.purgeAsset(candidate.objectKey);
+    raw
+      .prepare(
+        "update cover_decisions set purge_state = 'completed' where id = ?",
+      )
+      .run(decision.id);
+    return true;
+  } catch (error) {
+    raw
+      .prepare("update cover_decisions set purge_state = 'failed' where id = ?")
+      .run(decision.id);
+    throw error;
+  }
+};
+
+export const rollbackCoverProjectionSqlite = (
+  raw: SqliteDatabase,
+  input: {
+    workId: string;
+    targetProjectionId: string;
+    actorRef: string;
+    reason: string;
+    rolledBackAt: number;
+  },
+): { selection: CoverSelection; changed: boolean } => {
+  const target = raw
+    .prepare(
+      `select id, work_id as "workId", candidate_id as "candidateId", state
+       from cover_projections where id = ? and work_id = ?`,
+    )
+    .get(input.targetProjectionId, input.workId) as ProjectionRow | undefined;
+  if (!target?.candidateId) {
+    throw new Error("Rollback target does not select a cover candidate");
+  }
+  const eligible = eligibleCandidates(raw, input.workId).some(
+    (row) => row.candidate.id === target.candidateId,
+  );
+  if (!eligible) throw new Error("Rollback target is no longer eligible");
+  const current = loadProjection(raw, input.workId);
+  if (current?.candidateId === target.candidateId) {
+    return {
+      selection: getCoverSelectionSqlite(raw, input.workId),
+      changed: false,
+    };
+  }
+  const projection = appendProjection(raw, {
+    workId: input.workId,
+    candidateId: target.candidateId,
+    state: "rolled_back",
+    reasonCode: input.reason,
+    actorRef: input.actorRef,
+    projectedAt: input.rolledBackAt,
+  });
+  return {
+    selection: getCoverSelectionSqlite(raw, input.workId),
+    changed: projection.changed,
+  };
+};

--- a/src/db/catalog/enrichment/covers/types.ts
+++ b/src/db/catalog/enrichment/covers/types.ts
@@ -1,0 +1,106 @@
+import type {
+  CoverDecisionState,
+  CoverDecodeResult,
+  CoverIdentityMatchKind,
+  CoverPermissionState,
+  CoverRepresentationType,
+} from "../../values";
+
+export const COVER_POLICY_VERSION = "cover-gates-2026-07-29.v1";
+export const COVER_INSPECTION_VERSION = "cover-inspection-2026-07-29.v1";
+
+export const COVER_FLAG_CODES = [
+  "corrupt",
+  "tiny_dimensions",
+  "square_canvas",
+  "sidebars",
+  "extreme_aspect_ratio",
+  "extreme_crop",
+  "blur_risk",
+  "upscaling_risk",
+  "duplicate",
+  "locale_conflict",
+  "adaptation_conflict",
+] as const;
+
+export const COVER_GATE_CODES = [
+  "source_policy_ineligible",
+  "rights_evidence_incomplete",
+  "attribution_incomplete",
+  "identity_evidence_ineligible",
+  "identity_conflict",
+  "decode_failed",
+  "media_type_unsupported",
+  "adaptation_conflict",
+  "locale_conflict",
+] as const;
+
+export type CoverFlagCode = (typeof COVER_FLAG_CODES)[number];
+export type CoverGateCode = (typeof COVER_GATE_CODES)[number];
+
+export type CoverTransformation = {
+  operation: string;
+  version: string;
+  parameters: Readonly<Record<string, string | number | boolean>>;
+};
+
+export type CoverCandidateInput = {
+  workId: string;
+  editionId: string | null;
+  sourceRecordId: string;
+  representationType: CoverRepresentationType;
+  identityMatchKind: CoverIdentityMatchKind;
+  identityEvidence: Readonly<Record<string, unknown>>;
+  permissionState: CoverPermissionState;
+  rightsBasis: string | null;
+  attributionText: string | null;
+  attributionUrl: string | null;
+  sourceUrl: string;
+  sourceRevision: string;
+  sourcePolicyVersion: string;
+  objectKey: string;
+  transformationHistory: readonly CoverTransformation[];
+  createdAt: number;
+};
+
+export type CoverInspectionSignals = {
+  localeConflict?: boolean;
+  adaptationConflict?: boolean;
+  blurRisk?: boolean;
+  sidebars?: boolean;
+  extremeCrop?: boolean;
+};
+
+export type CoverInspection = {
+  mediaType: string | null;
+  byteSize: number;
+  width: number | null;
+  height: number | null;
+  aspectRatio: number | null;
+  checksum: string;
+  decodeResult: CoverDecodeResult;
+  flags: CoverFlagCode[];
+  qualityScore: number;
+  inspectionVersion: string;
+  inspectedAt: number;
+};
+
+export type CoverCandidateResult = {
+  candidateId: string;
+  inspectionId: string;
+  decisionId: string;
+  state: CoverDecisionState;
+  gateCodes: CoverGateCode[];
+  warningCodes: CoverFlagCode[];
+  changed: boolean;
+};
+
+export type CoverSelection = {
+  workId: string;
+  candidateId: string | null;
+  objectKey: string;
+  representationType: CoverRepresentationType | null;
+  editionId: string | null;
+  publicDisplayEligible: false;
+  state: "selected" | "placeholder" | "withdrawn" | "rolled_back";
+};

--- a/src/db/catalog/enrichment/covers/validation.ts
+++ b/src/db/catalog/enrichment/covers/validation.ts
@@ -1,0 +1,175 @@
+import type {
+  CoverCandidateInput,
+  CoverFlagCode,
+  CoverGateCode,
+  CoverInspection,
+} from "./types";
+
+export type CoverSourceContext = {
+  sourceRevision: string | null;
+  sourceRecordState: "active" | "withdrawn" | "deleted";
+  sourceApproval: "pending" | "approved" | "suspended" | "retired";
+  sourceLinkState: "active" | "candidate" | "rejected" | null;
+  sourceLinkMatchKind:
+    | "exact_identifier"
+    | "source_relationship"
+    | "curated"
+    | "candidate"
+    | null;
+  metadataPolicy: unknown;
+  assetPolicy: unknown;
+};
+
+type AssetPolicy = {
+  display?: unknown;
+  sourcePolicyVersion?: unknown;
+  purgeOnWithdrawal?: unknown;
+  attribution?: {
+    required?: unknown;
+  };
+  fieldPermission?: {
+    allowedFields?: unknown;
+    cache?: unknown;
+    transform?: unknown;
+  };
+};
+
+const parseObject = (value: unknown): Record<string, unknown> => {
+  try {
+    const parsed: unknown =
+      typeof value === "string" ? JSON.parse(value) : value;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+};
+
+export const parseCoverAssetPolicy = (value: unknown): AssetPolicy =>
+  parseObject(value) as AssetPolicy;
+
+const sourcePolicyVersion = (value: unknown): string | null => {
+  const parsed = parseObject(value);
+  return typeof parsed.sourcePolicyVersion === "string"
+    ? parsed.sourcePolicyVersion
+    : null;
+};
+
+const sorted = <T extends string>(values: readonly T[]): T[] =>
+  [...new Set(values)].sort();
+
+export const validateCoverCandidate = (input: {
+  candidate: CoverCandidateInput;
+  inspection: CoverInspection;
+  source: CoverSourceContext | undefined;
+  editionBelongsToWork: boolean;
+  identityEvidenceVerified: boolean;
+}): {
+  gateCodes: CoverGateCode[];
+  warningCodes: CoverFlagCode[];
+  hardRejected: boolean;
+} => {
+  const { candidate, inspection, source } = input;
+  const assetPolicy = parseCoverAssetPolicy(source?.assetPolicy);
+  const allowedFields = assetPolicy.fieldPermission?.allowedFields;
+  const sourceEligible = Boolean(
+    source &&
+      source.sourceRecordState === "active" &&
+      source.sourceApproval === "approved" &&
+      source.sourceLinkState === "active" &&
+      source.sourceRevision === candidate.sourceRevision &&
+      sourcePolicyVersion(source.metadataPolicy) ===
+        candidate.sourcePolicyVersion &&
+      assetPolicy.sourcePolicyVersion === candidate.sourcePolicyVersion &&
+      assetPolicy.display === true &&
+      Array.isArray(allowedFields) &&
+      allowedFields.includes("edition.covers"),
+  );
+
+  const gateCodes: CoverGateCode[] = [];
+  if (!sourceEligible || candidate.permissionState === "denied") {
+    gateCodes.push("source_policy_ineligible");
+  }
+  if (
+    candidate.permissionState !== "approved" ||
+    !candidate.rightsBasis?.trim()
+  ) {
+    gateCodes.push("rights_evidence_incomplete");
+  }
+  if (
+    assetPolicy.attribution?.required === true &&
+    !candidate.attributionText?.trim() &&
+    !candidate.attributionUrl?.trim()
+  ) {
+    gateCodes.push("attribution_incomplete");
+  }
+
+  if (
+    candidate.representationType === "selected_edition" &&
+    (!candidate.editionId || !input.editionBelongsToWork)
+  ) {
+    gateCodes.push("identity_conflict");
+  } else if (
+    candidate.representationType === "selected_edition" &&
+    (![
+      "exact_isbn",
+      "provider_edition_relation",
+      "approved_strong_edition_tuple",
+    ].includes(candidate.identityMatchKind) ||
+      !input.identityEvidenceVerified)
+  ) {
+    gateCodes.push(
+      candidate.identityMatchKind === "conflicting"
+        ? "identity_conflict"
+        : "identity_evidence_ineligible",
+    );
+  } else if (
+    candidate.representationType === "work_representative" &&
+    (!["provider_work_relation", "curated_work_relation"].includes(
+      candidate.identityMatchKind,
+    ) ||
+      !input.identityEvidenceVerified)
+  ) {
+    gateCodes.push(
+      candidate.identityMatchKind === "conflicting"
+        ? "identity_conflict"
+        : "identity_evidence_ineligible",
+    );
+  }
+
+  if (inspection.decodeResult === "corrupt") {
+    gateCodes.push("decode_failed");
+  } else if (inspection.decodeResult === "unsupported") {
+    gateCodes.push("media_type_unsupported");
+  }
+  if (inspection.flags.includes("adaptation_conflict")) {
+    gateCodes.push("adaptation_conflict");
+  }
+  if (inspection.flags.includes("locale_conflict")) {
+    gateCodes.push("locale_conflict");
+  }
+
+  const warningCodes = inspection.flags.filter(
+    (flag) =>
+      !["corrupt", "adaptation_conflict", "locale_conflict"].includes(flag),
+  );
+  const hardRejected = gateCodes.some((code) =>
+    [
+      "source_policy_ineligible",
+      "identity_conflict",
+      "decode_failed",
+      "media_type_unsupported",
+      "adaptation_conflict",
+      "locale_conflict",
+    ].includes(code),
+  );
+  return {
+    gateCodes: sorted(gateCodes),
+    warningCodes: sorted(warningCodes),
+    hardRejected,
+  };
+};
+
+export const coverPolicyRequiresPurge = (assetPolicy: unknown): boolean =>
+  parseCoverAssetPolicy(assetPolicy).purgeOnWithdrawal === true;

--- a/src/db/catalog/enrichment/covers/validation.ts
+++ b/src/db/catalog/enrichment/covers/validation.ts
@@ -21,8 +21,10 @@ export type CoverSourceContext = {
 };
 
 type AssetPolicy = {
+  cache?: unknown;
   display?: unknown;
   sourcePolicyVersion?: unknown;
+  transform?: unknown;
   purgeOnWithdrawal?: unknown;
   attribution?: {
     required?: unknown;
@@ -30,6 +32,8 @@ type AssetPolicy = {
   fieldPermission?: {
     allowedFields?: unknown;
     cache?: unknown;
+    display?: unknown;
+    fetch?: unknown;
     transform?: unknown;
   };
 };
@@ -82,9 +86,16 @@ export const validateCoverCandidate = (input: {
       sourcePolicyVersion(source.metadataPolicy) ===
         candidate.sourcePolicyVersion &&
       assetPolicy.sourcePolicyVersion === candidate.sourcePolicyVersion &&
+      assetPolicy.cache === true &&
       assetPolicy.display === true &&
       Array.isArray(allowedFields) &&
-      allowedFields.includes("edition.covers"),
+      allowedFields.includes("edition.covers") &&
+      assetPolicy.fieldPermission?.fetch === true &&
+      assetPolicy.fieldPermission.cache === true &&
+      assetPolicy.fieldPermission.display === true &&
+      (candidate.transformationHistory.length === 0 ||
+        (assetPolicy.transform === true &&
+          assetPolicy.fieldPermission.transform === true)),
   );
 
   const gateCodes: CoverGateCode[] = [];

--- a/src/db/catalog/enrichment/policies.ts
+++ b/src/db/catalog/enrichment/policies.ts
@@ -337,10 +337,14 @@ export function metadataSourceRow(
     withdrawal: adapter.withdrawal,
   });
   const assetPolicy = canonicalJson({
+    attribution: adapter.attribution,
     cache: adapter.permissions.asset.cache,
     display: adapter.permissions.asset.display,
     fieldPermission: adapter.permissions.asset,
+    policySources: adapter.policySources,
+    proposedEvidenceOnly: adapter.proposedEvidenceOnly,
     purgeOnWithdrawal: adapter.withdrawal.purgeCachedAssets,
+    sourcePolicyVersion: adapter.sourcePolicyVersion,
     transform: adapter.permissions.asset.transform,
     withdrawal: adapter.withdrawal,
   });

--- a/src/db/catalog/postgres-rebuild.ts
+++ b/src/db/catalog/postgres-rebuild.ts
@@ -30,6 +30,12 @@ import {
 import { CATALOG_TARGET_TABLE_NAMES } from "./sqlite-rebuild";
 
 const CLEAR_TABLES = [
+  "cover_projection_heads",
+  "cover_projections",
+  "cover_decision_heads",
+  "cover_decisions",
+  "cover_inspections",
+  "cover_candidates",
   "description_projection_heads",
   "description_projections",
   "description_review_queue",

--- a/src/db/catalog/schema.pg.ts
+++ b/src/db/catalog/schema.pg.ts
@@ -19,6 +19,13 @@ import {
   CATALOG_FIELD_KEYS,
   CATEGORY_STATUSES,
   CHANGE_TYPES,
+  COVER_DECISION_STATES,
+  COVER_DECODE_RESULTS,
+  COVER_IDENTITY_MATCH_KINDS,
+  COVER_PERMISSION_STATES,
+  COVER_PROJECTION_STATES,
+  COVER_PURGE_STATES,
+  COVER_REPRESENTATION_TYPES,
   COVER_STATES,
   DESCRIPTION_CLASSES,
   DESCRIPTION_DECISION_STATES,
@@ -764,6 +771,246 @@ export const fieldResolutionHeadsPg = pgTable(
   ],
 );
 
+export const coverCandidatesPg = pgTable(
+  "cover_candidates",
+  {
+    id: text("id").primaryKey(),
+    workId: text("work_id")
+      .notNull()
+      .references(() => worksPg.id, { onDelete: "restrict" }),
+    editionId: text("edition_id").references(() => editionsPg.id, {
+      onDelete: "restrict",
+    }),
+    sourceRecordId: text("source_record_id")
+      .notNull()
+      .references(() => sourceRecordsPg.id, { onDelete: "restrict" }),
+    representationType: text("representation_type").notNull(),
+    identityMatchKind: text("identity_match_kind").notNull(),
+    identityEvidenceJson: jsonb("identity_evidence_json").notNull(),
+    permissionState: text("permission_state").notNull(),
+    rightsBasis: text("rights_basis"),
+    attributionText: text("attribution_text"),
+    attributionUrl: text("attribution_url"),
+    sourceUrl: text("source_url").notNull(),
+    sourceRevision: text("source_revision").notNull(),
+    sourcePolicyVersion: text("source_policy_version").notNull(),
+    objectKey: text("object_key").notNull(),
+    transformationHistoryJson: jsonb("transformation_history_json").notNull(),
+    createdAt: timestamp("created_at").notNull(),
+  },
+  (table) => [
+    check(
+      "cover_candidates_representation_ck",
+      sql`${table.representationType} in (${sql.raw(sqlList(COVER_REPRESENTATION_TYPES))})
+        and (
+          (${table.representationType} = 'selected_edition' and ${table.editionId} is not null)
+          or (${table.representationType} = 'work_representative' and ${table.editionId} is null)
+        )`,
+    ),
+    check(
+      "cover_candidates_identity_ck",
+      sql`${table.identityMatchKind} in (${sql.raw(sqlList(COVER_IDENTITY_MATCH_KINDS))})`,
+    ),
+    check(
+      "cover_candidates_permission_ck",
+      sql`${table.permissionState} in (${sql.raw(sqlList(COVER_PERMISSION_STATES))})`,
+    ),
+    check(
+      "cover_candidates_nonempty_ck",
+      sql`length(trim(${table.sourceUrl})) > 0
+        and length(trim(${table.sourceRevision})) > 0
+        and length(trim(${table.sourcePolicyVersion})) > 0
+        and length(trim(${table.objectKey})) > 0
+        and substring(${table.objectKey} from 1 for 8) = '/covers/'`,
+    ),
+    index("cover_candidates_work_created_idx").on(
+      table.workId,
+      table.createdAt,
+    ),
+    index("cover_candidates_source_record_idx").on(table.sourceRecordId),
+  ],
+);
+
+export const coverInspectionsPg = pgTable(
+  "cover_inspections",
+  {
+    id: text("id").primaryKey(),
+    candidateId: text("candidate_id")
+      .notNull()
+      .references(() => coverCandidatesPg.id, { onDelete: "restrict" }),
+    mediaType: text("media_type"),
+    byteSize: bigint("byte_size", { mode: "number" }).notNull(),
+    width: integer("width"),
+    height: integer("height"),
+    aspectRatio: doublePrecision("aspect_ratio"),
+    checksum: text("checksum").notNull(),
+    decodeResult: text("decode_result").notNull(),
+    flagsJson: jsonb("flags_json").notNull(),
+    qualityScore: doublePrecision("quality_score").notNull(),
+    duplicateOfCandidateId: text("duplicate_of_candidate_id").references(
+      () => coverCandidatesPg.id,
+      { onDelete: "restrict" },
+    ),
+    inspectionVersion: text("inspection_version").notNull(),
+    inspectedAt: timestamp("inspected_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("cover_inspections_identity_uq").on(
+      table.candidateId,
+      table.checksum,
+      table.inspectionVersion,
+    ),
+    check(
+      "cover_inspections_decode_ck",
+      sql`${table.decodeResult} in (${sql.raw(sqlList(COVER_DECODE_RESULTS))})
+        and (
+          (${table.decodeResult} = 'decoded'
+            and ${table.mediaType} is not null
+            and ${table.width} > 0
+            and ${table.height} > 0
+            and ${table.aspectRatio} > 0)
+          or (${table.decodeResult} <> 'decoded'
+            and ${table.width} is null
+            and ${table.height} is null
+            and ${table.aspectRatio} is null)
+        )`,
+    ),
+    check(
+      "cover_inspections_values_ck",
+      sql`${table.byteSize} > 0
+        and length(${table.checksum}) = 64
+        and ${table.qualityScore} between 0 and 100
+        and length(trim(${table.inspectionVersion})) > 0`,
+    ),
+    index("cover_inspections_checksum_idx").on(table.checksum),
+    index("cover_inspections_candidate_idx").on(table.candidateId),
+  ],
+);
+
+export const coverDecisionsPg = pgTable(
+  "cover_decisions",
+  {
+    id: text("id").primaryKey(),
+    candidateId: text("candidate_id")
+      .notNull()
+      .references(() => coverCandidatesPg.id, { onDelete: "restrict" }),
+    inspectionId: text("inspection_id")
+      .notNull()
+      .references(() => coverInspectionsPg.id, { onDelete: "restrict" }),
+    state: text("state").notNull(),
+    gateCodesJson: jsonb("gate_codes_json").notNull(),
+    warningCodesJson: jsonb("warning_codes_json").notNull(),
+    reviewerRef: text("reviewer_ref"),
+    reviewReason: text("review_reason"),
+    purgeState: text("purge_state").notNull(),
+    previousDecisionId: text("previous_decision_id").references(
+      (): AnyPgColumn => coverDecisionsPg.id,
+      { onDelete: "restrict" },
+    ),
+    policyVersion: text("policy_version").notNull(),
+    decidedAt: timestamp("decided_at").notNull(),
+  },
+  (table) => [
+    check(
+      "cover_decisions_state_ck",
+      sql`${table.state} in (${sql.raw(sqlList(COVER_DECISION_STATES))})`,
+    ),
+    check(
+      "cover_decisions_purge_ck",
+      sql`${table.purgeState} in (${sql.raw(sqlList(COVER_PURGE_STATES))})`,
+    ),
+    check(
+      "cover_decisions_review_ck",
+      sql`(${table.reviewerRef} is null and ${table.reviewReason} is null)
+        or (
+          length(trim(${table.reviewerRef})) > 0
+          and length(trim(${table.reviewReason})) > 0
+        )`,
+    ),
+    check(
+      "cover_decisions_policy_ck",
+      sql`length(trim(${table.policyVersion})) > 0`,
+    ),
+    index("cover_decisions_candidate_history_idx").on(
+      table.candidateId,
+      table.decidedAt,
+    ),
+  ],
+);
+
+export const coverDecisionHeadsPg = pgTable(
+  "cover_decision_heads",
+  {
+    candidateId: text("candidate_id")
+      .primaryKey()
+      .references(() => coverCandidatesPg.id, { onDelete: "restrict" }),
+    decisionId: text("decision_id")
+      .notNull()
+      .references(() => coverDecisionsPg.id, { onDelete: "restrict" }),
+  },
+  (table) => [
+    uniqueIndex("cover_decision_heads_decision_uq").on(table.decisionId),
+  ],
+);
+
+export const coverProjectionsPg = pgTable(
+  "cover_projections",
+  {
+    id: text("id").primaryKey(),
+    workId: text("work_id")
+      .notNull()
+      .references(() => worksPg.id, { onDelete: "restrict" }),
+    candidateId: text("candidate_id").references(() => coverCandidatesPg.id, {
+      onDelete: "restrict",
+    }),
+    state: text("state").notNull(),
+    previousProjectionId: text("previous_projection_id").references(
+      (): AnyPgColumn => coverProjectionsPg.id,
+      { onDelete: "restrict" },
+    ),
+    reasonCode: text("reason_code").notNull(),
+    actorRef: text("actor_ref").notNull(),
+    policyVersion: text("policy_version").notNull(),
+    projectedAt: timestamp("projected_at").notNull(),
+  },
+  (table) => [
+    check(
+      "cover_projections_state_ck",
+      sql`${table.state} in (${sql.raw(sqlList(COVER_PROJECTION_STATES))})`,
+    ),
+    check(
+      "cover_projections_selection_ck",
+      sql`(${table.state} in ('selected', 'rolled_back') and ${table.candidateId} is not null)
+        or (${table.state} in ('placeholder', 'withdrawn') and ${table.candidateId} is null)`,
+    ),
+    check(
+      "cover_projections_nonempty_ck",
+      sql`length(trim(${table.reasonCode})) > 0
+        and length(trim(${table.actorRef})) > 0
+        and length(trim(${table.policyVersion})) > 0`,
+    ),
+    index("cover_projections_work_history_idx").on(
+      table.workId,
+      table.projectedAt,
+    ),
+  ],
+);
+
+export const coverProjectionHeadsPg = pgTable(
+  "cover_projection_heads",
+  {
+    workId: text("work_id")
+      .primaryKey()
+      .references(() => worksPg.id, { onDelete: "restrict" }),
+    projectionId: text("projection_id")
+      .notNull()
+      .references(() => coverProjectionsPg.id, { onDelete: "restrict" }),
+  },
+  (table) => [
+    uniqueIndex("cover_projection_heads_projection_uq").on(table.projectionId),
+  ],
+);
+
 export const descriptionCandidatesPg = pgTable(
   "description_candidates",
   {
@@ -1156,6 +1403,12 @@ export const catalogPostgresTables = {
   fieldObservations: fieldObservationsPg,
   fieldResolutions: fieldResolutionsPg,
   fieldResolutionHeads: fieldResolutionHeadsPg,
+  coverCandidates: coverCandidatesPg,
+  coverInspections: coverInspectionsPg,
+  coverDecisions: coverDecisionsPg,
+  coverDecisionHeads: coverDecisionHeadsPg,
+  coverProjections: coverProjectionsPg,
+  coverProjectionHeads: coverProjectionHeadsPg,
   descriptionCandidates: descriptionCandidatesPg,
   descriptionClaims: descriptionClaimsPg,
   descriptionClaimEvidence: descriptionClaimEvidencePg,

--- a/src/db/catalog/schema.ts
+++ b/src/db/catalog/schema.ts
@@ -16,6 +16,13 @@ import {
   CATALOG_FIELD_KEYS,
   CATEGORY_STATUSES,
   CHANGE_TYPES,
+  COVER_DECISION_STATES,
+  COVER_DECODE_RESULTS,
+  COVER_IDENTITY_MATCH_KINDS,
+  COVER_PERMISSION_STATES,
+  COVER_PROJECTION_STATES,
+  COVER_PURGE_STATES,
+  COVER_REPRESENTATION_TYPES,
   COVER_STATES,
   DESCRIPTION_CLASSES,
   DESCRIPTION_DECISION_STATES,
@@ -778,6 +785,257 @@ export const fieldResolutionHeads = sqliteTable(
   ],
 );
 
+export const coverCandidates = sqliteTable(
+  "cover_candidates",
+  {
+    id: text("id").primaryKey(),
+    workId: text("work_id")
+      .notNull()
+      .references(() => works.id, { onDelete: "restrict" }),
+    editionId: text("edition_id").references(() => editions.id, {
+      onDelete: "restrict",
+    }),
+    sourceRecordId: text("source_record_id")
+      .notNull()
+      .references(() => sourceRecords.id, { onDelete: "restrict" }),
+    representationType: text("representation_type").notNull(),
+    identityMatchKind: text("identity_match_kind").notNull(),
+    identityEvidenceJson: text("identity_evidence_json").notNull(),
+    permissionState: text("permission_state").notNull(),
+    rightsBasis: text("rights_basis"),
+    attributionText: text("attribution_text"),
+    attributionUrl: text("attribution_url"),
+    sourceUrl: text("source_url").notNull(),
+    sourceRevision: text("source_revision").notNull(),
+    sourcePolicyVersion: text("source_policy_version").notNull(),
+    objectKey: text("object_key").notNull(),
+    transformationHistoryJson: text("transformation_history_json").notNull(),
+    createdAt: integer("created_at").notNull(),
+  },
+  (table) => [
+    check(
+      "cover_candidates_representation_ck",
+      sql`${table.representationType} in (${sql.raw(sqlList(COVER_REPRESENTATION_TYPES))})
+        and (
+          (${table.representationType} = 'selected_edition' and ${table.editionId} is not null)
+          or (${table.representationType} = 'work_representative' and ${table.editionId} is null)
+        )`,
+    ),
+    check(
+      "cover_candidates_identity_ck",
+      sql`${table.identityMatchKind} in (${sql.raw(sqlList(COVER_IDENTITY_MATCH_KINDS))})`,
+    ),
+    check(
+      "cover_candidates_permission_ck",
+      sql`${table.permissionState} in (${sql.raw(sqlList(COVER_PERMISSION_STATES))})`,
+    ),
+    check(
+      "cover_candidates_json_ck",
+      sql`json_valid(${table.identityEvidenceJson})
+        and json_valid(${table.transformationHistoryJson})`,
+    ),
+    check(
+      "cover_candidates_nonempty_ck",
+      sql`length(trim(${table.sourceUrl})) > 0
+        and length(trim(${table.sourceRevision})) > 0
+        and length(trim(${table.sourcePolicyVersion})) > 0
+        and length(trim(${table.objectKey})) > 0
+        and substr(${table.objectKey}, 1, 8) = '/covers/'`,
+    ),
+    index("cover_candidates_work_created_idx").on(
+      table.workId,
+      table.createdAt,
+    ),
+    index("cover_candidates_source_record_idx").on(table.sourceRecordId),
+  ],
+);
+
+export const coverInspections = sqliteTable(
+  "cover_inspections",
+  {
+    id: text("id").primaryKey(),
+    candidateId: text("candidate_id")
+      .notNull()
+      .references(() => coverCandidates.id, { onDelete: "restrict" }),
+    mediaType: text("media_type"),
+    byteSize: integer("byte_size").notNull(),
+    width: integer("width"),
+    height: integer("height"),
+    aspectRatio: real("aspect_ratio"),
+    checksum: text("checksum").notNull(),
+    decodeResult: text("decode_result").notNull(),
+    flagsJson: text("flags_json").notNull(),
+    qualityScore: real("quality_score").notNull(),
+    duplicateOfCandidateId: text("duplicate_of_candidate_id").references(
+      () => coverCandidates.id,
+      { onDelete: "restrict" },
+    ),
+    inspectionVersion: text("inspection_version").notNull(),
+    inspectedAt: integer("inspected_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("cover_inspections_identity_uq").on(
+      table.candidateId,
+      table.checksum,
+      table.inspectionVersion,
+    ),
+    check(
+      "cover_inspections_decode_ck",
+      sql`${table.decodeResult} in (${sql.raw(sqlList(COVER_DECODE_RESULTS))})
+        and (
+          (${table.decodeResult} = 'decoded'
+            and ${table.mediaType} is not null
+            and ${table.width} > 0
+            and ${table.height} > 0
+            and ${table.aspectRatio} > 0)
+          or (${table.decodeResult} <> 'decoded'
+            and ${table.width} is null
+            and ${table.height} is null
+            and ${table.aspectRatio} is null)
+        )`,
+    ),
+    check(
+      "cover_inspections_values_ck",
+      sql`${table.byteSize} > 0
+        and length(${table.checksum}) = 64
+        and json_valid(${table.flagsJson})
+        and ${table.qualityScore} between 0 and 100
+        and length(trim(${table.inspectionVersion})) > 0`,
+    ),
+    index("cover_inspections_checksum_idx").on(table.checksum),
+    index("cover_inspections_candidate_idx").on(table.candidateId),
+  ],
+);
+
+export const coverDecisions = sqliteTable(
+  "cover_decisions",
+  {
+    id: text("id").primaryKey(),
+    candidateId: text("candidate_id")
+      .notNull()
+      .references(() => coverCandidates.id, { onDelete: "restrict" }),
+    inspectionId: text("inspection_id")
+      .notNull()
+      .references(() => coverInspections.id, { onDelete: "restrict" }),
+    state: text("state").notNull(),
+    gateCodesJson: text("gate_codes_json").notNull(),
+    warningCodesJson: text("warning_codes_json").notNull(),
+    reviewerRef: text("reviewer_ref"),
+    reviewReason: text("review_reason"),
+    purgeState: text("purge_state").notNull(),
+    previousDecisionId: text("previous_decision_id").references(
+      (): AnySQLiteColumn => coverDecisions.id,
+      { onDelete: "restrict" },
+    ),
+    policyVersion: text("policy_version").notNull(),
+    decidedAt: integer("decided_at").notNull(),
+  },
+  (table) => [
+    check(
+      "cover_decisions_state_ck",
+      sql`${table.state} in (${sql.raw(sqlList(COVER_DECISION_STATES))})`,
+    ),
+    check(
+      "cover_decisions_purge_ck",
+      sql`${table.purgeState} in (${sql.raw(sqlList(COVER_PURGE_STATES))})`,
+    ),
+    check(
+      "cover_decisions_json_ck",
+      sql`json_valid(${table.gateCodesJson})
+        and json_valid(${table.warningCodesJson})`,
+    ),
+    check(
+      "cover_decisions_review_ck",
+      sql`(${table.reviewerRef} is null and ${table.reviewReason} is null)
+        or (
+          length(trim(${table.reviewerRef})) > 0
+          and length(trim(${table.reviewReason})) > 0
+        )`,
+    ),
+    check(
+      "cover_decisions_policy_ck",
+      sql`length(trim(${table.policyVersion})) > 0`,
+    ),
+    index("cover_decisions_candidate_history_idx").on(
+      table.candidateId,
+      table.decidedAt,
+    ),
+  ],
+);
+
+export const coverDecisionHeads = sqliteTable(
+  "cover_decision_heads",
+  {
+    candidateId: text("candidate_id")
+      .primaryKey()
+      .references(() => coverCandidates.id, { onDelete: "restrict" }),
+    decisionId: text("decision_id")
+      .notNull()
+      .references(() => coverDecisions.id, { onDelete: "restrict" }),
+  },
+  (table) => [
+    uniqueIndex("cover_decision_heads_decision_uq").on(table.decisionId),
+  ],
+);
+
+export const coverProjections = sqliteTable(
+  "cover_projections",
+  {
+    id: text("id").primaryKey(),
+    workId: text("work_id")
+      .notNull()
+      .references(() => works.id, { onDelete: "restrict" }),
+    candidateId: text("candidate_id").references(() => coverCandidates.id, {
+      onDelete: "restrict",
+    }),
+    state: text("state").notNull(),
+    previousProjectionId: text("previous_projection_id").references(
+      (): AnySQLiteColumn => coverProjections.id,
+      { onDelete: "restrict" },
+    ),
+    reasonCode: text("reason_code").notNull(),
+    actorRef: text("actor_ref").notNull(),
+    policyVersion: text("policy_version").notNull(),
+    projectedAt: integer("projected_at").notNull(),
+  },
+  (table) => [
+    check(
+      "cover_projections_state_ck",
+      sql`${table.state} in (${sql.raw(sqlList(COVER_PROJECTION_STATES))})`,
+    ),
+    check(
+      "cover_projections_selection_ck",
+      sql`(${table.state} in ('selected', 'rolled_back') and ${table.candidateId} is not null)
+        or (${table.state} in ('placeholder', 'withdrawn') and ${table.candidateId} is null)`,
+    ),
+    check(
+      "cover_projections_nonempty_ck",
+      sql`length(trim(${table.reasonCode})) > 0
+        and length(trim(${table.actorRef})) > 0
+        and length(trim(${table.policyVersion})) > 0`,
+    ),
+    index("cover_projections_work_history_idx").on(
+      table.workId,
+      table.projectedAt,
+    ),
+  ],
+);
+
+export const coverProjectionHeads = sqliteTable(
+  "cover_projection_heads",
+  {
+    workId: text("work_id")
+      .primaryKey()
+      .references(() => works.id, { onDelete: "restrict" }),
+    projectionId: text("projection_id")
+      .notNull()
+      .references(() => coverProjections.id, { onDelete: "restrict" }),
+  },
+  (table) => [
+    uniqueIndex("cover_projection_heads_projection_uq").on(table.projectionId),
+  ],
+);
+
 export const descriptionCandidates = sqliteTable(
   "description_candidates",
   {
@@ -1186,6 +1444,12 @@ export const catalogSqliteTables = {
   fieldObservations,
   fieldResolutions,
   fieldResolutionHeads,
+  coverCandidates,
+  coverInspections,
+  coverDecisions,
+  coverDecisionHeads,
+  coverProjections,
+  coverProjectionHeads,
   descriptionCandidates,
   descriptionClaims,
   descriptionClaimEvidence,

--- a/src/db/catalog/sqlite-rebuild.ts
+++ b/src/db/catalog/sqlite-rebuild.ts
@@ -34,6 +34,12 @@ export const CATALOG_TARGET_TABLE_NAMES = [
   "catalog_change_events",
   "categories",
   "cover_assets",
+  "cover_candidates",
+  "cover_decision_heads",
+  "cover_decisions",
+  "cover_inspections",
+  "cover_projection_heads",
+  "cover_projections",
   "description_candidates",
   "description_claim_evidence",
   "description_claims",
@@ -62,6 +68,12 @@ export const CATALOG_TARGET_TABLE_NAMES = [
 ] as const;
 
 const CLEAR_SQL = `
+  delete from cover_projection_heads;
+  delete from cover_projections;
+  delete from cover_decision_heads;
+  delete from cover_decisions;
+  delete from cover_inspections;
+  delete from cover_candidates;
   delete from description_projection_heads;
   delete from description_projections;
   delete from description_review_queue;

--- a/src/db/catalog/values.ts
+++ b/src/db/catalog/values.ts
@@ -124,6 +124,47 @@ export const DESCRIPTION_PROJECTION_STATES = [
   "invalidated",
   "rolled_back",
 ] as const;
+export const COVER_REPRESENTATION_TYPES = [
+  "selected_edition",
+  "work_representative",
+] as const;
+export const COVER_IDENTITY_MATCH_KINDS = [
+  "exact_isbn",
+  "provider_edition_relation",
+  "approved_strong_edition_tuple",
+  "provider_work_relation",
+  "curated_work_relation",
+  "title_creator_candidate",
+  "conflicting",
+] as const;
+export const COVER_PERMISSION_STATES = [
+  "approved",
+  "pending",
+  "denied",
+] as const;
+export const COVER_DECODE_RESULTS = [
+  "decoded",
+  "corrupt",
+  "unsupported",
+] as const;
+export const COVER_DECISION_STATES = [
+  "review_required",
+  "eligible",
+  "rejected",
+  "withdrawn",
+] as const;
+export const COVER_PURGE_STATES = [
+  "not_required",
+  "pending",
+  "completed",
+  "failed",
+] as const;
+export const COVER_PROJECTION_STATES = [
+  "selected",
+  "placeholder",
+  "withdrawn",
+  "rolled_back",
+] as const;
 
 export type CatalogEntityType = (typeof CATALOG_ENTITY_TYPES)[number];
 export type CatalogFieldKey = (typeof CATALOG_FIELD_KEYS)[number];
@@ -136,6 +177,15 @@ export type DescriptionDecisionState =
 export type DescriptionQueueState = (typeof DESCRIPTION_QUEUE_STATES)[number];
 export type DescriptionProjectionState =
   (typeof DESCRIPTION_PROJECTION_STATES)[number];
+export type CoverRepresentationType =
+  (typeof COVER_REPRESENTATION_TYPES)[number];
+export type CoverIdentityMatchKind =
+  (typeof COVER_IDENTITY_MATCH_KINDS)[number];
+export type CoverPermissionState = (typeof COVER_PERMISSION_STATES)[number];
+export type CoverDecodeResult = (typeof COVER_DECODE_RESULTS)[number];
+export type CoverDecisionState = (typeof COVER_DECISION_STATES)[number];
+export type CoverPurgeState = (typeof COVER_PURGE_STATES)[number];
+export type CoverProjectionState = (typeof COVER_PROJECTION_STATES)[number];
 
 export function sqlList(values: readonly string[]): string {
   return values.map((value) => `'${value.replaceAll("'", "''")}'`).join(", ");

--- a/src/features/books/covers.helpers.test.ts
+++ b/src/features/books/covers.helpers.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   buildOpenLibraryCandidates,
   extractOpenLibrarySearchCandidates,
+  findEditionMatchedOpenLibraryCandidates,
   findOpenLibraryCandidates,
 } from "@/../scripts/covers/helpers";
+import { assertOpenLibraryCoverPublishingAllowed } from "@/../scripts/covers/policy";
 
 describe("covers helpers", () => {
   it("prefers ISBN-based candidates when isbn present", () => {
@@ -22,6 +24,29 @@ describe("covers helpers", () => {
       isbn: undefined,
     });
     expect(urls).toEqual([]);
+  });
+
+  it("keeps selected-edition inspection candidates exact-ISBN only", () => {
+    expect(
+      findEditionMatchedOpenLibraryCandidates({
+        title: "Moby-Dick",
+        author: "Herman Melville",
+        isbn: undefined,
+      }),
+    ).toEqual([]);
+    expect(
+      findEditionMatchedOpenLibraryCandidates({
+        title: "Dune",
+        author: "Frank Herbert",
+        isbn: "9780441172719",
+      })[0],
+    ).toMatch(/isbn\/9780441172719-L\.jpg/);
+  });
+
+  it("blocks publishing while the recorded cover asset policy is pending", () => {
+    expect(() => assertOpenLibraryCoverPublishingAllowed()).toThrow(
+      /open-library\.covers is pending/i,
+    );
   });
 
   it("extracts cover-id and OLID candidates from search results", () => {


### PR DESCRIPTION
﻿## Summary

- Adds deterministic, edition-aware cover inspection and selection for the five diagnostic books, with review flags and accessible placeholder fallback.
- Keeps all cover decisions internal until the #135 dry-run: existing production/public cover projections are unchanged.

## Linked Issue

- Closes #134
- Labels aligned with linked issue: enhancement, backend, database, quality, data-curation, area: catalog

## Changes

- Adds a lean cover-candidate, inspection, decision, and internal-projection model with SQLite/PostgreSQL parity and existing lifecycle/provenance integration.
- Records media type, bytes, dimensions, aspect ratio, checksum, decode result, source revision, representation type, transformation history, basic attribution, and permission facts.
- Enforces exact ISBN/provider edition evidence for selected-edition covers; explicit work-representative covers remain supported while weak, conflicting, locale, or adaptation matches stay in review or rejection.
- Adds deterministic advisory quality scoring and flags for corruption, tiny dimensions, square/sidebars, extreme aspect/crop, blur/upscaling, duplicates, and locale/adaptation conflicts.
- Adds idempotent inspection, withdrawal with purge retry, fallback recomputation, rollback, and deterministic fixtures/tests for Dune, Moby-Dick, The City and the Stars, Born a Crime, and Faithful Place.
- Restricts the current Open Library path to inspection only while its repository policy is pending; no live provider credentials or crawling are required.
- Enforces fetch/cache/display and conditional transform permissions, requires curated strong-tuple approval, canonicalizes duplicates independently of arrival order, and provides matching PostgreSQL review/retry/idempotency behavior.

## Validation

- [x] `bun run lint`
- [x] `bun run test` (61 files passed, 5 skipped; 281 tests passed, 7 skipped)
- [x] `bunx playwright test` (28 passed)
- [x] manual verification completed where relevant
- [x] `bunx tsc --noEmit`
- [x] `bun run test:storybook` (39 passed)
- [x] `bun run build:ci`
- [x] `bun run db:verify`
- [x] `git diff --check`
- [x] SQLite and PostgreSQL migration generation produced no diff
- [x] deterministic five-book SQLite dry run completed with no public writes
- [x] disposable PostgreSQL proof passed 4 files / 6 tests across cover lifecycle and related enrichment persistence

## UX Notes

- [x] no visual changes
- [x] accessibility impact reviewed

Notes:

- Rejected or uncertain internal candidates resolve to the existing accessible placeholder. Browser comparison is not applicable because reader-facing presentation and public cover projections do not change.

## Architecture Notes

- [x] follows existing architecture and framework defaults

ADR / decision links:

- Follows ADR 0015 and the enrichment lifecycle introduced by #131-#133; no new ADR is needed.

## Data / API / Infra Impact

- [x] database schema changed
- [x] seed/import/catalog data changed
- [x] CI/CD or deployment behavior changed

Operational notes:

- Adds six internal cover-enrichment tables and includes the focused PostgreSQL cover repository test in CI. Existing public cover tables/heads are not written by this workflow.

## Risks

- [x] medium risk

Main risks and mitigations:

- risk: a weak or technically poor cover is selected for later publication.
- mitigation: hard identity/permission gates, deterministic review flags, exact-edition preference, placeholder fallback, and internal-only projections pending #135 approval.
- risk: withdrawal or retry leaves stale internal cover state.
- mitigation: idempotent decisions, purge-state tracking, fallback recomputation, rollback tests, and SQLite/PostgreSQL parity coverage.

## Checklist

- [x] scope matches the linked issue
- [x] PR labels match the linked issue labels where applicable
- [x] touched code is cleaner than before
- [x] tests cover the changed behavior
- [x] docs were updated where needed
- [x] local-only/generated artifacts are excluded from git
