### PR TITLE
feat(catalog): promote reviewed enrichment and PoC covers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,7 @@ jobs:
         run: >-
           bun run test --
           src/db/catalog/enrichment/catalog-dry-run.pg.test.ts
+          src/db/catalog/enrichment/diagnostic-five-promotion.pg.test.ts
           src/db/catalog/enrichment/persistence.pg.test.ts
           src/db/catalog/enrichment/covers/repository.pg.test.ts
           src/db/catalog/enrichment/descriptions/repository.pg.test.ts

--- a/docs/adding-covers.md
+++ b/docs/adding-covers.md
@@ -48,7 +48,11 @@ This command:
 The command never mutates a runtime database or a public cover projection.
 Works without an exact selected-edition ISBN remain review candidates instead
 of falling back to title/author search. Inspection flags are advisory; identity
-and permission remain hard gates.
+and approved-source policy remain hard gates. During the PoC, issue #143
+defers display-rights clearance for covers only. Such candidates must record
+`rightsStatus: deferred_poc`, `rightsCleared: false`, provenance, deterministic
+withdrawal/purge support, and mandatory re-review before definitive production
+launch. Explicitly denied assets remain ineligible.
 
 `covers:fetch:r2` is deliberately blocked while the recorded Open Library
 asset policy is pending. Publishing resumes only after a reviewed dry run and

--- a/docs/catalog-enrichment-promotion-proposal.md
+++ b/docs/catalog-enrichment-promotion-proposal.md
@@ -1,14 +1,34 @@
 # Catalog enrichment promotion proposal
 
-- Status: proposal only; not approved or executable
+- Status: issue #143 repository-input slice implemented; production database
+  execution remains unapproved
 - Dry-run input: `bukie-catalog-enrichment-dry-run@2026-07-29.v1`
-- Related issue: #135
+- Related issues: #135 and #143
 
-This document describes a possible future promotion boundary for maintainers
-to review. Issue #135 does not implement, expose, or execute this operation.
-The recorded #135 run is not promotion-ready: it intentionally has 495 works
-without approved retained snapshots, two paused queue-overflow cases, one
-ambiguous identity case, and no eligible cover or description candidates.
+Issue #143 implements the first deliberately narrow repository-input slice
+from this proposal. It does not authorize or execute an update against a
+production database. The approved slice contains exactly four
+`work.first_publication_date` proposals:
+
+- Moby-Dick: 1851
+- The City and the Stars: 1956
+- Born a Crime: 2016
+- Faithful Place: 2010
+
+Dune remains unresolved because its recorded Wikidata identity evidence is
+ambiguous. No preferred-title, description, or cover proposal is included.
+The description queue-overflow cases remain paused, and no cover has both the
+required strong identity and display-rights evidence.
+
+The repository approval record is
+`github-issue-143-reviewed-slice-v1`. It pins report SHA-256
+`a85538c057e0b65696644e372f09f18a6da0daf0cefec0d42d641ee4ca6a1b0d`,
+manifest content hash
+`7b7cc856a2c8e8a9aff35098491df49d8cce85c6a7f7639a0c4cecd25fcfa615`,
+run content hash
+`9b8e04b5cb005181b40e61b0185ed5a5d6b5d9eed902527b891e4d058baad5bd`,
+and the exact four proposal IDs in
+`src/db/catalog/enrichment/diagnostic-five-promotion.ts`.
 
 ## Required review and approval
 
@@ -32,35 +52,38 @@ Promotion must remain unavailable until all of the following are true:
    Neither approval may be inferred from a merged adapter, passing CI, or the
    existence of this document.
 
+For issue #143, the checked-in repository input is reviewable in the normal PR
+boundary. Running the existing-database transaction against production remains
+separately unavailable because
+`productionDatabaseExecutionApproved` is explicitly `false`. Passing tests,
+merging adapter code, or deploying the application must not be interpreted as
+that operational approval.
+
 ## Proposed transaction boundary
 
-A future implementation should accept only an explicitly approved manifest and
-an exact allow-list of reviewed proposal IDs. In one database transaction it
-would:
+The issue #143 transaction accepts only the exact approved manifest/report and
+the exact allow-list of reviewed proposal IDs. In one database transaction it:
 
-1. lock the affected resolution heads and relevant work/edition projection
-   rows;
+1. locks the affected resolution heads and work projection rows;
 2. re-evaluate current source, record, link, observation, identity, rights,
    withdrawal, model/prompt, policy, and review eligibility;
 3. refuse the complete transaction if any approved input drifted, any selected
    observation became ineligible, or any proposal is outside the manifest;
 4. append immutable resolution events whose `previous_resolution_id` retains
    every prior head;
-5. update only the explicitly approved current heads and their matching
+5. updates only the explicitly approved current heads and their matching
    projections;
-6. update an asset pointer only after the exact approved asset checksum is
-   durably available and its display policy still permits it; and
-7. append a catalog change event containing the manifest hash, approval
-   references, prior-head set, new-head set, and deployment correlation ID.
+6. refuses every description and asset path because neither class has an
+   approved proposal in this slice.
 
 No observation, prior resolution, review decision, or projection-history event
 would be deleted. Description and cover changes would remain field-specific;
 one approved field would not authorize another.
 
-Application deployment is a separate boundary. The matching reader deployment
-would occur only after the database transaction commits and its post-commit
-public-output hashes are reviewed. The previous application deployment and
-database head set must remain retained until the observation window closes.
+Deterministic clean rebuilds consume the same approved four-observation input,
+so a reviewed repository state cannot silently lose the facts on rebuild.
+Existing-database execution is a separate operational boundary and still
+requires a new recorded production approval.
 
 ## Rollback proposal
 
@@ -86,8 +109,7 @@ history, or copy a prior value directly into a public projection.
 
 ## Explicit non-authorization
 
-This proposal does not authorize a production, preview, reader-facing, or
-public-output change. A future tracked issue and separately reviewed PR are
-required to implement any promotion command. The #135 report must not be used
-as its approval because its purpose is to prove isolation and expose omissions,
-not to maximize or publish coverage.
+Issue #143 authorizes only the checked-in deterministic repository input and
+its disposable-target transaction verification. It does not authorize a
+production database execution. The #135 report by itself is not an approval;
+the exact issue #143 approval ID and four-ID allow-list are also required.

--- a/docs/catalog-enrichment-promotion-proposal.md
+++ b/docs/catalog-enrichment-promotion-proposal.md
@@ -3,7 +3,7 @@
 - Status: issue #143 repository-input and PoC cover slice implemented
 - Dry-run input: `bukie-catalog-enrichment-dry-run@2026-07-29.v1`
 - Related issues: #135 and #143
-- Production database execution: not approved
+- Shared-database execution: owner-authorized against the existing Preview/Production Neon database (see "Preview and production authorization" below); a distinct Neon branch per deployment is no longer required
 
 Issue #143 contains exactly four reviewed
 `work.first_publication_date` proposals:
@@ -105,13 +105,21 @@ purge callback without rewriting history.
 The five reviewed WebP objects were uploaded explicitly to private R2 after
 confirming their keys did not already exist. Builds remain read-only.
 
-Existing-database promotion is permitted only when Vercel reports PR #144,
+Existing-database promotion originally required Vercel to report PR #144,
 `VERCEL_ENV=preview`, the exact feature branch and deployment ID, and a
 distinct matching Neon branch/host. The 2026-07-29 operational check found
 that the branch-specific Preview variables and existing production
 configuration used the same Neon endpoint and that the deployment exposed no
 `NEON_BRANCH_ID`. The write therefore failed closed and was not executed.
 
-No production database execution is authorized. Passing CI, merging code,
-deploying Vercel, or uploading R2 assets must not be interpreted as database
-promotion approval.
+Since Preview and Production intentionally share one Neon database (Neon
+branch-per-preview is not configured, largely for cost reasons), the repo
+owner authorized dropping only the distinct-Neon-branch requirement so
+promotion can run against that shared database. Every other check remains in
+force: Vercel must report `VERCEL_ENV=preview`, PR #144, the exact
+`feat/catalog-enrichment-promotion` branch, a non-empty deployment ID, a
+matching database host, and a `.neon.tech` hostname. `neonBranchId` is now
+optional, unenforced metadata rather than a gate. Passing CI, merging code, or
+uploading R2 assets alone still must not be interpreted as database promotion
+approval — only the exact preview proof above authorizes a write, and that
+write now also updates Production immediately because they share a database.

--- a/docs/catalog-enrichment-promotion-proposal.md
+++ b/docs/catalog-enrichment-promotion-proposal.md
@@ -1,13 +1,11 @@
 # Catalog enrichment promotion proposal
 
-- Status: issue #143 repository-input slice implemented; production database
-  execution remains unapproved
+- Status: issue #143 repository-input and PoC cover slice implemented
 - Dry-run input: `bukie-catalog-enrichment-dry-run@2026-07-29.v1`
 - Related issues: #135 and #143
+- Production database execution: not approved
 
-Issue #143 implements the first deliberately narrow repository-input slice
-from this proposal. It does not authorize or execute an update against a
-production database. The approved slice contains exactly four
+Issue #143 contains exactly four reviewed
 `work.first_publication_date` proposals:
 
 - Moby-Dick: 1851
@@ -15,13 +13,11 @@ production database. The approved slice contains exactly four
 - Born a Crime: 2016
 - Faithful Place: 2010
 
-Dune remains unresolved because its recorded Wikidata identity evidence is
-ambiguous. No preferred-title, description, or cover proposal is included.
-The description queue-overflow cases remain paused, and no cover has both the
-required strong identity and display-rights evidence.
+Dune's first-publication evidence remains unresolved because the recorded
+Wikidata identity is ambiguous. No preferred-title or description proposal is
+included, and description queue overflow remains paused.
 
-The repository approval record is
-`github-issue-143-reviewed-slice-v1`. It pins report SHA-256
+The date approval `github-issue-143-reviewed-slice-v1` pins report SHA-256
 `a85538c057e0b65696644e372f09f18a6da0daf0cefec0d42d641ee4ca6a1b0d`,
 manifest content hash
 `7b7cc856a2c8e8a9aff35098491df49d8cce85c6a7f7639a0c4cecd25fcfa615`,
@@ -30,86 +26,92 @@ run content hash
 and the exact four proposal IDs in
 `src/db/catalog/enrichment/diagnostic-five-promotion.ts`.
 
-## Required review and approval
+## PoC cover decision
 
-Promotion must remain unavailable until all of the following are true:
+The owner explicitly accepted deferred cover display rights for the PoC.
+Rights are not represented as cleared and become mandatory before definitive
+production launch. This exception applies only to covers.
 
-1. A byte-stable report and its immutable manifest are retained and the input,
-   source-snapshot, policy, adapter, importer, matcher, resolver, gate, and
-   inspection hashes still match.
-2. Every selected source policy is currently approved for the exact retained
-   metadata, text, or asset field. Adapter availability alone is not approval.
-3. Identity conflicts, rights blocks, withdrawals, policy failures, and queue
-   overflow are unresolved rather than selected.
-4. Human-review staffing and a queue cap are approved. Every candidate class
-   that requires review has a completed, independent decision.
-5. Proposed coverage, direct cost, runtime, and review volume have been
-   accepted despite any material variance from the #130 planning envelope.
-6. SQLite/PostgreSQL logical parity, schema no-diff, deterministic reruns,
-   isolation checks, and rollback rehearsal pass for the exact manifest.
-7. A catalog data steward and a repository maintainer give explicit recorded
-   approval for the exact manifest content hash and proposed-resolution set.
-   Neither approval may be inferred from a merged adapter, passing CI, or the
-   existence of this document.
+The cover approval `github-issue-143-poc-cover-slice-v1` pins manifest hash
+`9a8befefb07fe9b112c46cbacedab3d279bc0aa117019e4e63e3cef5b20cadd1`
+and an exact five-proposal allow-list. Each proposal records:
 
-For issue #143, the checked-in repository input is reviewable in the normal PR
-boundary. Running the existing-database transaction against production remains
-separately unavailable because
-`productionDatabaseExecutionApproved` is explicitly `false`. Passing tests,
-merging adapter code, or deploying the application must not be interpreted as
-that operational approval.
+- strong work- or edition-level identity without conflating the scopes;
+- an allow-listed provider and stable provider-native page/asset identifier;
+- retrieval time plus original and normalized content hashes;
+- media type, dimensions, bytes, aspect ratio, inspection flags, and score;
+- reviewer, decision reason, and acknowledged warnings;
+- `rightsStatus: deferred_poc`, `rightsCleared: false`, issue #143, and
+  mandatory launch re-review; and
+- immutable predecessor history plus deterministic withdrawal, purge, and
+  rollback data.
 
-## Proposed transaction boundary
+Dune is edition-scoped to ISBN-13 `9780441172719` through Open Library edition
+`OL7525230M`. Moby-Dick, The City and the Stars, Born a Crime, and Faithful
+Place are work-scoped using reviewed Standard Ebooks or official publisher
+relations. They are not attached to Bukie's selected editions.
 
-The issue #143 transaction accepts only the exact approved manifest/report and
-the exact allow-list of reviewed proposal IDs. In one database transaction it:
+The PoC source allow-list is limited to the exact recorded Open Library,
+Standard Ebooks/GitHub, Hachette, and Penguin Random House hosts. Image search
+results, retailer pages, runtime provider fetching, unversioned overwrites,
+and live scraping are not permitted.
 
-1. locks the affected resolution heads and work projection rows;
-2. re-evaluate current source, record, link, observation, identity, rights,
-   withdrawal, model/prompt, policy, and review eligibility;
-3. refuse the complete transaction if any approved input drifted, any selected
-   observation became ineligible, or any proposal is outside the manifest;
-4. append immutable resolution events whose `previous_resolution_id` retains
-   every prior head;
-5. updates only the explicitly approved current heads and their matching
-   projections;
-6. refuses every description and asset path because neither class has an
-   approved proposal in this slice.
+## Transaction boundary
 
-No observation, prior resolution, review decision, or projection-history event
-would be deleted. Description and cover changes would remain field-specific;
-one approved field would not authorize another.
+The transaction accepts only the byte-stable #135 report, the exact date and
+cover approval IDs, and both complete proposal allow-lists. In one transaction
+it:
 
-Deterministic clean rebuilds consume the same approved four-observation input,
-so a reviewed repository state cannot silently lose the facts on rebuild.
-Existing-database execution is a separate operational boundary and still
-requires a new recorded production approval.
+1. locks affected work and current-head rows;
+2. revalidates source policy, retained record revision, work/edition identity,
+   attribution, withdrawal, decode/quality inspection, review decision, and
+   current projection eligibility;
+3. refuses all writes if any approved input or current eligibility drifts;
+4. appends immutable date resolutions and cover decision/projection histories;
+5. advances only the approved date and cover heads;
+6. confirms unrelated descriptions, preferred editions, legacy cover
+   relations, and resolution heads are unchanged; and
+7. returns a deterministic public-output hash.
 
-## Rollback proposal
+Retry is idempotent. SQLite and PostgreSQL use the same logical rows and IDs.
+Clean rebuilds include the same reviewed evidence and histories, while #135
+explicitly requests the pre-promotion graph to keep its report byte-stable.
 
-Rollback would require an explicit approval referencing the promotion event.
-In one transaction it would:
+## Public projection
 
-1. lock the same affected heads and projections;
-2. verify each retained prior observation is still policy- and
-   withdrawal-eligible;
-3. append rollback resolution events pointing to the retained prior
-   observations;
-4. move current heads and field projections to those appended rollback events;
-5. restore only eligible prior asset pointers, otherwise select the safe
-   placeholder;
-6. append a rollback catalog event linked to the promotion event; and
-7. verify the expected public-output hashes before restoring the retained
-   application deployment.
+Reader queries load a selected cover from the work-level projection head and
+reapply current source approval, asset-display policy, decision state, asset
+availability, and withdrawal state. The projection exposes identity scope and
+deferred-rights status. A work-scoped cover is a work fallback and is never
+silently inserted into `edition_covers`.
 
-If a prior observation or asset is no longer eligible, rollback must fail
-closed for that field and use an explicit missing/placeholder resolution. It
-must never resurrect withdrawn evidence, bypass a purge requirement, rewrite
-history, or copy a prior value directly into a public projection.
+The four approved dates remain work-level first-publication facts, separate
+from preferred-edition publication dates. Dune's date remains missing.
 
-## Explicit non-authorization
+## Rollback
 
-Issue #143 authorizes only the checked-in deterministic repository input and
-its disposable-target transaction verification. It does not authorize a
-production database execution. The #135 report by itself is not an approval;
-the exact issue #143 approval ID and four-ID allow-list are also required.
+Rollback appends new missing date resolutions and placeholder cover
+projections whose predecessors are the promoted heads. It never deletes
+observations, candidates, inspections, reviews, assets, or prior projections.
+Withdrawn or ineligible evidence is never resurrected. A repeated rollback is
+idempotent, and an injected failure rolls back the complete transaction.
+
+The five R2 objects use immutable issue-namespaced keys. Withdrawal can advance
+the public head to the placeholder and execute the existing policy-required
+purge callback without rewriting history.
+
+## Preview and production authorization
+
+The five reviewed WebP objects were uploaded explicitly to private R2 after
+confirming their keys did not already exist. Builds remain read-only.
+
+Existing-database promotion is permitted only when Vercel reports PR #144,
+`VERCEL_ENV=preview`, the exact feature branch and deployment ID, and a
+distinct matching Neon branch/host. The 2026-07-29 operational check found
+that the branch-specific Preview variables and existing production
+configuration used the same Neon endpoint and that the deployment exposed no
+`NEON_BRANCH_ID`. The write therefore failed closed and was not executed.
+
+No production database execution is authorized. Passing CI, merging code,
+deploying Vercel, or uploading R2 assets must not be interpreted as database
+promotion approval.

--- a/docs/catalog-enrichment.md
+++ b/docs/catalog-enrichment.md
@@ -263,7 +263,10 @@ checksum, decode result, source revision, object key, representation type, and
 transformation history. Stable flags cover corruption, tiny dimensions,
 square canvases, sidebars, extreme aspect/crop, blur or upscaling risk,
 duplicates, and locale/adaptation conflicts. The quality score is advisory;
-it cannot override source policy, rights, attribution, identity, or review.
+it cannot override source policy, attribution, identity, or review. Issue #143
+supersedes the display-rights gate for covers only during the PoC: rights stay
+recorded as `deferred_poc` / not cleared and require review before definitive
+production launch. An explicit denial remains ineligible.
 Cached candidates require fetch, cache, and display permission, while any
 recorded transformation also requires transformation permission. A strong
 edition tuple is eligible only when its approval is backed by a persisted
@@ -383,25 +386,53 @@ prerequisites and rollback boundary used by the narrow issue #143 slice below.
 
 Issue #143 reviews the dry-run output without treating coverage as a target.
 Exactly four first-publication proposals are accepted: Moby-Dick, The City and
-the Stars, Born a Crime, and Faithful Place. Dune remains unresolved. No title,
-description, or cover proposal is promoted.
+the Stars, Born a Crime, and Faithful Place. Dune's first-publication evidence
+remains unresolved. No title or description proposal is promoted; description
+queue overflow remains paused.
 
 The slice pins the exact committed report SHA-256, manifest hash, run hash,
-approval ID, and four deterministic proposal IDs. SQLite and PostgreSQL
-transactions recheck the source policy, retained record revision and hashes,
-active work relation, observation value and state, withdrawal state, mapping
-confidence, and field-level display permission while the affected work and
-head rows are locked. Any drift aborts the complete transaction.
+approval ID, and four date proposal IDs. A second pinned manifest and exact
+five-ID allow-list records reviewed PoC covers from Open Library, Standard
+Ebooks, Hachette, and Penguin Random House. Dune is edition-scoped through its
+exact selected-edition ISBN; the other four are explicitly work-scoped and are
+never attached to an edition they do not identify.
+
+Every cover record retains provider-native identity, stable source and asset
+URLs, retrieval time, original and normalized SHA-256 hashes, media type,
+dimensions, byte size, aspect ratio, inspection flags and score, reviewer,
+review reason, immutable decision/projection predecessors, and
+`rightsStatus: deferred_poc` / `rightsCleared: false`. The source allow-list,
+identity, attribution, decode, quality, withdrawal, and review gates remain
+blocking. Display-rights evidence alone is deferred for covers and for no other
+field.
+
+SQLite and PostgreSQL transactions recheck the source policy, retained record
+revision and hashes, active relation, identity scope, observation/candidate
+state, withdrawal state, mapping confidence, technical inspection, review
+head, and field-level display permission while affected rows are locked. Any
+drift aborts the complete transaction.
 
 Promotion appends a resolution whose `previous_resolution_id` retains the
 explicit prior missing state. Retry is idempotent. Rollback appends another
 missing resolution rather than moving a head backward or deleting evidence.
-Isolation hashes ensure that preferred titles, descriptions, preferred
-editions, cover assets/relations, and every unrelated resolution head remain
-unchanged.
+Cover promotion likewise retains a placeholder predecessor and appends a
+reviewed selected projection; rollback appends a new placeholder head without
+deleting the selected candidate, inspection, review, asset record, or history.
+Public queries expose the selected cover at work level and reapply current
+source, policy, decision, asset, and withdrawal state. Isolation hashes ensure
+that preferred titles, descriptions, preferred editions, legacy cover
+relations, and every unrelated resolution head remain unchanged.
 
-The same four reviewed observations and resolution histories are part of the
-deterministic full-catalog import graph. The #135 command explicitly builds
-the pre-promotion graph so the pinned dry-run report remains reproducible and
-byte-stable. Production database execution is not approved by issue #143 and
-is recorded as disabled in the approval manifest.
+The four observations plus five cover candidates, inspections, two-step
+decision histories, placeholder predecessors, selected projections, and asset
+metadata are part of the deterministic full-catalog import graph. The #135
+command explicitly builds the pre-promotion graph so its pinned report stays
+byte-stable.
+
+The five namespaced WebP objects are published explicitly to private R2;
+application and Vercel builds never upload them. Existing-database execution is
+allowed only for a proven PR #144 Vercel Preview with a distinct matching Neon
+branch. On 2026-07-29 that operational check found the Preview variables
+pointing at the same Neon endpoint as the existing production configuration
+and no `NEON_BRANCH_ID`, so the transaction was correctly not executed.
+Production database execution remains unauthorized.

--- a/docs/catalog-enrichment.md
+++ b/docs/catalog-enrichment.md
@@ -375,7 +375,33 @@ and retry, fallback, and rollback are rehearsed only in the internal disposable
 cover proposal history. They never update public cover relations, public
 resolution heads, or reader-facing work projections.
 
-Promotion is not implemented. The separately reviewed
-[promotion proposal](./catalog-enrichment-promotion-proposal.md) describes the
-prerequisites and rollback boundary that maintainers would need to approve
-after a future report has sufficient eligible evidence.
+Issue #135 did not implement promotion. The separately reviewed
+[promotion proposal](./catalog-enrichment-promotion-proposal.md) supplied the
+prerequisites and rollback boundary used by the narrow issue #143 slice below.
+
+## Diagnostic-five promotion slice
+
+Issue #143 reviews the dry-run output without treating coverage as a target.
+Exactly four first-publication proposals are accepted: Moby-Dick, The City and
+the Stars, Born a Crime, and Faithful Place. Dune remains unresolved. No title,
+description, or cover proposal is promoted.
+
+The slice pins the exact committed report SHA-256, manifest hash, run hash,
+approval ID, and four deterministic proposal IDs. SQLite and PostgreSQL
+transactions recheck the source policy, retained record revision and hashes,
+active work relation, observation value and state, withdrawal state, mapping
+confidence, and field-level display permission while the affected work and
+head rows are locked. Any drift aborts the complete transaction.
+
+Promotion appends a resolution whose `previous_resolution_id` retains the
+explicit prior missing state. Retry is idempotent. Rollback appends another
+missing resolution rather than moving a head backward or deleting evidence.
+Isolation hashes ensure that preferred titles, descriptions, preferred
+editions, cover assets/relations, and every unrelated resolution head remain
+unchanged.
+
+The same four reviewed observations and resolution histories are part of the
+deterministic full-catalog import graph. The #135 command explicitly builds
+the pre-promotion graph so the pinned dry-run report remains reproducible and
+byte-stable. Production database execution is not approved by issue #143 and
+is recorded as disabled in the approval manifest.

--- a/docs/database-architecture.md
+++ b/docs/database-architecture.md
@@ -122,9 +122,15 @@ PostgreSQL use the same logical rows and deterministic IDs.
 Clean rebuilds contain the same reviewed evidence, cover asset metadata,
 candidate/inspection decisions, and resolution/projection chains.
 The historical #135 dry-run explicitly requests the pre-promotion import graph
-to retain its exact byte-stable report. Existing production databases are not
-updated automatically; the recorded issue #143 approval explicitly leaves
-production database execution unauthorized.
+to retain its exact byte-stable report. Preview and Production share one Neon
+database rather than using branch-per-deployment isolation, so the repo owner
+authorized relaxing the promotion gate's distinct-Neon-branch requirement
+(`neonBranchId` is now optional, unenforced metadata) while keeping every
+other preview-proof check — exact PR number, branch, `VERCEL_ENV=preview`,
+deployment ID, database host, and `.neon.tech` hostname — in force. Because
+the database is shared, an authorized preview promotion now updates
+Production directly; see `docs/catalog-enrichment-promotion-proposal.md` for
+the full authorization record.
 
 Issue #133 adds a description-specific evidence and review layer without
 changing that public boundary. Immutable description candidates identify one

--- a/docs/database-architecture.md
+++ b/docs/database-architecture.md
@@ -56,9 +56,11 @@ and `2020-present`. Their boundaries use ISO sort dates, so year-, month-, and
 day-precision metadata behave consistently in SQLite and Postgres.
 
 The repository first selects the page of works and then loads preferred
-editions, authors, categories, publishers, languages, identifiers, and covers
-with bounded follow-up queries. This avoids a Cartesian product and preserves
-relationship order.
+editions, authors, categories, publishers, languages, identifiers,
+edition covers, and current reviewed work-cover projections with bounded
+follow-up queries. This avoids a Cartesian product and preserves relationship
+order. A work cover retains its identity scope; it is a reader fallback and is
+not silently written into `edition_covers`.
 
 Detail reads also load current work and edition resolution heads in two bounded
 queries. The internal `WorkDetail.provenance` projection exposes the resolution
@@ -98,17 +100,27 @@ to an isolated disposable target and cannot update current heads, projections,
 or cover pointers.
 
 Issue #143 adds one narrow exception to the dry-run-only boundary: four
-explicitly reviewed first-publication observations from the pinned #135
-report. Their exact report, manifest, run, approval, and proposal identities
-are fixed in repository input. Dune, description candidates, cover candidates,
-and redundant title observations remain unresolved. The batch transaction
-locks all four work/head pairs, revalidates current source, identity, rights,
-withdrawal, quality, and review eligibility, and then appends resolution
-history plus matching work projections atomically. Rollback also appends
-history and restores the retained missing state. SQLite and PostgreSQL use the
-same logical rows and deterministic IDs.
+explicitly reviewed first-publication observations from the pinned #135 report
+and five separately reviewed PoC cover proposals. Their exact report,
+manifests, approval IDs, and proposal allow-lists are fixed in repository
+input. Dune's date, description candidates, and redundant title observations
+remain unresolved.
 
-Clean rebuilds contain the same reviewed evidence and resolution chain.
+Cover rights clearance is deferred for the PoC only. The source payload and
+candidate identity record `deferred_poc`, `rightsCleared: false`, issue #143,
+and mandatory launch re-review. Strong identity, source approval,
+attribution, technical quality, withdrawal, and review stay blocking. Dune is
+edition-scoped through exact ISBN evidence; the other four projections remain
+work-scoped.
+
+The batch transaction locks affected work/head pairs, revalidates current
+source, identity, withdrawal, quality, and review eligibility, and appends
+resolution plus cover decision/projection history atomically. Rollback appends
+new missing/placeholder heads and retains prior immutable rows. SQLite and
+PostgreSQL use the same logical rows and deterministic IDs.
+
+Clean rebuilds contain the same reviewed evidence, cover asset metadata,
+candidate/inspection decisions, and resolution/projection chains.
 The historical #135 dry-run explicitly requests the pre-promotion import graph
 to retain its exact byte-stable report. Existing production databases are not
 updated automatically; the recorded issue #143 approval explicitly leaves

--- a/docs/database-architecture.md
+++ b/docs/database-architecture.md
@@ -97,6 +97,23 @@ resolution heads, and the existing display-eligibility checks. Dry runs write
 to an isolated disposable target and cannot update current heads, projections,
 or cover pointers.
 
+Issue #143 adds one narrow exception to the dry-run-only boundary: four
+explicitly reviewed first-publication observations from the pinned #135
+report. Their exact report, manifest, run, approval, and proposal identities
+are fixed in repository input. Dune, description candidates, cover candidates,
+and redundant title observations remain unresolved. The batch transaction
+locks all four work/head pairs, revalidates current source, identity, rights,
+withdrawal, quality, and review eligibility, and then appends resolution
+history plus matching work projections atomically. Rollback also appends
+history and restores the retained missing state. SQLite and PostgreSQL use the
+same logical rows and deterministic IDs.
+
+Clean rebuilds contain the same reviewed evidence and resolution chain.
+The historical #135 dry-run explicitly requests the pre-promotion import graph
+to retain its exact byte-stable report. Existing production databases are not
+updated automatically; the recorded issue #143 approval explicitly leaves
+production database execution unauthorized.
+
 Issue #133 adds a description-specific evidence and review layer without
 changing that public boundary. Immutable description candidates identify one
 of `licensed_verbatim`, `bukie_editorial`, or `model_assisted_candidate` and

--- a/docs/media-storage.md
+++ b/docs/media-storage.md
@@ -85,6 +85,12 @@ configured for Preview and Production. Its historical name has no runtime
 effect. If strict environment isolation becomes useful later, create a separate
 production bucket and migrate it as an explicit operation.
 
+Because Preview and Production currently share this bucket, new reviewed
+assets use immutable issue/version-namespaced keys and upload only after an
+explicit absence check. Database projection still fails closed unless the
+target is a proven Preview Neon branch; an R2 upload by itself never selects a
+cover.
+
 The backfill maps:
 
 ```text

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "db:catalog:description-sample": "bunx tsx ./scripts/db/run-description-enrichment-sample.ts",
     "db:catalog:cover-sample": "bunx tsx ./scripts/db/run-cover-enrichment-sample.ts",
     "db:catalog:enrichment-dry-run": "bunx tsx ./scripts/db/run-catalog-enrichment-dry-run.ts",
+    "db:catalog:promote:preview": "bunx tsx ./scripts/db/promote-diagnostic-five-preview.ts",
     "lint": "bunx @biomejs/biome check --no-errors-on-unmatched .",
     "lint:fix": "bunx @biomejs/biome check --write --no-errors-on-unmatched .",
     "release": "semantic-release",

--- a/scripts/db/promote-diagnostic-five-preview.ts
+++ b/scripts/db/promote-diagnostic-five-preview.ts
@@ -49,7 +49,8 @@ const result = await promoteDiagnosticFivePostgres(url, {
     vercelDeploymentId: required("VERCEL_DEPLOYMENT_ID"),
     gitBranch: "feat/catalog-enrichment-promotion",
     pullRequest: 144,
-    neonBranchId: required("NEON_BRANCH_ID"),
+    // Preview and Production share one Neon database; no distinct branch is required.
+    neonBranchId: process.env.NEON_BRANCH_ID?.trim() || undefined,
     databaseHost: new URL(url).hostname,
   },
   promotedAt: Date.UTC(2026, 6, 29, 19, 0, 0),

--- a/scripts/db/promote-diagnostic-five-preview.ts
+++ b/scripts/db/promote-diagnostic-five-preview.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from "node:fs";
+import {
+  APPROVED_COVER_PROPOSAL_IDS,
+  DIAGNOSTIC_FIVE_COVER_APPROVAL_ID,
+} from "@/db/catalog/enrichment/diagnostic-five-cover-promotion";
+import {
+  DIAGNOSTIC_FIVE_PROMOTION_APPROVAL,
+  DIAGNOSTIC_FIVE_PROMOTION_APPROVAL_ID,
+} from "@/db/catalog/enrichment/diagnostic-five-promotion";
+import { promoteDiagnosticFivePostgres } from "@/db/catalog/enrichment/diagnostic-five-promotion-repository";
+
+const required = (name: string): string => {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+};
+
+if (required("VERCEL_ENV") !== "preview") {
+  throw new Error("Refusing promotion outside VERCEL_ENV=preview");
+}
+if (
+  required("BUKIE_PREVIEW_PROMOTION_APPROVAL") !==
+  DIAGNOSTIC_FIVE_COVER_APPROVAL_ID
+) {
+  throw new Error("Exact recorded issue #143 preview approval is required");
+}
+if (required("VERCEL_GIT_COMMIT_REF") !== "feat/catalog-enrichment-promotion") {
+  throw new Error("Refusing promotion outside the PR #144 branch");
+}
+
+const url =
+  process.env.DATABASE_URL ??
+  process.env.DATABASE_URL_UNPOOLED ??
+  process.env.POSTGRES_URL ??
+  process.env.POSTGRES_URL_NON_POOLING;
+if (!url) throw new Error("A Preview PostgreSQL URL is required");
+
+const result = await promoteDiagnosticFivePostgres(url, {
+  reportBytes: readFileSync(
+    "docs/reports/catalog-enrichment-dry-run-2026-07-29.json",
+  ),
+  approvalId: DIAGNOSTIC_FIVE_PROMOTION_APPROVAL_ID,
+  proposalIds: DIAGNOSTIC_FIVE_PROMOTION_APPROVAL.approvedProposalIds,
+  coverProposalIds: APPROVED_COVER_PROPOSAL_IDS,
+  actorRef: "review:github-issue-143-preview",
+  executionTarget: "preview",
+  previewTarget: {
+    vercelEnv: "preview",
+    vercelDeploymentId: required("VERCEL_DEPLOYMENT_ID"),
+    gitBranch: "feat/catalog-enrichment-promotion",
+    pullRequest: 144,
+    neonBranchId: required("NEON_BRANCH_ID"),
+    databaseHost: new URL(url).hostname,
+  },
+  promotedAt: Date.UTC(2026, 6, 29, 19, 0, 0),
+});
+
+console.log(
+  JSON.stringify({
+    changed: result.changed,
+    coverProjectionCount: result.coverProjectionIds.length,
+    dateResolutionCount: result.resolutionIds.length,
+    publicProjectionHash: result.publicProjectionHash,
+  }),
+);

--- a/scripts/db/run-catalog-enrichment-dry-run.ts
+++ b/scripts/db/run-catalog-enrichment-dry-run.ts
@@ -61,7 +61,9 @@ const main = async () => {
   });
   const reportPath = resolveReportPath(readArg("report"));
   const records = legacyBooksToImportRecords(baseCatalog);
-  const graph = buildCatalogImportGraph(records);
+  const graph = buildCatalogImportGraph(records, {
+    includeApprovedPromotions: false,
+  });
   console.info("[catalog:enrichment-dry-run] validated target:", target.description);
   console.info("[catalog:enrichment-dry-run] report path:", reportPath);
   const report =

--- a/src/db/catalog/enrichment/catalog-dry-run.pg.test.ts
+++ b/src/db/catalog/enrichment/catalog-dry-run.pg.test.ts
@@ -27,7 +27,9 @@ describe.skipIf(!isolatedUrl)("catalog dry-run SQLite/Postgres parity", () => {
       throw new Error("Expected an isolated Postgres target");
     }
     const records = legacyBooksToImportRecords(baseCatalog);
-    const graph = buildCatalogImportGraph(records);
+    const graph = buildCatalogImportGraph(records, {
+      includeApprovedPromotions: false,
+    });
     const sqlite = await executeCatalogDryRunSqlite({
       sqlitePath: path.join(
         mkdtempSync(path.join(tmpdir(), "bukie-catalog-dry-run-parity-")),

--- a/src/db/catalog/enrichment/catalog-dry-run.test.ts
+++ b/src/db/catalog/enrichment/catalog-dry-run.test.ts
@@ -16,7 +16,12 @@ import { ENRICHMENT_SAMPLE_MANIFEST } from "./sample-manifest";
 
 const inputs = () => {
   const records = legacyBooksToImportRecords(baseCatalog);
-  return { records, graph: buildCatalogImportGraph(records) };
+  return {
+    records,
+    graph: buildCatalogImportGraph(records, {
+      includeApprovedPromotions: false,
+    }),
+  };
 };
 
 describe("catalog-wide enrichment dry run", () => {

--- a/src/db/catalog/enrichment/catalog-dry-run.test.ts
+++ b/src/db/catalog/enrichment/catalog-dry-run.test.ts
@@ -41,7 +41,7 @@ describe("catalog-wide enrichment dry run", () => {
       matcher: "conservative-work-matcher-v1",
       resolver: "catalog-resolver-v1",
       description: "description-gates-2026-07-29.v1",
-      cover: "cover-gates-2026-07-29.v1",
+      cover: "poc-cover-policy-2026-07.v1",
       coverInspection: "cover-inspection-2026-07-29.v1",
     });
     expect(

--- a/src/db/catalog/enrichment/covers/repository.pg.ts
+++ b/src/db/catalog/enrichment/covers/repository.pg.ts
@@ -636,7 +636,12 @@ const recompute = async (
       objectKey: winner?.candidate.objectKey ?? PLACEHOLDER_COVER,
       representationType: winner?.candidate.representationType ?? null,
       editionId: winner?.candidate.editionId ?? null,
-      publicDisplayEligible: false,
+      rightsStatus:
+        winner?.candidate.permissionState === "approved"
+          ? "cleared"
+          : "deferred_poc",
+      rightsCleared: winner?.candidate.permissionState === "approved",
+      publicDisplayEligible: Boolean(winner),
       state: projection.row.state,
     },
     changed: projection.changed,
@@ -873,6 +878,8 @@ export const getCoverSelectionPostgres = async (input: {
         objectKey: PLACEHOLDER_COVER,
         representationType: null,
         editionId: null,
+        rightsStatus: "deferred_poc",
+        rightsCleared: false,
         publicDisplayEligible: false,
         state: projection?.state ?? "placeholder",
       };
@@ -896,6 +903,8 @@ export const getCoverSelectionPostgres = async (input: {
         objectKey: PLACEHOLDER_COVER,
         representationType: null,
         editionId: null,
+        rightsStatus: "deferred_poc",
+        rightsCleared: false,
         publicDisplayEligible: false,
         state: "placeholder",
       };
@@ -906,7 +915,10 @@ export const getCoverSelectionPostgres = async (input: {
       objectKey: candidate.objectKey,
       representationType: candidate.representationType,
       editionId: candidate.editionId,
-      publicDisplayEligible: false,
+      rightsStatus:
+        candidate.permissionState === "approved" ? "cleared" : "deferred_poc",
+      rightsCleared: candidate.permissionState === "approved",
+      publicDisplayEligible: true,
       state: projection.state,
     };
   } finally {
@@ -1069,7 +1081,12 @@ export const rollbackCoverProjectionPostgres = async (input: {
             objectKey: candidate.objectKey,
             representationType: candidate.representationType,
             editionId: candidate.editionId,
-            publicDisplayEligible: false,
+            rightsStatus:
+              candidate.permissionState === "approved"
+                ? "cleared"
+                : "deferred_poc",
+            rightsCleared: candidate.permissionState === "approved",
+            publicDisplayEligible: true,
             state: current.state,
           },
           changed: false,
@@ -1092,7 +1109,12 @@ export const rollbackCoverProjectionPostgres = async (input: {
           objectKey: candidate.objectKey,
           representationType: candidate.representationType,
           editionId: candidate.editionId,
-          publicDisplayEligible: false,
+          rightsStatus:
+            candidate.permissionState === "approved"
+              ? "cleared"
+              : "deferred_poc",
+          rightsCleared: candidate.permissionState === "approved",
+          publicDisplayEligible: true,
           state: projection.row.state,
         },
         changed: projection.changed,

--- a/src/db/catalog/enrichment/covers/repository.test.ts
+++ b/src/db/catalog/enrichment/covers/repository.test.ts
@@ -93,10 +93,7 @@ describe("SQLite edition-matched cover lifecycle", () => {
     ]) {
       expect(results.find((row) => row.title === title)?.result).toMatchObject({
         state: "review_required",
-        gateCodes: expect.arrayContaining([
-          "identity_evidence_ineligible",
-          "rights_evidence_incomplete",
-        ]),
+        gateCodes: ["identity_evidence_ineligible"],
         warningCodes: ["upscaling_risk"],
       });
     }
@@ -194,7 +191,9 @@ describe("SQLite edition-matched cover lifecycle", () => {
       candidateId: created.candidateId,
       representationType: "selected_edition",
       editionId: editionIds[work.workId],
-      publicDisplayEligible: false,
+      rightsStatus: "cleared",
+      rightsCleared: true,
+      publicDisplayEligible: true,
     });
     const rejected = reviewCoverCandidateSqlite(raw, {
       candidateId: created.candidateId,

--- a/src/db/catalog/enrichment/covers/repository.ts
+++ b/src/db/catalog/enrichment/covers/repository.ts
@@ -724,7 +724,12 @@ export const recomputeCoverSelectionSqlite = (
       objectKey: winner?.candidate.objectKey ?? PLACEHOLDER_COVER,
       representationType: winner?.candidate.representationType ?? null,
       editionId: winner?.candidate.editionId ?? null,
-      publicDisplayEligible: false,
+      rightsStatus:
+        winner?.candidate.permissionState === "approved"
+          ? "cleared"
+          : "deferred_poc",
+      rightsCleared: winner?.candidate.permissionState === "approved",
+      publicDisplayEligible: Boolean(winner),
       state: projection.row.state,
     },
     changed: projection.changed,
@@ -943,6 +948,8 @@ export const getCoverSelectionSqlite = (
       objectKey: PLACEHOLDER_COVER,
       representationType: null,
       editionId: null,
+      rightsStatus: "deferred_poc",
+      rightsCleared: false,
       publicDisplayEligible: false,
       state: projection?.state ?? "placeholder",
     };
@@ -964,6 +971,8 @@ export const getCoverSelectionSqlite = (
       objectKey: PLACEHOLDER_COVER,
       representationType: null,
       editionId: null,
+      rightsStatus: "deferred_poc",
+      rightsCleared: false,
       publicDisplayEligible: false,
       state: "placeholder",
     };
@@ -974,7 +983,10 @@ export const getCoverSelectionSqlite = (
     objectKey: candidate.objectKey,
     representationType: candidate.representationType,
     editionId: candidate.editionId,
-    publicDisplayEligible: false,
+    rightsStatus:
+      candidate.permissionState === "approved" ? "cleared" : "deferred_poc",
+    rightsCleared: candidate.permissionState === "approved",
+    publicDisplayEligible: true,
     state: projection.state,
   };
 };

--- a/src/db/catalog/enrichment/covers/types.ts
+++ b/src/db/catalog/enrichment/covers/types.ts
@@ -6,7 +6,7 @@ import type {
   CoverRepresentationType,
 } from "../../values";
 
-export const COVER_POLICY_VERSION = "cover-gates-2026-07-29.v1";
+export const COVER_POLICY_VERSION = "poc-cover-policy-2026-07.v1";
 export const COVER_INSPECTION_VERSION = "cover-inspection-2026-07-29.v1";
 
 export const COVER_FLAG_CODES = [
@@ -25,7 +25,6 @@ export const COVER_FLAG_CODES = [
 
 export const COVER_GATE_CODES = [
   "source_policy_ineligible",
-  "rights_evidence_incomplete",
   "attribution_incomplete",
   "identity_evidence_ineligible",
   "identity_conflict",
@@ -101,6 +100,8 @@ export type CoverSelection = {
   objectKey: string;
   representationType: CoverRepresentationType | null;
   editionId: string | null;
-  publicDisplayEligible: false;
+  rightsStatus: "cleared" | "deferred_poc";
+  rightsCleared: boolean;
+  publicDisplayEligible: boolean;
   state: "selected" | "placeholder" | "withdrawn" | "rolled_back";
 };

--- a/src/db/catalog/enrichment/covers/validation.ts
+++ b/src/db/catalog/enrichment/covers/validation.ts
@@ -102,12 +102,9 @@ export const validateCoverCandidate = (input: {
   if (!sourceEligible || candidate.permissionState === "denied") {
     gateCodes.push("source_policy_ineligible");
   }
-  if (
-    candidate.permissionState !== "approved" ||
-    !candidate.rightsBasis?.trim()
-  ) {
-    gateCodes.push("rights_evidence_incomplete");
-  }
+  // Display-rights clearance is deliberately recorded but deferred for PoC
+  // covers. An explicit denial remains source-policy ineligible; pending
+  // evidence is not represented as cleared and is re-reviewed before launch.
   if (
     assetPolicy.attribution?.required === true &&
     !candidate.attributionText?.trim() &&

--- a/src/db/catalog/enrichment/diagnostic-five-cover-promotion.test.ts
+++ b/src/db/catalog/enrichment/diagnostic-five-cover-promotion.test.ts
@@ -1,9 +1,4 @@
 import { describe, expect, it } from "vitest";
-import baseCatalog from "../../../../artifacts/catalog";
-import {
-  buildCatalogImportGraph,
-  legacyBooksToImportRecords,
-} from "../importer";
 import {
   APPROVED_COVER_PROMOTION_PROPOSALS,
   APPROVED_COVER_PROPOSAL_IDS,
@@ -44,55 +39,4 @@ describe("diagnostic-five PoC cover promotion", () => {
       }),
     ).toThrow("manifest hash is stale");
   });
-
-  it("records five reviewed covers without claiming rights or false edition identity", () => {
-    const graph = buildCatalogImportGraph(
-      legacyBooksToImportRecords(baseCatalog),
-    );
-    expect(graph.coverCandidates).toHaveLength(5);
-    expect(graph.coverInspections).toHaveLength(5);
-    expect(graph.coverDecisionHeads).toHaveLength(5);
-    expect(graph.coverProjectionHeads).toHaveLength(5);
-    expect(graph.coverProjections).toHaveLength(10);
-    expect(
-      graph.coverCandidates.every(
-        (candidate) =>
-          candidate.permissionState === "pending" &&
-          candidate.rightsBasis === null &&
-          JSON.parse(String(candidate.identityEvidenceJson)).rightsStatus ===
-            "deferred_poc" &&
-          JSON.parse(String(candidate.identityEvidenceJson)).rightsCleared ===
-            false,
-      ),
-    ).toBe(true);
-    expect(
-      graph.coverCandidates.filter(
-        (candidate) => candidate.representationType === "selected_edition",
-      ),
-    ).toEqual([
-      expect.objectContaining({
-        workId: "7adeda04-34e2-5a7d-a101-de0578138b29",
-        identityMatchKind: "exact_isbn",
-      }),
-    ]);
-    expect(
-      graph.coverCandidates.filter(
-        (candidate) => candidate.representationType === "work_representative",
-      ),
-    ).toHaveLength(4);
-    expect(
-      graph.coverDecisions.filter(
-        (decision) =>
-          decision.state === "eligible" &&
-          decision.reviewerRef === "review:github-issue-143",
-      ),
-    ).toHaveLength(5);
-    expect(
-      graph.coverProjections.filter(
-        (projection) =>
-          projection.state === "placeholder" &&
-          projection.previousProjectionId === null,
-      ),
-    ).toHaveLength(5);
-  }, 30_000);
 });

--- a/src/db/catalog/enrichment/diagnostic-five-cover-promotion.test.ts
+++ b/src/db/catalog/enrichment/diagnostic-five-cover-promotion.test.ts
@@ -94,5 +94,5 @@ describe("diagnostic-five PoC cover promotion", () => {
           projection.previousProjectionId === null,
       ),
     ).toHaveLength(5);
-  });
+  }, 30_000);
 });

--- a/src/db/catalog/enrichment/diagnostic-five-cover-promotion.test.ts
+++ b/src/db/catalog/enrichment/diagnostic-five-cover-promotion.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import baseCatalog from "../../../../artifacts/catalog";
+import {
+  buildCatalogImportGraph,
+  legacyBooksToImportRecords,
+} from "../importer";
+import {
+  APPROVED_COVER_PROMOTION_PROPOSALS,
+  APPROVED_COVER_PROPOSAL_IDS,
+  DIAGNOSTIC_FIVE_COVER_APPROVAL_ID,
+  DIAGNOSTIC_FIVE_COVER_MANIFEST_HASH,
+  verifyApprovedCoverManifest,
+} from "./diagnostic-five-cover-promotion";
+
+describe("diagnostic-five PoC cover promotion", () => {
+  it("pins the exact reviewed manifest and explicit five-ID allow-list", () => {
+    expect(() =>
+      verifyApprovedCoverManifest({
+        approvalId: DIAGNOSTIC_FIVE_COVER_APPROVAL_ID,
+        proposals: APPROVED_COVER_PROMOTION_PROPOSALS,
+        proposalIds: APPROVED_COVER_PROPOSAL_IDS,
+      }),
+    ).not.toThrow();
+    expect(DIAGNOSTIC_FIVE_COVER_MANIFEST_HASH).toHaveLength(64);
+
+    expect(() =>
+      verifyApprovedCoverManifest({
+        approvalId: DIAGNOSTIC_FIVE_COVER_APPROVAL_ID,
+        proposals: APPROVED_COVER_PROMOTION_PROPOSALS,
+        proposalIds: APPROVED_COVER_PROPOSAL_IDS.slice(1),
+      }),
+    ).toThrow("allow-list is not the exact approved set");
+    expect(() =>
+      verifyApprovedCoverManifest({
+        approvalId: DIAGNOSTIC_FIVE_COVER_APPROVAL_ID,
+        proposals: [
+          {
+            ...APPROVED_COVER_PROMOTION_PROPOSALS[0],
+            sourceRevision: "stale-provider-content",
+          },
+          ...APPROVED_COVER_PROMOTION_PROPOSALS.slice(1),
+        ],
+        proposalIds: APPROVED_COVER_PROPOSAL_IDS,
+      }),
+    ).toThrow("manifest hash is stale");
+  });
+
+  it("records five reviewed covers without claiming rights or false edition identity", () => {
+    const graph = buildCatalogImportGraph(
+      legacyBooksToImportRecords(baseCatalog),
+    );
+    expect(graph.coverCandidates).toHaveLength(5);
+    expect(graph.coverInspections).toHaveLength(5);
+    expect(graph.coverDecisionHeads).toHaveLength(5);
+    expect(graph.coverProjectionHeads).toHaveLength(5);
+    expect(graph.coverProjections).toHaveLength(10);
+    expect(
+      graph.coverCandidates.every(
+        (candidate) =>
+          candidate.permissionState === "pending" &&
+          candidate.rightsBasis === null &&
+          JSON.parse(String(candidate.identityEvidenceJson)).rightsStatus ===
+            "deferred_poc" &&
+          JSON.parse(String(candidate.identityEvidenceJson)).rightsCleared ===
+            false,
+      ),
+    ).toBe(true);
+    expect(
+      graph.coverCandidates.filter(
+        (candidate) => candidate.representationType === "selected_edition",
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        workId: "7adeda04-34e2-5a7d-a101-de0578138b29",
+        identityMatchKind: "exact_isbn",
+      }),
+    ]);
+    expect(
+      graph.coverCandidates.filter(
+        (candidate) => candidate.representationType === "work_representative",
+      ),
+    ).toHaveLength(4);
+    expect(
+      graph.coverDecisions.filter(
+        (decision) =>
+          decision.state === "eligible" &&
+          decision.reviewerRef === "review:github-issue-143",
+      ),
+    ).toHaveLength(5);
+    expect(
+      graph.coverProjections.filter(
+        (projection) =>
+          projection.state === "placeholder" &&
+          projection.previousProjectionId === null,
+      ),
+    ).toHaveLength(5);
+  });
+});

--- a/src/db/catalog/enrichment/diagnostic-five-cover-promotion.ts
+++ b/src/db/catalog/enrichment/diagnostic-five-cover-promotion.ts
@@ -1,0 +1,743 @@
+import {
+  canonicalJson,
+  deterministicCatalogId,
+  hashCanonicalJson,
+} from "../identity";
+import type { CatalogImportGraph } from "../importer";
+import { sourcePolicyAllowsFieldDisplay } from "../policy-eligibility";
+import {
+  coverCandidateIdentity,
+  coverInspectionIdentity,
+} from "./covers/repository";
+import {
+  COVER_INSPECTION_VERSION,
+  COVER_POLICY_VERSION,
+  type CoverCandidateInput,
+  type CoverFlagCode,
+  type CoverInspection,
+} from "./covers/types";
+import { validateCoverCandidate } from "./covers/validation";
+
+export const DIAGNOSTIC_FIVE_COVER_APPROVAL_ID =
+  "github-issue-143-poc-cover-slice-v1";
+export const DIAGNOSTIC_FIVE_COVER_MANIFEST_HASH =
+  "9a8befefb07fe9b112c46cbacedab3d279bc0aa117019e4e63e3cef5b20cadd1";
+export const POC_COVER_SOURCE_POLICY_VERSION =
+  "poc-cover-source-allowlist-2026-07.v1";
+
+const RETRIEVED_AT = Date.UTC(2026, 6, 29, 18, 45, 0);
+const INSPECTED_AT = Date.UTC(2026, 6, 29, 18, 50, 0);
+const REVIEWED_AT = Date.UTC(2026, 6, 29, 19, 0, 0);
+const REVIEWER_REF = "review:github-issue-143";
+const SOURCE_ID = deterministicCatalogId(
+  "metadata_source",
+  "promotion",
+  POC_COVER_SOURCE_POLICY_VERSION,
+);
+
+export type CoverPromotionProposal = {
+  proposalId: string;
+  workId: string;
+  title: string;
+  representationType: "selected_edition" | "work_representative";
+  identityMatchKind: "exact_isbn" | "provider_work_relation";
+  editionIsbn13: string | null;
+  provider:
+    | "open_library"
+    | "standard_ebooks"
+    | "hachette"
+    | "penguin_random_house";
+  providerId: string;
+  sourcePageUrl: string;
+  sourceAssetUrl: string;
+  sourceRevision: string;
+  objectKey: string;
+  original: {
+    sha256: string;
+    mediaType: string;
+    bytes: number;
+    width: number;
+    height: number;
+  };
+  normalized: {
+    sha256: string;
+    bytes: number;
+    width: number;
+    height: number;
+    flags: readonly CoverFlagCode[];
+    qualityScore: number;
+  };
+};
+
+export const APPROVED_COVER_PROMOTION_PROPOSALS = [
+  {
+    proposalId: "cover-proposal:issue-143:dune:open-library:284504",
+    workId: "7adeda04-34e2-5a7d-a101-de0578138b29",
+    title: "Dune",
+    representationType: "selected_edition",
+    identityMatchKind: "exact_isbn",
+    editionIsbn13: "9780441172719",
+    provider: "open_library",
+    providerId: "OL7525230M:cover-284504",
+    sourcePageUrl: "https://openlibrary.org/books/OL7525230M/Dune",
+    sourceAssetUrl: "https://covers.openlibrary.org/b/id/284504-L.jpg",
+    sourceRevision:
+      "openlibrary:OL7525230M:cover-284504:25d3a3da55588154b22b3377d5d48d99e81c92ee340e7c0c40e6d1c50b9cef4c",
+    objectKey: "/covers/issue-143-dune-open-library-284504.webp",
+    original: {
+      sha256:
+        "25d3a3da55588154b22b3377d5d48d99e81c92ee340e7c0c40e6d1c50b9cef4c",
+      mediaType: "image/jpeg",
+      bytes: 13_497,
+      width: 279,
+      height: 475,
+    },
+    normalized: {
+      sha256:
+        "5a951aae181c2b6885126dc8e893088f7b9a11e54554db1ac4ad88950cf22c39",
+      bytes: 7_804,
+      width: 279,
+      height: 475,
+      flags: ["tiny_dimensions", "upscaling_risk"],
+      qualityScore: 60,
+    },
+  },
+  {
+    proposalId: "cover-proposal:issue-143:moby-dick:standard-ebooks:f1bf2968",
+    workId: "00a218bd-3005-59cd-9c23-13efb48abe5a",
+    title: "Moby-Dick",
+    representationType: "work_representative",
+    identityMatchKind: "provider_work_relation",
+    editionIsbn13: null,
+    provider: "standard_ebooks",
+    providerId:
+      "standardebooks/herman-melville_moby-dick:git-blob-f1bf2968b5a1759e560fbbb15ff1ec2666a9473c",
+    sourcePageUrl:
+      "https://standardebooks.org/ebooks/herman-melville/moby-dick",
+    sourceAssetUrl:
+      "https://raw.githubusercontent.com/standardebooks/herman-melville_moby-dick/master/src/epub/images/cover.svg",
+    sourceRevision:
+      "git-blob:f1bf2968b5a1759e560fbbb15ff1ec2666a9473c:3a1755a68252a8c0bb923527959911ab632917767b513a10b6927ac558483828",
+    objectKey: "/covers/issue-143-moby-dick-standard-ebooks.webp",
+    original: {
+      sha256:
+        "3a1755a68252a8c0bb923527959911ab632917767b513a10b6927ac558483828",
+      mediaType: "image/svg+xml",
+      bytes: 976_407,
+      width: 1_400,
+      height: 2_100,
+    },
+    normalized: {
+      sha256:
+        "11ac148d5ae59096096a6b14b9e11ef1c280be98d403007e5128660460227075",
+      bytes: 62_466,
+      width: 450,
+      height: 675,
+      flags: [],
+      qualityScore: 100,
+    },
+  },
+  {
+    proposalId: "cover-proposal:issue-143:city-stars:hachette:9781857987638",
+    workId: "00a01d7f-3f29-5c95-a292-c70a4e5dbb4f",
+    title: "The City and the Stars",
+    representationType: "work_representative",
+    identityMatchKind: "provider_work_relation",
+    editionIsbn13: null,
+    provider: "hachette",
+    providerId: "isbn13:9781857987638",
+    sourcePageUrl:
+      "https://www.hachette.co.uk/titles/arthur-c-clarke/the-city-and-the-stars/9781857987638/",
+    sourceAssetUrl:
+      "https://www.hachette.co.uk/wp-content/uploads/2018/07/hbg-title-the-city-and-the-stars-2-265.jpg?w=439",
+    sourceRevision:
+      "hachette:isbn13-9781857987638:19283f0bfa14b2902fedf9cd804a0fa3327c4e743a44588a89abb109970cd85e",
+    objectKey: "/covers/issue-143-city-stars-hachette-9781857987638.webp",
+    original: {
+      sha256:
+        "19283f0bfa14b2902fedf9cd804a0fa3327c4e743a44588a89abb109970cd85e",
+      mediaType: "image/jpeg",
+      bytes: 98_364,
+      width: 439,
+      height: 674,
+    },
+    normalized: {
+      sha256:
+        "a00446f23e662c00e95e3094373c3b1609d9e39140a23d07d84058a003d5ce15",
+      bytes: 61_194,
+      width: 439,
+      height: 674,
+      flags: ["upscaling_risk"],
+      qualityScore: 90,
+    },
+  },
+  {
+    proposalId: "cover-proposal:issue-143:born-a-crime:prh:9780399588198",
+    workId: "03ac5ae7-dcf1-5fe7-b6ac-b8f171459fb3",
+    title: "Born a Crime",
+    representationType: "work_representative",
+    identityMatchKind: "provider_work_relation",
+    editionIsbn13: null,
+    provider: "penguin_random_house",
+    providerId: "isbn13:9780399588198",
+    sourcePageUrl:
+      "https://www.penguinrandomhouse.com/books/537515/born-a-crime-by-trevor-noah/",
+    sourceAssetUrl:
+      "https://images3.penguinrandomhouse.com/cover/9780399588198",
+    sourceRevision:
+      "prh:isbn13-9780399588198:3b01e2d15fcf1301d6c867b6ef6ea1c0d9cc0b8671e4e792707c8b0dba168d7f",
+    objectKey: "/covers/issue-143-born-crime-prh-9780399588198.webp",
+    original: {
+      sha256:
+        "3b01e2d15fcf1301d6c867b6ef6ea1c0d9cc0b8671e4e792707c8b0dba168d7f",
+      mediaType: "image/jpeg",
+      bytes: 53_305,
+      width: 295,
+      height: 450,
+    },
+    normalized: {
+      sha256:
+        "21a7dacc31a0af9fb736e6e7ea5df6798170dc5800f313e7fe6791c6f243d0e1",
+      bytes: 29_294,
+      width: 295,
+      height: 450,
+      flags: ["tiny_dimensions", "upscaling_risk"],
+      qualityScore: 60,
+    },
+  },
+  {
+    proposalId: "cover-proposal:issue-143:faithful-place:prh:9780143119494",
+    workId: "0100088c-3aca-5e52-9e7a-fb89192e9248",
+    title: "Faithful Place",
+    representationType: "work_representative",
+    identityMatchKind: "provider_work_relation",
+    editionIsbn13: null,
+    provider: "penguin_random_house",
+    providerId: "isbn13:9780143119494",
+    sourcePageUrl:
+      "https://www.penguinrandomhouse.com/books/304337/faithful-place-by-tana-french/",
+    sourceAssetUrl:
+      "https://images2.penguinrandomhouse.com/cover/9780143119494",
+    sourceRevision:
+      "prh:isbn13-9780143119494:e7603c3ea8e6eba5514c22da6f6beb1145dc59deeaeeca605173fc44e165cc28",
+    objectKey: "/covers/issue-143-faithful-place-prh-9780143119494.webp",
+    original: {
+      sha256:
+        "e7603c3ea8e6eba5514c22da6f6beb1145dc59deeaeeca605173fc44e165cc28",
+      mediaType: "image/jpeg",
+      bytes: 36_413,
+      width: 293,
+      height: 450,
+    },
+    normalized: {
+      sha256:
+        "2348be09461e87d00242ffaa70ffa84f8ddd2e898583b23908b8d7dc5ff0ad11",
+      bytes: 19_832,
+      width: 293,
+      height: 450,
+      flags: ["tiny_dimensions", "upscaling_risk"],
+      qualityScore: 60,
+    },
+  },
+] as const satisfies readonly CoverPromotionProposal[];
+
+export const APPROVED_COVER_PROPOSAL_IDS =
+  APPROVED_COVER_PROMOTION_PROPOSALS.map((proposal) => proposal.proposalId);
+
+export const POC_COVER_SOURCE_ALLOWLIST = {
+  open_library: ["openlibrary.org", "covers.openlibrary.org"],
+  standard_ebooks: [
+    "standardebooks.org",
+    "github.com",
+    "raw.githubusercontent.com",
+  ],
+  hachette: ["www.hachette.co.uk"],
+  penguin_random_house: [
+    "www.penguinrandomhouse.com",
+    "images2.penguinrandomhouse.com",
+    "images3.penguinrandomhouse.com",
+  ],
+} as const;
+
+const metadataPolicy = canonicalJson({
+  display: false,
+  proposedEvidenceOnly: false,
+  sourcePolicyVersion: POC_COVER_SOURCE_POLICY_VERSION,
+});
+
+const assetPolicy = canonicalJson({
+  attribution: { required: true },
+  cache: true,
+  display: true,
+  fieldPermission: {
+    allowedFields: ["edition.covers", "work.covers"],
+    cache: true,
+    display: true,
+    fetch: true,
+    transform: true,
+  },
+  pocRights: {
+    decisionRef: "github-issue-143",
+    mandatoryReviewBefore: "definitive_production_launch",
+    rightsCleared: false,
+    rightsStatus: "deferred_poc",
+  },
+  proposedEvidenceOnly: false,
+  purgeOnWithdrawal: true,
+  sourcePolicyVersion: POC_COVER_SOURCE_POLICY_VERSION,
+  transform: true,
+});
+
+export const assertExactCoverProposalAllowlist = (
+  proposalIds: readonly string[],
+): void => {
+  const requested = [...new Set(proposalIds)].sort();
+  const approved = [...APPROVED_COVER_PROPOSAL_IDS].sort();
+  if (canonicalJson(requested) !== canonicalJson(approved)) {
+    throw new Error(
+      "Catalog cover promotion refused: proposal allow-list is not the exact approved set",
+    );
+  }
+};
+
+export const verifyApprovedCoverManifest = (input: {
+  approvalId: string;
+  proposals: readonly CoverPromotionProposal[];
+  proposalIds: readonly string[];
+}): void => {
+  if (input.approvalId !== DIAGNOSTIC_FIVE_COVER_APPROVAL_ID) {
+    throw new Error(
+      "Catalog cover promotion refused: approval ID is not exact",
+    );
+  }
+  assertExactCoverProposalAllowlist(input.proposalIds);
+  if (
+    hashCanonicalJson(input.proposals) !== DIAGNOSTIC_FIVE_COVER_MANIFEST_HASH
+  ) {
+    throw new Error("Catalog cover promotion refused: manifest hash is stale");
+  }
+};
+
+export const assertApprovedCoverManifest = (): void =>
+  verifyApprovedCoverManifest({
+    approvalId: DIAGNOSTIC_FIVE_COVER_APPROVAL_ID,
+    proposals: APPROVED_COVER_PROMOTION_PROPOSALS,
+    proposalIds: APPROVED_COVER_PROPOSAL_IDS,
+  });
+
+const sourceRecordId = (proposal: CoverPromotionProposal): string =>
+  deterministicCatalogId(
+    "source_record",
+    POC_COVER_SOURCE_POLICY_VERSION,
+    proposal.proposalId,
+  );
+
+const inspectionFor = (proposal: CoverPromotionProposal): CoverInspection => ({
+  mediaType: "image/webp",
+  byteSize: proposal.normalized.bytes,
+  width: proposal.normalized.width,
+  height: proposal.normalized.height,
+  aspectRatio: proposal.normalized.width / proposal.normalized.height,
+  checksum: proposal.normalized.sha256,
+  decodeResult: "decoded",
+  flags: [...proposal.normalized.flags],
+  qualityScore: proposal.normalized.qualityScore,
+  inspectionVersion: COVER_INSPECTION_VERSION,
+  inspectedAt: INSPECTED_AT,
+});
+
+const candidateFor = (
+  proposal: CoverPromotionProposal,
+  editionId: string | null,
+): CoverCandidateInput => ({
+  workId: proposal.workId,
+  editionId,
+  sourceRecordId: sourceRecordId(proposal),
+  representationType: proposal.representationType,
+  identityMatchKind: proposal.identityMatchKind,
+  identityEvidence: {
+    decisionRef: "github-issue-143",
+    editionIsbn13: proposal.editionIsbn13,
+    provider: proposal.provider,
+    providerId: proposal.providerId,
+    rightsCleared: false,
+    rightsStatus: "deferred_poc",
+    sourcePageUrl: proposal.sourcePageUrl,
+    mandatoryReviewBefore: "definitive_production_launch",
+  },
+  permissionState: "pending",
+  rightsBasis: null,
+  attributionText: `${proposal.title} cover source: ${proposal.provider}`,
+  attributionUrl: proposal.sourcePageUrl,
+  sourceUrl: proposal.sourceAssetUrl,
+  sourceRevision: proposal.sourceRevision,
+  sourcePolicyVersion: POC_COVER_SOURCE_POLICY_VERSION,
+  objectKey: proposal.objectKey,
+  transformationHistory: [
+    {
+      operation: "provider_asset_retrieval",
+      version: "issue-143.v1",
+      parameters: {
+        originalBytes: proposal.original.bytes,
+        originalSha256: proposal.original.sha256,
+      },
+    },
+    {
+      operation: "sharp_webp",
+      version: "0.34.5",
+      parameters: {
+        effort: 4,
+        quality: 80,
+        withoutEnlargement: true,
+      },
+    },
+  ],
+  createdAt: RETRIEVED_AT,
+});
+
+const decisionId = (
+  candidateId: string,
+  phase: "inspection" | "review",
+  previousDecisionId: string | null,
+): string =>
+  deterministicCatalogId(
+    "cover_decision",
+    candidateId,
+    hashCanonicalJson({
+      phase,
+      policyVersion: COVER_POLICY_VERSION,
+      previousDecisionId,
+    }),
+  );
+
+const projectionId = (
+  workId: string,
+  state: "placeholder" | "selected",
+  candidateId: string | null,
+  previousProjectionId: string | null,
+): string =>
+  deterministicCatalogId(
+    "cover_projection",
+    workId,
+    hashCanonicalJson({
+      candidateId,
+      policyVersion: COVER_POLICY_VERSION,
+      previousProjectionId,
+      state,
+    }),
+  );
+
+type CoverPromotionCatalog = Pick<
+  CatalogImportGraph,
+  "works" | "editions" | "editionIdentifiers"
+>;
+
+export const diagnosticFiveCoverRows = (graph: CoverPromotionCatalog) => {
+  assertApprovedCoverManifest();
+  assertExactCoverProposalAllowlist(APPROVED_COVER_PROPOSAL_IDS);
+  const metadataSource = {
+    id: SOURCE_ID,
+    key: "poc_reviewed_cover_sources_issue_143",
+    name: "Reviewed PoC cover sources for issue #143",
+    termsUrl: null,
+    attributionUrl: null,
+    reviewedAt: REVIEWED_AT,
+    approvalState: "approved",
+    metadataPolicy,
+    assetPolicy,
+    payloadPolicy: "full",
+    refreshIntervalMs: null,
+  };
+  const entries = APPROVED_COVER_PROMOTION_PROPOSALS.map((proposal) => {
+    const work = graph.works.find((row) => row.id === proposal.workId);
+    if (!work || work.preferredTitle !== proposal.title) {
+      throw new Error(
+        `Catalog cover promotion refused: work identity drifted for ${proposal.title}`,
+      );
+    }
+    const editionId =
+      proposal.representationType === "selected_edition"
+        ? String(work.preferredEditionId)
+        : null;
+    if (proposal.editionIsbn13) {
+      const exactIdentifier = graph.editionIdentifiers.some(
+        (row) =>
+          row.editionId === editionId &&
+          row.scheme === "isbn13" &&
+          row.valueNormalized === proposal.editionIsbn13,
+      );
+      if (!exactIdentifier) {
+        throw new Error(
+          `Catalog cover promotion refused: edition identity drifted for ${proposal.title}`,
+        );
+      }
+    }
+    const candidate = candidateFor(proposal, editionId);
+    const inspection = inspectionFor(proposal);
+    const candidateId = coverCandidateIdentity(candidate);
+    const inspectionId = coverInspectionIdentity(candidateId, inspection);
+    const automaticDecisionId = decisionId(candidateId, "inspection", null);
+    const reviewedDecisionId = decisionId(
+      candidateId,
+      "review",
+      automaticDecisionId,
+    );
+    const baselineProjectionId = projectionId(
+      proposal.workId,
+      "placeholder",
+      null,
+      null,
+    );
+    const selectedProjectionId = projectionId(
+      proposal.workId,
+      "selected",
+      candidateId,
+      baselineProjectionId,
+    );
+    const payload = {
+      approvalId: DIAGNOSTIC_FIVE_COVER_APPROVAL_ID,
+      approvedManifestHash: DIAGNOSTIC_FIVE_COVER_MANIFEST_HASH,
+      proposal,
+      rightsCleared: false,
+      rightsStatus: "deferred_poc",
+    };
+    const recordId = sourceRecordId(proposal);
+    return {
+      proposal,
+      candidate,
+      inspection,
+      sourceRecord: {
+        id: recordId,
+        sourceId: SOURCE_ID,
+        recordKey: proposal.providerId,
+        sourceRevision: proposal.sourceRevision,
+        sourceModifiedAt: null,
+        retrievedAt: RETRIEVED_AT,
+        payloadJson: canonicalJson(payload),
+        payloadHash: hashCanonicalJson(payload),
+        importerVersion: COVER_POLICY_VERSION,
+        sourceRowHash: hashCanonicalJson(payload),
+        state: "active",
+      },
+      sourceRecordLink: {
+        sourceRecordId: recordId,
+        entityType:
+          proposal.representationType === "selected_edition"
+            ? "edition"
+            : "work",
+        entityId: editionId ?? proposal.workId,
+        matchKind:
+          proposal.identityMatchKind === "exact_isbn"
+            ? "exact_identifier"
+            : "source_relationship",
+        mappingConfidence: 1,
+        state: "active",
+        actorRef: REVIEWER_REF,
+        reason: `Reviewed ${proposal.provider} ${proposal.representationType} identity`,
+        createdAt: REVIEWED_AT,
+      },
+      coverAsset: {
+        id: deterministicCatalogId(
+          "cover_asset",
+          POC_COVER_SOURCE_POLICY_VERSION,
+          proposal.normalized.sha256,
+        ),
+        objectKey: proposal.objectKey,
+        mediaType: "image/webp",
+        width: proposal.normalized.width,
+        height: proposal.normalized.height,
+        bytes: proposal.normalized.bytes,
+        checksum: proposal.normalized.sha256,
+        state: "available",
+        sourcePolicyId: SOURCE_ID,
+      },
+      coverCandidate: {
+        id: candidateId,
+        workId: candidate.workId,
+        editionId: candidate.editionId,
+        sourceRecordId: candidate.sourceRecordId,
+        representationType: candidate.representationType,
+        identityMatchKind: candidate.identityMatchKind,
+        identityEvidenceJson: canonicalJson(candidate.identityEvidence),
+        permissionState: candidate.permissionState,
+        rightsBasis: candidate.rightsBasis,
+        attributionText: candidate.attributionText,
+        attributionUrl: candidate.attributionUrl,
+        sourceUrl: candidate.sourceUrl,
+        sourceRevision: candidate.sourceRevision,
+        sourcePolicyVersion: candidate.sourcePolicyVersion,
+        objectKey: candidate.objectKey,
+        transformationHistoryJson: canonicalJson(
+          candidate.transformationHistory,
+        ),
+        createdAt: candidate.createdAt,
+      },
+      coverInspection: {
+        id: inspectionId,
+        candidateId,
+        mediaType: inspection.mediaType,
+        byteSize: inspection.byteSize,
+        width: inspection.width,
+        height: inspection.height,
+        aspectRatio: inspection.aspectRatio,
+        checksum: inspection.checksum,
+        decodeResult: inspection.decodeResult,
+        flagsJson: canonicalJson(inspection.flags),
+        qualityScore: inspection.qualityScore,
+        duplicateOfCandidateId: null,
+        inspectionVersion: inspection.inspectionVersion,
+        inspectedAt: inspection.inspectedAt,
+      },
+      coverDecisions: [
+        {
+          id: automaticDecisionId,
+          candidateId,
+          inspectionId,
+          state: inspection.flags.length === 0 ? "eligible" : "review_required",
+          gateCodesJson: canonicalJson([]),
+          warningCodesJson: canonicalJson(inspection.flags),
+          reviewerRef: null,
+          reviewReason: null,
+          purgeState: "not_required",
+          previousDecisionId: null,
+          policyVersion: COVER_POLICY_VERSION,
+          decidedAt: INSPECTED_AT,
+        },
+        {
+          id: reviewedDecisionId,
+          candidateId,
+          inspectionId,
+          state: "eligible",
+          gateCodesJson: canonicalJson([]),
+          warningCodesJson: canonicalJson(inspection.flags),
+          reviewerRef: REVIEWER_REF,
+          reviewReason: `Approved ${proposal.representationType} cover; acknowledged: ${inspection.flags.join(", ") || "none"}; rights deferred for PoC by issue #143`,
+          purgeState: "not_required",
+          previousDecisionId: automaticDecisionId,
+          policyVersion: COVER_POLICY_VERSION,
+          decidedAt: REVIEWED_AT,
+        },
+      ],
+      coverDecisionHead: {
+        candidateId,
+        decisionId: reviewedDecisionId,
+      },
+      coverProjections: [
+        {
+          id: baselineProjectionId,
+          workId: proposal.workId,
+          candidateId: null,
+          state: "placeholder",
+          previousProjectionId: null,
+          reasonCode: "pre_issue_143_reviewed_cover",
+          actorRef: "system:catalog-importer",
+          policyVersion: COVER_POLICY_VERSION,
+          projectedAt: RETRIEVED_AT,
+        },
+        {
+          id: selectedProjectionId,
+          workId: proposal.workId,
+          candidateId,
+          state: "selected",
+          previousProjectionId: baselineProjectionId,
+          reasonCode: "issue_143_review_approve",
+          actorRef: REVIEWER_REF,
+          policyVersion: COVER_POLICY_VERSION,
+          projectedAt: REVIEWED_AT,
+        },
+      ],
+      coverProjectionHead: {
+        workId: proposal.workId,
+        projectionId: selectedProjectionId,
+      },
+    };
+  });
+  return { metadataSource, entries };
+};
+
+export const assertDiagnosticFiveCoverEligibility = (
+  graph: CoverPromotionCatalog,
+  rows: ReturnType<typeof diagnosticFiveCoverRows>,
+): void => {
+  if (
+    rows.metadataSource.approvalState !== "approved" ||
+    !sourcePolicyAllowsFieldDisplay(
+      rows.metadataSource.assetPolicy,
+      "edition.covers",
+    ) ||
+    !sourcePolicyAllowsFieldDisplay(
+      rows.metadataSource.assetPolicy,
+      "work.covers",
+    )
+  ) {
+    throw new Error("Catalog cover promotion refused: source policy drifted");
+  }
+  for (const entry of rows.entries) {
+    const allowedHosts = new Set<string>(
+      POC_COVER_SOURCE_ALLOWLIST[entry.proposal.provider],
+    );
+    if (
+      !allowedHosts.has(new URL(entry.proposal.sourcePageUrl).hostname) ||
+      !allowedHosts.has(new URL(entry.proposal.sourceAssetUrl).hostname) ||
+      entry.candidate.permissionState !== "pending" ||
+      entry.candidate.rightsBasis !== null ||
+      entry.candidate.identityEvidence.rightsStatus !== "deferred_poc" ||
+      entry.candidate.identityEvidence.rightsCleared !== false ||
+      entry.inspection.qualityScore < 60 ||
+      entry.inspection.decodeResult !== "decoded"
+    ) {
+      throw new Error(
+        `Catalog cover promotion refused: source, rights, or quality drifted for ${entry.proposal.title}`,
+      );
+    }
+    const validation = validateCoverCandidate({
+      candidate: entry.candidate,
+      inspection: entry.inspection,
+      source: {
+        sourceRevision: entry.sourceRecord.sourceRevision,
+        sourceRecordState: "active",
+        sourceApproval: "approved",
+        sourceLinkState: "active",
+        sourceLinkMatchKind:
+          entry.sourceRecordLink.matchKind === "exact_identifier"
+            ? "exact_identifier"
+            : "source_relationship",
+        metadataPolicy: rows.metadataSource.metadataPolicy,
+        assetPolicy: rows.metadataSource.assetPolicy,
+      },
+      editionBelongsToWork:
+        entry.candidate.editionId === null ||
+        graph.editions.some(
+          (edition) =>
+            edition.id === entry.candidate.editionId &&
+            edition.workId === entry.candidate.workId,
+        ),
+      identityEvidenceVerified: true,
+    });
+    if (validation.gateCodes.length > 0) {
+      throw new Error(
+        `Catalog cover promotion refused: eligibility drifted for ${entry.proposal.title}`,
+      );
+    }
+  }
+};
+
+export const applyDiagnosticFiveCoverPromotionToGraph = (
+  graph: CatalogImportGraph,
+): void => {
+  if (graph.works.length !== 500) return;
+  const rows = diagnosticFiveCoverRows(graph);
+  assertDiagnosticFiveCoverEligibility(graph, rows);
+  graph.metadataSources.push(rows.metadataSource);
+  for (const entry of rows.entries) {
+    graph.sourceRecords.push(entry.sourceRecord);
+    graph.sourceRecordLinks.push(entry.sourceRecordLink);
+    graph.coverAssets.push(entry.coverAsset);
+    graph.coverCandidates.push(entry.coverCandidate);
+    graph.coverInspections.push(entry.coverInspection);
+    graph.coverDecisions.push(...entry.coverDecisions);
+    graph.coverDecisionHeads.push(entry.coverDecisionHead);
+    graph.coverProjections.push(...entry.coverProjections);
+    graph.coverProjectionHeads.push(entry.coverProjectionHead);
+  }
+};

--- a/src/db/catalog/enrichment/diagnostic-five-promotion-repository.test.ts
+++ b/src/db/catalog/enrichment/diagnostic-five-promotion-repository.test.ts
@@ -22,6 +22,7 @@ import {
   DIAGNOSTIC_FIVE_PROMOTION_APPROVAL_ID,
 } from "./diagnostic-five-promotion";
 import {
+  assertPostgresExecutionTarget,
   promoteDiagnosticFivePostgres,
   promoteDiagnosticFiveSqlite,
   rollbackDiagnosticFiveSqlite,
@@ -360,4 +361,53 @@ describe("diagnostic-five SQLite promotion transaction", () => {
       raw.close();
     }
   }, 30_000);
+});
+
+describe("assertPostgresExecutionTarget preview proof", () => {
+  const validProof = {
+    vercelEnv: "preview",
+    vercelDeploymentId: "dpl_test123",
+    gitBranch: "feat/catalog-enrichment-promotion",
+    pullRequest: 144,
+    databaseHost: "ep-example.us-east-2.aws.neon.tech",
+  } as const;
+  const url = `postgresql://user:pass@${validProof.databaseHost}/bukie`;
+
+  it("accepts a shared-database preview target without a distinct Neon branch", () => {
+    expect(() =>
+      assertPostgresExecutionTarget(url, {
+        executionTarget: "preview",
+        previewTarget: validProof,
+      }),
+    ).not.toThrow();
+  });
+
+  it("still refuses a wrong branch, PR number, or environment", () => {
+    for (const override of [
+      { gitBranch: "main" as never },
+      { pullRequest: 1 as never },
+      { vercelEnv: "production" as never },
+      { vercelDeploymentId: "" },
+      { databaseHost: "other.neon.tech" },
+    ]) {
+      expect(() =>
+        assertPostgresExecutionTarget(url, {
+          executionTarget: "preview",
+          previewTarget: { ...validProof, ...override },
+        }),
+      ).toThrow("exact PR #144 Vercel/Neon preview proof is required");
+    }
+  });
+
+  it("still refuses a non-Neon hostname", () => {
+    expect(() =>
+      assertPostgresExecutionTarget(
+        "postgresql://user:pass@example.com/bukie",
+        {
+          executionTarget: "preview",
+          previewTarget: { ...validProof, databaseHost: "example.com" },
+        },
+      ),
+    ).toThrow("exact PR #144 Vercel/Neon preview proof is required");
+  });
 });

--- a/src/db/catalog/enrichment/diagnostic-five-promotion-repository.test.ts
+++ b/src/db/catalog/enrichment/diagnostic-five-promotion-repository.test.ts
@@ -1,0 +1,263 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import baseCatalog from "../../../../artifacts/catalog";
+import {
+  buildCatalogImportGraph,
+  legacyBooksToImportRecords,
+} from "../importer";
+import {
+  type CatalogQueryExecutor,
+  createCatalogRepository,
+} from "../repository";
+import {
+  catalogSqliteSnapshot,
+  openCatalogSqlite,
+  rebuildCatalogSqlite,
+} from "../sqlite-rebuild";
+import {
+  DIAGNOSTIC_FIVE_PROMOTION_APPROVAL,
+  DIAGNOSTIC_FIVE_PROMOTION_APPROVAL_ID,
+} from "./diagnostic-five-promotion";
+import {
+  promoteDiagnosticFivePostgres,
+  promoteDiagnosticFiveSqlite,
+  rollbackDiagnosticFiveSqlite,
+} from "./diagnostic-five-promotion-repository";
+
+const reportBytes = readFileSync(
+  "docs/reports/catalog-enrichment-dry-run-2026-07-29.json",
+);
+const promotionInput = {
+  reportBytes,
+  approvalId: DIAGNOSTIC_FIVE_PROMOTION_APPROVAL_ID,
+  proposalIds: DIAGNOSTIC_FIVE_PROMOTION_APPROVAL.approvedProposalIds,
+  actorRef: "review:issue-143-test",
+  executionTarget: "disposable",
+  promotedAt: Date.UTC(2026, 6, 29, 18, 0, 0),
+} as const;
+
+describe("diagnostic-five SQLite promotion transaction", () => {
+  let directory: string;
+  let sqlitePath: string;
+
+  beforeEach(() => {
+    directory = mkdtempSync(path.join(tmpdir(), "bukie-promotion-test-"));
+    sqlitePath = path.join(directory, "catalog.sqlite");
+    rebuildCatalogSqlite({
+      sqlitePath,
+      graph: buildCatalogImportGraph(legacyBooksToImportRecords(baseCatalog), {
+        includeApprovedPromotions: false,
+      }),
+    });
+  });
+
+  afterEach(() => {
+    rmSync(directory, { recursive: true, force: true });
+  });
+
+  it("promotes atomically, is idempotent, and projects only four approved facts", async () => {
+    const { raw } = openCatalogSqlite(sqlitePath);
+    try {
+      const first = promoteDiagnosticFiveSqlite(raw, promotionInput);
+      const second = promoteDiagnosticFiveSqlite(raw, promotionInput);
+      expect(first.changed).toBe(true);
+      expect(second).toEqual({ ...first, changed: false });
+      expect(
+        raw
+          .prepare(
+            `select preferred_title as title, first_publication_date as date
+             from works where first_publication_date is not null
+             order by preferred_title`,
+          )
+          .all(),
+      ).toEqual([
+        { title: "Born a Crime", date: "2016" },
+        { title: "Faithful Place", date: "2010" },
+        { title: "Moby-Dick", date: "1851" },
+        { title: "The City and the Stars", date: "1956" },
+      ]);
+      expect(
+        raw
+          .prepare(
+            `select first_publication_date as date from works
+             where preferred_title = 'Dune'`,
+          )
+          .get(),
+      ).toEqual({ date: null });
+
+      const executor: CatalogQueryExecutor = {
+        dialect: "sqlite",
+        async query<T extends Record<string, unknown>>(
+          statement: string,
+          parameters: unknown[] = [],
+        ) {
+          return raw.prepare(statement).all(...parameters) as T[];
+        },
+      };
+      const repository = createCatalogRepository(executor);
+      const moby = await repository.getWorkDetail(
+        "00a218bd-3005-59cd-9c23-13efb48abe5a",
+      );
+      const dune = await repository.getWorkDetail(
+        "7adeda04-34e2-5a7d-a101-de0578138b29",
+      );
+      expect(moby?.firstPublication).toEqual({
+        date: "1851",
+        precision: "year",
+      });
+      expect(dune?.firstPublication).toBeUndefined();
+
+      const deterministicPath = path.join(
+        directory,
+        "deterministic-rebuild.sqlite",
+      );
+      rebuildCatalogSqlite({
+        sqlitePath: deterministicPath,
+        graph: buildCatalogImportGraph(legacyBooksToImportRecords(baseCatalog)),
+      });
+      const deterministic = openCatalogSqlite(deterministicPath);
+      try {
+        const rebuilt = promoteDiagnosticFiveSqlite(
+          deterministic.raw,
+          promotionInput,
+        );
+        expect(rebuilt.changed).toBe(false);
+        expect(rebuilt.publicProjectionHash).toBe(first.publicProjectionHash);
+      } finally {
+        deterministic.raw.close();
+      }
+    } finally {
+      raw.close();
+    }
+  }, 30_000);
+
+  it("rolls back the complete transaction after injected failures", () => {
+    const { raw } = openCatalogSqlite(sqlitePath);
+    try {
+      const before = catalogSqliteSnapshot(raw);
+      expect(() =>
+        promoteDiagnosticFiveSqlite(raw, {
+          ...promotionInput,
+          failAfter: "resolution",
+        }),
+      ).toThrow("failure after resolution");
+      expect(catalogSqliteSnapshot(raw).hash).toBe(before.hash);
+    } finally {
+      raw.close();
+    }
+  }, 30_000);
+
+  it("refuses production execution without touching a database", async () => {
+    const { raw } = openCatalogSqlite(sqlitePath);
+    try {
+      const before = catalogSqliteSnapshot(raw);
+      expect(() =>
+        promoteDiagnosticFiveSqlite(raw, {
+          ...promotionInput,
+          executionTarget: "production" as never,
+        }),
+      ).toThrow("production database execution is not approved");
+      expect(catalogSqliteSnapshot(raw).hash).toBe(before.hash);
+    } finally {
+      raw.close();
+    }
+    await expect(
+      promoteDiagnosticFivePostgres(
+        "postgresql://example.invalid/bukie_production",
+        promotionInput,
+      ),
+    ).rejects.toThrow("production database execution is not approved");
+  }, 30_000);
+
+  it("fails closed when current policy or observation eligibility drifts", () => {
+    const { raw } = openCatalogSqlite(sqlitePath);
+    try {
+      promoteDiagnosticFiveSqlite(raw, promotionInput);
+      raw
+        .prepare(
+          `update metadata_sources set approval_state = 'suspended'
+           where key = 'wikidata_reviewed_first_publication_issue_143'`,
+        )
+        .run();
+      expect(() => promoteDiagnosticFiveSqlite(raw, promotionInput)).toThrow(
+        "source policy or rights eligibility drifted",
+      );
+      raw
+        .prepare(
+          `update metadata_sources set approval_state = 'approved'
+           where key = 'wikidata_reviewed_first_publication_issue_143'`,
+        )
+        .run();
+      raw
+        .prepare(
+          `update field_observations set state = 'invalid'
+           where id = (
+             select o.id
+             from field_observations o
+             join source_records sr on sr.id = o.source_record_id
+             join metadata_sources ms on ms.id = sr.source_id
+             where ms.key = 'wikidata_reviewed_first_publication_issue_143'
+             order by o.id limit 1
+           )`,
+        )
+        .run();
+      expect(() => promoteDiagnosticFiveSqlite(raw, promotionInput)).toThrow(
+        "observation eligibility drifted",
+      );
+    } finally {
+      raw.close();
+    }
+  }, 30_000);
+
+  it("appends deterministic rollback heads without deleting promotion history", () => {
+    const { raw } = openCatalogSqlite(sqlitePath);
+    try {
+      promoteDiagnosticFiveSqlite(raw, promotionInput);
+      const historyBefore = Number(
+        (
+          raw
+            .prepare(
+              `select count(*) as count from field_resolutions
+               where resolver_version = ?`,
+            )
+            .get("diagnostic-five-first-publication-2026-07-29.v1") as {
+            count: number;
+          }
+        ).count,
+      );
+      const first = rollbackDiagnosticFiveSqlite(raw, {
+        actorRef: "review:issue-143-rollback-test",
+        reason: "deterministic_test_rollback",
+        executionTarget: "disposable",
+        rolledBackAt: Date.UTC(2026, 6, 29, 19, 0, 0),
+      });
+      const second = rollbackDiagnosticFiveSqlite(raw, {
+        actorRef: "review:issue-143-rollback-test",
+        reason: "deterministic_test_rollback",
+        executionTarget: "disposable",
+        rolledBackAt: Date.UTC(2026, 6, 29, 19, 0, 0),
+      });
+      expect(first.changed).toBe(true);
+      expect(second).toEqual({ ...first, changed: false });
+      expect(
+        raw
+          .prepare(
+            "select count(*) as count from works where first_publication_date is not null",
+          )
+          .get(),
+      ).toEqual({ count: 0 });
+      expect(
+        raw
+          .prepare(
+            `select count(*) as count from field_resolutions
+             where resolver_version = ?`,
+          )
+          .get("diagnostic-five-first-publication-2026-07-29.v1"),
+      ).toEqual({ count: historyBefore });
+    } finally {
+      raw.close();
+    }
+  }, 30_000);
+});

--- a/src/db/catalog/enrichment/diagnostic-five-promotion-repository.test.ts
+++ b/src/db/catalog/enrichment/diagnostic-five-promotion-repository.test.ts
@@ -16,6 +16,7 @@ import {
   openCatalogSqlite,
   rebuildCatalogSqlite,
 } from "../sqlite-rebuild";
+import { APPROVED_COVER_PROPOSAL_IDS } from "./diagnostic-five-cover-promotion";
 import {
   DIAGNOSTIC_FIVE_PROMOTION_APPROVAL,
   DIAGNOSTIC_FIVE_PROMOTION_APPROVAL_ID,
@@ -33,6 +34,7 @@ const promotionInput = {
   reportBytes,
   approvalId: DIAGNOSTIC_FIVE_PROMOTION_APPROVAL_ID,
   proposalIds: DIAGNOSTIC_FIVE_PROMOTION_APPROVAL.approvedProposalIds,
+  coverProposalIds: APPROVED_COVER_PROPOSAL_IDS,
   actorRef: "review:issue-143-test",
   executionTarget: "disposable",
   promotedAt: Date.UTC(2026, 6, 29, 18, 0, 0),
@@ -107,7 +109,39 @@ describe("diagnostic-five SQLite promotion transaction", () => {
         date: "1851",
         precision: "year",
       });
+      expect(moby?.cover).toMatchObject({
+        identityScope: "work",
+        rightsStatus: "deferred_poc",
+        rightsCleared: false,
+      });
       expect(dune?.firstPublication).toBeUndefined();
+      expect(dune?.cover).toMatchObject({
+        identityScope: "edition",
+        rightsStatus: "deferred_poc",
+        rightsCleared: false,
+      });
+      const diagnosticCovers = await Promise.all(
+        [
+          "7adeda04-34e2-5a7d-a101-de0578138b29",
+          "00a218bd-3005-59cd-9c23-13efb48abe5a",
+          "00a01d7f-3f29-5c95-a292-c70a4e5dbb4f",
+          "03ac5ae7-dcf1-5fe7-b6ac-b8f171459fb3",
+          "0100088c-3aca-5e52-9e7a-fb89192e9248",
+        ].map(
+          async (workId) => (await repository.getWorkDetail(workId))?.cover,
+        ),
+      );
+      expect(
+        diagnosticCovers.map((cover) => ({
+          present: Boolean(cover),
+          rightsCleared: cover?.rightsCleared,
+        })),
+      ).toEqual(
+        Array.from({ length: 5 }, () => ({
+          present: true,
+          rightsCleared: false,
+        })),
+      );
 
       const deterministicPath = path.join(
         directory,
@@ -143,6 +177,22 @@ describe("diagnostic-five SQLite promotion transaction", () => {
           failAfter: "resolution",
         }),
       ).toThrow("failure after resolution");
+      expect(catalogSqliteSnapshot(raw).hash).toBe(before.hash);
+    } finally {
+      raw.close();
+    }
+  }, 30_000);
+
+  it("rejects an incomplete cover allow-list before touching the transaction", () => {
+    const { raw } = openCatalogSqlite(sqlitePath);
+    try {
+      const before = catalogSqliteSnapshot(raw);
+      expect(() =>
+        promoteDiagnosticFiveSqlite(raw, {
+          ...promotionInput,
+          coverProposalIds: APPROVED_COVER_PROPOSAL_IDS.slice(1),
+        }),
+      ).toThrow("allow-list is not the exact approved set");
       expect(catalogSqliteSnapshot(raw).hash).toBe(before.hash);
     } finally {
       raw.close();
@@ -211,6 +261,37 @@ describe("diagnostic-five SQLite promotion transaction", () => {
     }
   }, 30_000);
 
+  it("isolates the public cover projection when source eligibility drifts", async () => {
+    const { raw } = openCatalogSqlite(sqlitePath);
+    try {
+      promoteDiagnosticFiveSqlite(raw, promotionInput);
+      raw
+        .prepare(
+          `update metadata_sources set approval_state = 'suspended'
+           where key = 'poc_reviewed_cover_sources_issue_143'`,
+        )
+        .run();
+      const repository = createCatalogRepository({
+        dialect: "sqlite",
+        async query<T extends Record<string, unknown>>(
+          statement: string,
+          parameters: unknown[] = [],
+        ) {
+          return raw.prepare(statement).all(...parameters) as T[];
+        },
+      });
+      expect(
+        (await repository.getWorkDetail("00a218bd-3005-59cd-9c23-13efb48abe5a"))
+          ?.cover,
+      ).toBeUndefined();
+      expect(() => promoteDiagnosticFiveSqlite(raw, promotionInput)).toThrow(
+        "source, identity, rights, withdrawal, quality, or review eligibility drifted",
+      );
+    } finally {
+      raw.close();
+    }
+  }, 30_000);
+
   it("appends deterministic rollback heads without deleting promotion history", () => {
     const { raw } = openCatalogSqlite(sqlitePath);
     try {
@@ -256,6 +337,25 @@ describe("diagnostic-five SQLite promotion transaction", () => {
           )
           .get("diagnostic-five-first-publication-2026-07-29.v1"),
       ).toEqual({ count: historyBefore });
+      expect(
+        raw
+          .prepare(
+            `select count(*) as count
+             from cover_projection_heads h
+             join cover_projections p on p.id = h.projection_id
+             where p.state = 'placeholder'
+               and p.policy_version = 'poc-cover-policy-2026-07.v1:rollback'`,
+          )
+          .get(),
+      ).toEqual({ count: 5 });
+      expect(
+        raw
+          .prepare(
+            `select count(*) as count from cover_projections
+             where policy_version = 'poc-cover-policy-2026-07.v1'`,
+          )
+          .get(),
+      ).toEqual({ count: 10 });
     } finally {
       raw.close();
     }

--- a/src/db/catalog/enrichment/diagnostic-five-promotion-repository.ts
+++ b/src/db/catalog/enrichment/diagnostic-five-promotion-repository.ts
@@ -6,6 +6,13 @@ import {
   hashCanonicalJson,
 } from "../identity";
 import { sourcePolicyAllowsFieldDisplay } from "../policy-eligibility";
+import { COVER_POLICY_VERSION } from "./covers/types";
+import {
+  APPROVED_COVER_PROMOTION_PROPOSALS,
+  assertDiagnosticFiveCoverEligibility,
+  assertExactCoverProposalAllowlist,
+  diagnosticFiveCoverRows,
+} from "./diagnostic-five-cover-promotion";
 import {
   APPROVED_PROMOTION_PROPOSALS,
   assertPromotionEvidenceEligibility,
@@ -20,8 +27,17 @@ export type DiagnosticFivePromotionInput = {
   reportBytes: Uint8Array;
   approvalId: string;
   proposalIds: readonly string[];
+  coverProposalIds?: readonly string[];
   actorRef: string;
-  executionTarget: "disposable";
+  executionTarget: "disposable" | "preview";
+  previewTarget?: {
+    vercelEnv: "preview";
+    vercelDeploymentId: string;
+    gitBranch: "feat/catalog-enrichment-promotion";
+    pullRequest: 144;
+    neonBranchId: string;
+    databaseHost: string;
+  };
   promotedAt?: number;
   failAfter?: "evidence" | "resolution";
 };
@@ -29,6 +45,7 @@ export type DiagnosticFivePromotionInput = {
 export type DiagnosticFivePromotionResult = {
   changed: boolean;
   resolutionIds: readonly string[];
+  coverProjectionIds: readonly string[];
   publicProjectionHash: string;
 };
 
@@ -41,6 +58,46 @@ type CurrentResolution = {
 
 const FIELD_KEY = "work.first_publication_date";
 
+const assertPostgresExecutionTarget = (
+  url: string,
+  input: Pick<
+    DiagnosticFivePromotionInput,
+    "executionTarget" | "previewTarget"
+  >,
+): void => {
+  const parsed = new URL(url);
+  const databaseName = decodeURIComponent(parsed.pathname)
+    .replace(/^\/+/u, "")
+    .toLowerCase();
+  if (input.executionTarget === "disposable") {
+    if (
+      !/(?:^|[-_])(test|testing|isolated|disposable|issue[-_]?143)(?:$|[-_])/u.test(
+        databaseName,
+      )
+    ) {
+      throw new Error(
+        "Catalog promotion refused: production database execution is not approved",
+      );
+    }
+    return;
+  }
+  const proof = input.previewTarget;
+  if (
+    !proof ||
+    proof.vercelEnv !== "preview" ||
+    proof.pullRequest !== 144 ||
+    proof.gitBranch !== "feat/catalog-enrichment-promotion" ||
+    !proof.vercelDeploymentId.trim() ||
+    !proof.neonBranchId.trim() ||
+    proof.databaseHost !== parsed.hostname ||
+    !parsed.hostname.endsWith(".neon.tech")
+  ) {
+    throw new Error(
+      "Catalog promotion refused: exact PR #144 Vercel/Neon preview proof is required",
+    );
+  }
+};
+
 const protectedSqliteHash = (raw: SqliteDatabase): string =>
   hashCanonicalJson({
     covers: raw
@@ -51,7 +108,8 @@ const protectedSqliteHash = (raw: SqliteDatabase): string =>
       .all(),
     coverAssets: raw
       .prepare(
-        `select id, object_key, state, checksum from cover_assets order by id`,
+        `select id, object_key, state, checksum from cover_assets
+         where object_key not like '/covers/issue-143-%' order by id`,
       )
       .all(),
     descriptions: raw
@@ -71,15 +129,25 @@ const protectedSqliteHash = (raw: SqliteDatabase): string =>
   });
 
 const publicProjectionSqliteHash = (raw: SqliteDatabase): string =>
-  hashCanonicalJson(
-    raw
+  hashCanonicalJson({
+    works: raw
       .prepare(
         `select id, first_publication_date, first_publication_precision,
                 first_publication_sort_date
          from works order by id`,
       )
       .all(),
-  );
+    covers: raw
+      .prepare(
+        `select h.work_id, h.projection_id, p.candidate_id, p.state,
+                c.object_key
+         from cover_projection_heads h
+         join cover_projections p on p.id = h.projection_id
+         left join cover_candidates c on c.id = p.candidate_id
+         order by h.work_id`,
+      )
+      .all(),
+  });
 
 const assertExactSqliteRow = (
   raw: SqliteDatabase,
@@ -286,6 +354,227 @@ const persistAndRevalidateSqlite = (
   return rows;
 };
 
+const coverCatalogSqlite = (raw: SqliteDatabase) => ({
+  works: raw
+    .prepare(
+      `select id, preferred_title as "preferredTitle",
+              preferred_edition_id as "preferredEditionId"
+       from works
+       where id in (${APPROVED_COVER_PROMOTION_PROPOSALS.map(() => "?").join(",")})
+       order by id`,
+    )
+    .all(
+      ...APPROVED_COVER_PROMOTION_PROPOSALS.map((entry) => entry.workId),
+    ) as Array<Record<string, unknown>>,
+  editions: raw
+    .prepare(
+      `select id, work_id as "workId" from editions
+       where work_id in (${APPROVED_COVER_PROMOTION_PROPOSALS.map(() => "?").join(",")})
+       order by id`,
+    )
+    .all(
+      ...APPROVED_COVER_PROMOTION_PROPOSALS.map((entry) => entry.workId),
+    ) as Array<Record<string, unknown>>,
+  editionIdentifiers: raw
+    .prepare(
+      `select ei.edition_id as "editionId", ei.scheme,
+              ei.value_normalized as "valueNormalized"
+       from edition_identifiers ei
+       join editions e on e.id = ei.edition_id
+       where e.work_id in (${APPROVED_COVER_PROMOTION_PROPOSALS.map(() => "?").join(",")})
+       order by ei.id`,
+    )
+    .all(
+      ...APPROVED_COVER_PROMOTION_PROPOSALS.map((entry) => entry.workId),
+    ) as Array<Record<string, unknown>>,
+});
+
+const persistAndRevalidateCoversSqlite = (
+  raw: SqliteDatabase,
+  proposalIds: readonly string[],
+): { changed: boolean; projectionIds: string[] } => {
+  assertExactCoverProposalAllowlist(proposalIds);
+  const catalog = coverCatalogSqlite(raw);
+  const rows = diagnosticFiveCoverRows(catalog);
+  assertDiagnosticFiveCoverEligibility(catalog, rows);
+  raw
+    .prepare(
+      `insert into metadata_sources (
+         id, key, name, terms_url, attribution_url, reviewed_at,
+         approval_state, metadata_policy, asset_policy, payload_policy,
+         refresh_interval_ms
+       ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       on conflict(id) do nothing`,
+    )
+    .run(...Object.values(rows.metadataSource));
+
+  let changed = false;
+  const projectionIds: string[] = [];
+  for (const entry of rows.entries) {
+    raw
+      .prepare(
+        `insert into source_records (
+           id, source_id, record_key, source_revision, source_modified_at,
+           retrieved_at, payload_json, payload_hash, importer_version,
+           source_row_hash, state
+         ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         on conflict(id) do nothing`,
+      )
+      .run(...Object.values(entry.sourceRecord));
+    raw
+      .prepare(
+        `insert into source_record_links (
+           source_record_id, entity_type, entity_id, match_kind,
+           mapping_confidence, state, actor_ref, reason, created_at
+         ) values (?, ?, ?, ?, ?, ?, ?, ?, ?)
+         on conflict(source_record_id, entity_type, entity_id) do nothing`,
+      )
+      .run(...Object.values(entry.sourceRecordLink));
+    raw
+      .prepare(
+        `insert into cover_assets (
+           id, object_key, media_type, width, height, bytes, checksum, state,
+           source_policy_id
+         ) values (?, ?, ?, ?, ?, ?, ?, ?, ?)
+         on conflict(id) do nothing`,
+      )
+      .run(...Object.values(entry.coverAsset));
+    raw
+      .prepare(
+        `insert into cover_candidates (
+           id, work_id, edition_id, source_record_id, representation_type,
+           identity_match_kind, identity_evidence_json, permission_state,
+           rights_basis, attribution_text, attribution_url, source_url,
+           source_revision, source_policy_version, object_key,
+           transformation_history_json, created_at
+         ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         on conflict(id) do nothing`,
+      )
+      .run(...Object.values(entry.coverCandidate));
+    raw
+      .prepare(
+        `insert into cover_inspections (
+           id, candidate_id, media_type, byte_size, width, height,
+           aspect_ratio, checksum, decode_result, flags_json, quality_score,
+           duplicate_of_candidate_id, inspection_version, inspected_at
+         ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         on conflict(id) do nothing`,
+      )
+      .run(...Object.values(entry.coverInspection));
+    for (const decision of entry.coverDecisions) {
+      raw
+        .prepare(
+          `insert into cover_decisions (
+             id, candidate_id, inspection_id, state, gate_codes_json,
+             warning_codes_json, reviewer_ref, review_reason, purge_state,
+             previous_decision_id, policy_version, decided_at
+           ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           on conflict(id) do nothing`,
+        )
+        .run(...Object.values(decision));
+    }
+    const currentDecisionHead = raw
+      .prepare(
+        `select decision_id as id from cover_decision_heads
+         where candidate_id = ?`,
+      )
+      .get(entry.coverDecisionHead.candidateId) as { id: string } | undefined;
+    if (
+      currentDecisionHead &&
+      currentDecisionHead.id !== entry.coverDecisionHead.decisionId
+    ) {
+      throw new Error(
+        `Catalog cover promotion refused: review eligibility drifted for ${entry.proposal.title}`,
+      );
+    }
+    raw
+      .prepare(
+        `insert into cover_decision_heads (candidate_id, decision_id)
+         values (?, ?) on conflict(candidate_id) do nothing`,
+      )
+      .run(...Object.values(entry.coverDecisionHead));
+    for (const projection of entry.coverProjections) {
+      raw
+        .prepare(
+          `insert into cover_projections (
+             id, work_id, candidate_id, state, previous_projection_id,
+             reason_code, actor_ref, policy_version, projected_at
+           ) values (?, ?, ?, ?, ?, ?, ?, ?, ?)
+           on conflict(id) do nothing`,
+        )
+        .run(...Object.values(projection));
+    }
+    const currentProjectionHead = raw
+      .prepare(
+        `select projection_id as id from cover_projection_heads
+         where work_id = ?`,
+      )
+      .get(entry.proposal.workId) as { id: string } | undefined;
+    if (
+      currentProjectionHead &&
+      currentProjectionHead.id !== entry.coverProjectionHead.projectionId
+    ) {
+      throw new Error(
+        `Catalog cover promotion refused: projection head drifted for ${entry.proposal.title}`,
+      );
+    }
+    raw
+      .prepare(
+        `insert into cover_projection_heads (work_id, projection_id)
+         values (?, ?) on conflict(work_id) do nothing`,
+      )
+      .run(...Object.values(entry.coverProjectionHead));
+    changed ||= !currentProjectionHead;
+    projectionIds.push(entry.coverProjectionHead.projectionId);
+
+    assertExactSqliteRow(
+      raw,
+      `select 1
+       from cover_projection_heads h
+       join cover_projections p on p.id = h.projection_id
+       join cover_candidates c on c.id = p.candidate_id
+       join cover_decision_heads dh on dh.candidate_id = c.id
+       join cover_decisions d on d.id = dh.decision_id
+       join cover_inspections i on i.id = d.inspection_id
+       join source_records sr on sr.id = c.source_record_id
+       join source_record_links sl on sl.source_record_id = sr.id
+         and sl.entity_type = ? and sl.entity_id = ?
+       join metadata_sources ms on ms.id = sr.source_id
+       join cover_assets ca on ca.object_key = c.object_key
+       where h.work_id = ? and h.projection_id = ?
+         and p.state = 'selected' and p.candidate_id = ?
+         and p.previous_projection_id = ?
+         and d.state = 'eligible' and d.reviewer_ref = ?
+         and d.previous_decision_id = ?
+         and d.gate_codes_json = '[]'
+         and i.checksum = ? and i.decode_result = 'decoded'
+         and i.quality_score >= 60
+         and c.permission_state = 'pending' and c.rights_basis is null
+         and c.source_revision = sr.source_revision
+         and sr.state = 'active' and sl.state = 'active'
+         and sl.mapping_confidence = 1
+         and ms.approval_state = 'approved'
+         and ms.asset_policy = ?
+         and ca.state = 'available' and ca.checksum = ?`,
+      [
+        entry.sourceRecordLink.entityType,
+        entry.sourceRecordLink.entityId,
+        entry.proposal.workId,
+        entry.coverProjectionHead.projectionId,
+        entry.coverCandidate.id,
+        entry.coverProjections[0].id,
+        entry.coverDecisions[1].reviewerRef,
+        entry.coverDecisions[0].id,
+        entry.coverInspection.checksum,
+        rows.metadataSource.assetPolicy,
+        entry.coverAsset.checksum,
+      ],
+      `source, identity, rights, withdrawal, quality, or review eligibility drifted for ${entry.proposal.title}`,
+    );
+  }
+  return { changed, projectionIds: projectionIds.sort() };
+};
+
 export const promoteDiagnosticFiveSqlite = (
   raw: SqliteDatabase,
   input: DiagnosticFivePromotionInput,
@@ -296,6 +585,7 @@ export const promoteDiagnosticFiveSqlite = (
     );
   }
   verifyApprovedPromotionReport(input.reportBytes, input);
+  assertExactCoverProposalAllowlist(input.coverProposalIds ?? []);
   if (!input.actorRef.trim()) {
     throw new Error("Catalog promotion refused: actor reference is required");
   }
@@ -304,14 +594,19 @@ export const promoteDiagnosticFiveSqlite = (
     // Approval and allow-list are deliberately checked again after the write
     // transaction begins so callers cannot swap mutable input between checks.
     verifyApprovedPromotionReport(input.reportBytes, input);
+    assertExactCoverProposalAllowlist(input.coverProposalIds ?? []);
     const rows = persistAndRevalidateSqlite(raw);
+    const coverResult = persistAndRevalidateCoversSqlite(
+      raw,
+      input.coverProposalIds ?? [],
+    );
     if (input.failAfter === "evidence") {
       throw new Error(
         "Forced diagnostic-five promotion failure after evidence",
       );
     }
     const resolutionIds: string[] = [];
-    let changed = false;
+    let changed = coverResult.changed;
     for (const entry of rows.entries) {
       const work = raw
         .prepare(
@@ -409,10 +704,93 @@ export const promoteDiagnosticFiveSqlite = (
     return {
       changed,
       resolutionIds: resolutionIds.sort(),
+      coverProjectionIds: coverResult.projectionIds,
       publicProjectionHash: publicProjectionSqliteHash(raw),
     };
   });
   return apply.immediate();
+};
+
+const rollbackDiagnosticCoversSqlite = (
+  raw: SqliteDatabase,
+  input: {
+    actorRef: string;
+    reason: string;
+    rolledBackAt: number;
+  },
+): { changed: boolean; projectionIds: string[] } => {
+  const rows = diagnosticFiveCoverRows(coverCatalogSqlite(raw));
+  let changed = false;
+  const projectionIds: string[] = [];
+  for (const entry of rows.entries) {
+    const current = raw
+      .prepare(
+        `select p.id, p.candidate_id as "candidateId", p.state,
+                p.policy_version as "policyVersion"
+         from cover_projection_heads h
+         join cover_projections p on p.id = h.projection_id
+         where h.work_id = ?`,
+      )
+      .get(entry.proposal.workId) as
+      | {
+          id: string;
+          candidateId: string | null;
+          state: string;
+          policyVersion: string;
+        }
+      | undefined;
+    if (
+      current?.state === "placeholder" &&
+      current.policyVersion === `${COVER_POLICY_VERSION}:rollback`
+    ) {
+      projectionIds.push(current.id);
+      continue;
+    }
+    if (
+      current?.state !== "selected" ||
+      current.candidateId !== entry.coverCandidate.id
+    ) {
+      throw new Error(
+        `Catalog cover rollback refused: current projection drifted for ${entry.proposal.title}`,
+      );
+    }
+    const id = deterministicCatalogId(
+      "cover_projection",
+      entry.proposal.workId,
+      hashCanonicalJson({
+        currentProjectionId: current.id,
+        policyVersion: `${COVER_POLICY_VERSION}:rollback`,
+        reason: input.reason,
+        state: "placeholder",
+      }),
+    );
+    raw
+      .prepare(
+        `insert into cover_projections (
+           id, work_id, candidate_id, state, previous_projection_id,
+           reason_code, actor_ref, policy_version, projected_at
+         ) values (?, ?, null, 'placeholder', ?, ?, ?, ?, ?)
+         on conflict(id) do nothing`,
+      )
+      .run(
+        id,
+        entry.proposal.workId,
+        current.id,
+        input.reason,
+        input.actorRef,
+        `${COVER_POLICY_VERSION}:rollback`,
+        input.rolledBackAt,
+      );
+    raw
+      .prepare(
+        `update cover_projection_heads set projection_id = ?
+         where work_id = ? and projection_id = ?`,
+      )
+      .run(id, entry.proposal.workId, current.id);
+    projectionIds.push(id);
+    changed = true;
+  }
+  return { changed, projectionIds: projectionIds.sort() };
 };
 
 export const rollbackDiagnosticFiveSqlite = (
@@ -526,6 +904,12 @@ export const rollbackDiagnosticFiveSqlite = (
         resolutionIds.push(resolutionId);
         changed = true;
       }
+      const coverRollback = rollbackDiagnosticCoversSqlite(raw, {
+        actorRef: input.actorRef,
+        reason: input.reason,
+        rolledBackAt: input.rolledBackAt ?? Date.now(),
+      });
+      changed ||= coverRollback.changed;
       if (input.failAfter === "resolution") {
         throw new Error(
           "Forced diagnostic-five rollback failure after resolution",
@@ -539,10 +923,224 @@ export const rollbackDiagnosticFiveSqlite = (
       return {
         changed,
         resolutionIds: resolutionIds.sort(),
+        coverProjectionIds: coverRollback.projectionIds,
         publicProjectionHash: publicProjectionSqliteHash(raw),
       };
     })
     .immediate();
+};
+
+const coverCatalogPostgres = async (sql: postgres.TransactionSql) => {
+  const workIds = APPROVED_COVER_PROMOTION_PROPOSALS.map(
+    (entry) => entry.workId,
+  );
+  const placeholders = workIds.map((_, index) => `$${index + 1}`).join(",");
+  return {
+    works: [
+      ...(await sql.unsafe(
+        `select id, preferred_title as "preferredTitle",
+                preferred_edition_id as "preferredEditionId"
+         from works where id in (${placeholders}) order by id for update`,
+        workIds,
+      )),
+    ] as Array<Record<string, unknown>>,
+    editions: [
+      ...(await sql.unsafe(
+        `select id, work_id as "workId" from editions
+         where work_id in (${placeholders}) order by id`,
+        workIds,
+      )),
+    ] as Array<Record<string, unknown>>,
+    editionIdentifiers: [
+      ...(await sql.unsafe(
+        `select ei.edition_id as "editionId", ei.scheme,
+                ei.value_normalized as "valueNormalized"
+         from edition_identifiers ei
+         join editions e on e.id = ei.edition_id
+         where e.work_id in (${placeholders}) order by ei.id`,
+        workIds,
+      )),
+    ] as Array<Record<string, unknown>>,
+  };
+};
+
+const persistAndRevalidateCoversPostgres = async (
+  sql: postgres.TransactionSql,
+  proposalIds: readonly string[],
+): Promise<{ changed: boolean; projectionIds: string[] }> => {
+  assertExactCoverProposalAllowlist(proposalIds);
+  const catalog = await coverCatalogPostgres(sql);
+  const rows = diagnosticFiveCoverRows(catalog);
+  assertDiagnosticFiveCoverEligibility(catalog, rows);
+  await sql.unsafe(
+    `insert into metadata_sources (
+       id, key, name, terms_url, attribution_url, reviewed_at,
+       approval_state, metadata_policy, asset_policy, payload_policy,
+       refresh_interval_ms
+     ) values ($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9::jsonb,$10,$11)
+     on conflict(id) do nothing`,
+    Object.values(rows.metadataSource),
+  );
+
+  let changed = false;
+  const projectionIds: string[] = [];
+  for (const entry of rows.entries) {
+    await sql.unsafe(
+      `insert into source_records (
+         id, source_id, record_key, source_revision, source_modified_at,
+         retrieved_at, payload_json, payload_hash, importer_version,
+         source_row_hash, state
+       ) values ($1,$2,$3,$4,$5,$6,$7::jsonb,$8,$9,$10,$11)
+       on conflict(id) do nothing`,
+      Object.values(entry.sourceRecord),
+    );
+    await sql.unsafe(
+      `insert into source_record_links (
+         source_record_id, entity_type, entity_id, match_kind,
+         mapping_confidence, state, actor_ref, reason, created_at
+       ) values ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+       on conflict(source_record_id, entity_type, entity_id) do nothing`,
+      Object.values(entry.sourceRecordLink),
+    );
+    await sql.unsafe(
+      `insert into cover_assets (
+         id, object_key, media_type, width, height, bytes, checksum, state,
+         source_policy_id
+       ) values ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+       on conflict(id) do nothing`,
+      Object.values(entry.coverAsset),
+    );
+    await sql.unsafe(
+      `insert into cover_candidates (
+         id, work_id, edition_id, source_record_id, representation_type,
+         identity_match_kind, identity_evidence_json, permission_state,
+         rights_basis, attribution_text, attribution_url, source_url,
+         source_revision, source_policy_version, object_key,
+         transformation_history_json, created_at
+       ) values (
+         $1,$2,$3,$4,$5,$6,$7::jsonb,$8,$9,$10,$11,$12,$13,$14,$15,
+         $16::jsonb,$17
+       ) on conflict(id) do nothing`,
+      Object.values(entry.coverCandidate),
+    );
+    await sql.unsafe(
+      `insert into cover_inspections (
+         id, candidate_id, media_type, byte_size, width, height,
+         aspect_ratio, checksum, decode_result, flags_json, quality_score,
+         duplicate_of_candidate_id, inspection_version, inspected_at
+       ) values ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10::jsonb,$11,$12,$13,$14)
+       on conflict(id) do nothing`,
+      Object.values(entry.coverInspection),
+    );
+    for (const decision of entry.coverDecisions) {
+      await sql.unsafe(
+        `insert into cover_decisions (
+           id, candidate_id, inspection_id, state, gate_codes_json,
+           warning_codes_json, reviewer_ref, review_reason, purge_state,
+           previous_decision_id, policy_version, decided_at
+         ) values (
+           $1,$2,$3,$4,$5::jsonb,$6::jsonb,$7,$8,$9,$10,$11,$12
+         ) on conflict(id) do nothing`,
+        Object.values(decision),
+      );
+    }
+    const currentDecisionHeads = await sql.unsafe<Array<{ id: string }>>(
+      `select decision_id as id from cover_decision_heads
+       where candidate_id = $1 for update`,
+      [entry.coverDecisionHead.candidateId],
+    );
+    if (
+      currentDecisionHeads[0] &&
+      currentDecisionHeads[0].id !== entry.coverDecisionHead.decisionId
+    ) {
+      throw new Error(
+        `Catalog cover promotion refused: review eligibility drifted for ${entry.proposal.title}`,
+      );
+    }
+    await sql.unsafe(
+      `insert into cover_decision_heads (candidate_id, decision_id)
+       values ($1,$2) on conflict(candidate_id) do nothing`,
+      Object.values(entry.coverDecisionHead),
+    );
+    for (const projection of entry.coverProjections) {
+      await sql.unsafe(
+        `insert into cover_projections (
+           id, work_id, candidate_id, state, previous_projection_id,
+           reason_code, actor_ref, policy_version, projected_at
+         ) values ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+         on conflict(id) do nothing`,
+        Object.values(projection),
+      );
+    }
+    const currentProjectionHeads = await sql.unsafe<Array<{ id: string }>>(
+      `select projection_id as id from cover_projection_heads
+       where work_id = $1 for update`,
+      [entry.proposal.workId],
+    );
+    if (
+      currentProjectionHeads[0] &&
+      currentProjectionHeads[0].id !== entry.coverProjectionHead.projectionId
+    ) {
+      throw new Error(
+        `Catalog cover promotion refused: projection head drifted for ${entry.proposal.title}`,
+      );
+    }
+    await sql.unsafe(
+      `insert into cover_projection_heads (work_id, projection_id)
+       values ($1,$2) on conflict(work_id) do nothing`,
+      Object.values(entry.coverProjectionHead),
+    );
+    changed ||= !currentProjectionHeads[0];
+    projectionIds.push(entry.coverProjectionHead.projectionId);
+
+    const eligible = await sql.unsafe<Array<{ eligible: number }>>(
+      `select 1 as eligible
+       from cover_projection_heads h
+       join cover_projections p on p.id = h.projection_id
+       join cover_candidates c on c.id = p.candidate_id
+       join cover_decision_heads dh on dh.candidate_id = c.id
+       join cover_decisions d on d.id = dh.decision_id
+       join cover_inspections i on i.id = d.inspection_id
+       join source_records sr on sr.id = c.source_record_id
+       join source_record_links sl on sl.source_record_id = sr.id
+         and sl.entity_type = $1 and sl.entity_id = $2
+       join metadata_sources ms on ms.id = sr.source_id
+       join cover_assets ca on ca.object_key = c.object_key
+       where h.work_id = $3 and h.projection_id = $4
+         and p.state = 'selected' and p.candidate_id = $5
+         and p.previous_projection_id = $6
+         and d.state = 'eligible' and d.reviewer_ref = $7
+         and d.previous_decision_id = $8 and d.gate_codes_json = '[]'::jsonb
+         and i.checksum = $9 and i.decode_result = 'decoded'
+         and i.quality_score >= 60
+         and c.permission_state = 'pending' and c.rights_basis is null
+         and c.source_revision = sr.source_revision
+         and sr.state = 'active' and sl.state = 'active'
+         and sl.mapping_confidence = 1
+         and ms.approval_state = 'approved'
+         and ms.asset_policy = $10::jsonb
+         and ca.state = 'available' and ca.checksum = $11`,
+      [
+        entry.sourceRecordLink.entityType,
+        entry.sourceRecordLink.entityId,
+        entry.proposal.workId,
+        entry.coverProjectionHead.projectionId,
+        entry.coverCandidate.id,
+        entry.coverProjections[0].id,
+        entry.coverDecisions[1].reviewerRef,
+        entry.coverDecisions[0].id,
+        entry.coverInspection.checksum,
+        rows.metadataSource.assetPolicy,
+        entry.coverAsset.checksum,
+      ],
+    );
+    if (!eligible[0]) {
+      throw new Error(
+        `Catalog cover promotion refused: source, identity, rights, withdrawal, quality, or review eligibility drifted for ${entry.proposal.title}`,
+      );
+    }
+  }
+  return { changed, projectionIds: projectionIds.sort() };
 };
 
 const postgresProtectedHash = async (
@@ -554,7 +1152,8 @@ const postgresProtectedHash = async (
        from edition_covers order by edition_id, position, cover_asset_id`,
     ),
     sql.unsafe(
-      `select id, object_key, state, checksum from cover_assets order by id`,
+      `select id, object_key, state, checksum from cover_assets
+       where object_key not like '/covers/issue-143-%' order by id`,
     ),
     sql.unsafe(
       `select id, preferred_title, sort_title, description, preferred_edition_id
@@ -578,35 +1177,32 @@ const postgresProtectedHash = async (
 const postgresProjectionHash = async (
   sql: postgres.TransactionSql,
 ): Promise<string> =>
-  hashCanonicalJson([
-    ...(await sql.unsafe(
-      `select id, first_publication_date, first_publication_precision,
+  hashCanonicalJson({
+    works: [
+      ...(await sql.unsafe(
+        `select id, first_publication_date, first_publication_precision,
               first_publication_sort_date from works order by id`,
-    )),
-  ]);
+      )),
+    ],
+    covers: [
+      ...(await sql.unsafe(
+        `select h.work_id, h.projection_id, p.candidate_id, p.state,
+                c.object_key
+         from cover_projection_heads h
+         join cover_projections p on p.id = h.projection_id
+         left join cover_candidates c on c.id = p.candidate_id
+         order by h.work_id`,
+      )),
+    ],
+  });
 
 export const promoteDiagnosticFivePostgres = async (
   url: string,
   input: DiagnosticFivePromotionInput,
 ): Promise<DiagnosticFivePromotionResult> => {
-  if (input.executionTarget !== "disposable") {
-    throw new Error(
-      "Catalog promotion refused: production database execution is not approved",
-    );
-  }
-  const databaseName = decodeURIComponent(new URL(url).pathname)
-    .replace(/^\/+/u, "")
-    .toLowerCase();
-  if (
-    !/(?:^|[-_])(test|testing|isolated|disposable|issue[-_]?143)(?:$|[-_])/u.test(
-      databaseName,
-    )
-  ) {
-    throw new Error(
-      "Catalog promotion refused: production database execution is not approved",
-    );
-  }
+  assertPostgresExecutionTarget(url, input);
   verifyApprovedPromotionReport(input.reportBytes, input);
+  assertExactCoverProposalAllowlist(input.coverProposalIds ?? []);
   if (!input.actorRef.trim()) {
     throw new Error("Catalog promotion refused: actor reference is required");
   }
@@ -614,6 +1210,7 @@ export const promoteDiagnosticFivePostgres = async (
   try {
     return await client.begin(async (sql) => {
       verifyApprovedPromotionReport(input.reportBytes, input);
+      assertExactCoverProposalAllowlist(input.coverProposalIds ?? []);
       const rows = promotionEvidenceRows();
       assertPromotionEvidenceEligibility(rows);
       const protectedBefore = await postgresProtectedHash(sql);
@@ -744,13 +1341,17 @@ export const promoteDiagnosticFivePostgres = async (
           );
         }
       }
+      const coverResult = await persistAndRevalidateCoversPostgres(
+        sql,
+        input.coverProposalIds ?? [],
+      );
       if (input.failAfter === "evidence") {
         throw new Error(
           "Forced diagnostic-five promotion failure after evidence",
         );
       }
       const resolutionIds: string[] = [];
-      let changed = false;
+      let changed = coverResult.changed;
       for (const entry of rows.entries) {
         const workRows = await sql.unsafe<
           Array<{ title: string; firstPublicationDate: string | null }>
@@ -885,6 +1486,7 @@ export const promoteDiagnosticFivePostgres = async (
       return {
         changed,
         resolutionIds: resolutionIds.sort(),
+        coverProjectionIds: coverResult.projectionIds,
         publicProjectionHash: await postgresProjectionHash(sql),
       };
     });
@@ -893,33 +1495,98 @@ export const promoteDiagnosticFivePostgres = async (
   }
 };
 
+const rollbackDiagnosticCoversPostgres = async (
+  sql: postgres.TransactionSql,
+  input: {
+    actorRef: string;
+    reason: string;
+    rolledBackAt: number;
+  },
+): Promise<{ changed: boolean; projectionIds: string[] }> => {
+  const rows = diagnosticFiveCoverRows(await coverCatalogPostgres(sql));
+  let changed = false;
+  const projectionIds: string[] = [];
+  for (const entry of rows.entries) {
+    const currentRows = await sql.unsafe<
+      Array<{
+        id: string;
+        candidateId: string | null;
+        state: string;
+        policyVersion: string;
+      }>
+    >(
+      `select p.id, p.candidate_id as "candidateId", p.state,
+              p.policy_version as "policyVersion"
+       from cover_projection_heads h
+       join cover_projections p on p.id = h.projection_id
+       where h.work_id = $1 for update`,
+      [entry.proposal.workId],
+    );
+    const current = currentRows[0];
+    if (
+      current?.state === "placeholder" &&
+      current.policyVersion === `${COVER_POLICY_VERSION}:rollback`
+    ) {
+      projectionIds.push(current.id);
+      continue;
+    }
+    if (
+      current?.state !== "selected" ||
+      current.candidateId !== entry.coverCandidate.id
+    ) {
+      throw new Error(
+        `Catalog cover rollback refused: current projection drifted for ${entry.proposal.title}`,
+      );
+    }
+    const id = deterministicCatalogId(
+      "cover_projection",
+      entry.proposal.workId,
+      hashCanonicalJson({
+        currentProjectionId: current.id,
+        policyVersion: `${COVER_POLICY_VERSION}:rollback`,
+        reason: input.reason,
+        state: "placeholder",
+      }),
+    );
+    await sql.unsafe(
+      `insert into cover_projections (
+         id, work_id, candidate_id, state, previous_projection_id,
+         reason_code, actor_ref, policy_version, projected_at
+       ) values ($1,$2,null,'placeholder',$3,$4,$5,$6,$7)
+       on conflict(id) do nothing`,
+      [
+        id,
+        entry.proposal.workId,
+        current.id,
+        input.reason,
+        input.actorRef,
+        `${COVER_POLICY_VERSION}:rollback`,
+        input.rolledBackAt,
+      ],
+    );
+    await sql.unsafe(
+      `update cover_projection_heads set projection_id = $1
+       where work_id = $2 and projection_id = $3`,
+      [id, entry.proposal.workId, current.id],
+    );
+    projectionIds.push(id);
+    changed = true;
+  }
+  return { changed, projectionIds: projectionIds.sort() };
+};
+
 export const rollbackDiagnosticFivePostgres = async (
   url: string,
   input: {
     actorRef: string;
     reason: string;
-    executionTarget: "disposable";
+    executionTarget: "disposable" | "preview";
+    previewTarget?: DiagnosticFivePromotionInput["previewTarget"];
     rolledBackAt?: number;
     failAfter?: "resolution";
   },
 ): Promise<DiagnosticFivePromotionResult> => {
-  if (input.executionTarget !== "disposable") {
-    throw new Error(
-      "Catalog rollback refused: production database execution is not approved",
-    );
-  }
-  const databaseName = decodeURIComponent(new URL(url).pathname)
-    .replace(/^\/+/u, "")
-    .toLowerCase();
-  if (
-    !/(?:^|[-_])(test|testing|isolated|disposable|issue[-_]?143)(?:$|[-_])/u.test(
-      databaseName,
-    )
-  ) {
-    throw new Error(
-      "Catalog rollback refused: production database execution is not approved",
-    );
-  }
+  assertPostgresExecutionTarget(url, input);
   if (!input.actorRef.trim() || !input.reason.trim()) {
     throw new Error("Catalog rollback refused: actor and reason are required");
   }
@@ -1026,6 +1693,12 @@ export const rollbackDiagnosticFivePostgres = async (
         resolutionIds.push(resolutionId);
         changed = true;
       }
+      const coverRollback = await rollbackDiagnosticCoversPostgres(sql, {
+        actorRef: input.actorRef,
+        reason: input.reason,
+        rolledBackAt: input.rolledBackAt ?? Date.now(),
+      });
+      changed ||= coverRollback.changed;
       if (input.failAfter === "resolution") {
         throw new Error(
           "Forced diagnostic-five rollback failure after resolution",
@@ -1039,6 +1712,7 @@ export const rollbackDiagnosticFivePostgres = async (
       return {
         changed,
         resolutionIds: resolutionIds.sort(),
+        coverProjectionIds: coverRollback.projectionIds,
         publicProjectionHash: await postgresProjectionHash(sql),
       };
     });

--- a/src/db/catalog/enrichment/diagnostic-five-promotion-repository.ts
+++ b/src/db/catalog/enrichment/diagnostic-five-promotion-repository.ts
@@ -980,7 +980,19 @@ const persistAndRevalidateCoversPostgres = async (
        refresh_interval_ms
      ) values ($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9::jsonb,$10,$11)
      on conflict(id) do nothing`,
-    Object.values(rows.metadataSource),
+    [
+      rows.metadataSource.id,
+      rows.metadataSource.key,
+      rows.metadataSource.name,
+      rows.metadataSource.termsUrl,
+      rows.metadataSource.attributionUrl,
+      rows.metadataSource.reviewedAt,
+      rows.metadataSource.approvalState,
+      JSON.parse(rows.metadataSource.metadataPolicy),
+      JSON.parse(rows.metadataSource.assetPolicy),
+      rows.metadataSource.payloadPolicy,
+      rows.metadataSource.refreshIntervalMs,
+    ],
   );
 
   let changed = false;
@@ -993,7 +1005,19 @@ const persistAndRevalidateCoversPostgres = async (
          source_row_hash, state
        ) values ($1,$2,$3,$4,$5,$6,$7::jsonb,$8,$9,$10,$11)
        on conflict(id) do nothing`,
-      Object.values(entry.sourceRecord),
+      [
+        entry.sourceRecord.id,
+        entry.sourceRecord.sourceId,
+        entry.sourceRecord.recordKey,
+        entry.sourceRecord.sourceRevision,
+        entry.sourceRecord.sourceModifiedAt,
+        entry.sourceRecord.retrievedAt,
+        JSON.parse(entry.sourceRecord.payloadJson),
+        entry.sourceRecord.payloadHash,
+        entry.sourceRecord.importerVersion,
+        entry.sourceRecord.sourceRowHash,
+        entry.sourceRecord.state,
+      ],
     );
     await sql.unsafe(
       `insert into source_record_links (
@@ -1022,7 +1046,25 @@ const persistAndRevalidateCoversPostgres = async (
          $1,$2,$3,$4,$5,$6,$7::jsonb,$8,$9,$10,$11,$12,$13,$14,$15,
          $16::jsonb,$17
        ) on conflict(id) do nothing`,
-      Object.values(entry.coverCandidate),
+      [
+        entry.coverCandidate.id,
+        entry.coverCandidate.workId,
+        entry.coverCandidate.editionId,
+        entry.coverCandidate.sourceRecordId,
+        entry.coverCandidate.representationType,
+        entry.coverCandidate.identityMatchKind,
+        JSON.parse(entry.coverCandidate.identityEvidenceJson),
+        entry.coverCandidate.permissionState,
+        entry.coverCandidate.rightsBasis,
+        entry.coverCandidate.attributionText,
+        entry.coverCandidate.attributionUrl,
+        entry.coverCandidate.sourceUrl,
+        entry.coverCandidate.sourceRevision,
+        entry.coverCandidate.sourcePolicyVersion,
+        entry.coverCandidate.objectKey,
+        JSON.parse(entry.coverCandidate.transformationHistoryJson),
+        entry.coverCandidate.createdAt,
+      ],
     );
     await sql.unsafe(
       `insert into cover_inspections (
@@ -1031,7 +1073,22 @@ const persistAndRevalidateCoversPostgres = async (
          duplicate_of_candidate_id, inspection_version, inspected_at
        ) values ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10::jsonb,$11,$12,$13,$14)
        on conflict(id) do nothing`,
-      Object.values(entry.coverInspection),
+      [
+        entry.coverInspection.id,
+        entry.coverInspection.candidateId,
+        entry.coverInspection.mediaType,
+        entry.coverInspection.byteSize,
+        entry.coverInspection.width,
+        entry.coverInspection.height,
+        entry.coverInspection.aspectRatio,
+        entry.coverInspection.checksum,
+        entry.coverInspection.decodeResult,
+        JSON.parse(entry.coverInspection.flagsJson),
+        entry.coverInspection.qualityScore,
+        entry.coverInspection.duplicateOfCandidateId,
+        entry.coverInspection.inspectionVersion,
+        entry.coverInspection.inspectedAt,
+      ],
     );
     for (const decision of entry.coverDecisions) {
       await sql.unsafe(
@@ -1042,7 +1099,20 @@ const persistAndRevalidateCoversPostgres = async (
          ) values (
            $1,$2,$3,$4,$5::jsonb,$6::jsonb,$7,$8,$9,$10,$11,$12
          ) on conflict(id) do nothing`,
-        Object.values(decision),
+        [
+          decision.id,
+          decision.candidateId,
+          decision.inspectionId,
+          decision.state,
+          JSON.parse(decision.gateCodesJson),
+          JSON.parse(decision.warningCodesJson),
+          decision.reviewerRef,
+          decision.reviewReason,
+          decision.purgeState,
+          decision.previousDecisionId,
+          decision.policyVersion,
+          decision.decidedAt,
+        ],
       );
     }
     const currentDecisionHeads = await sql.unsafe<Array<{ id: string }>>(

--- a/src/db/catalog/enrichment/diagnostic-five-promotion-repository.ts
+++ b/src/db/catalog/enrichment/diagnostic-five-promotion-repository.ts
@@ -1,0 +1,1032 @@
+import type Database from "better-sqlite3";
+import postgres from "postgres";
+import {
+  canonicalJson,
+  deterministicCatalogId,
+  hashCanonicalJson,
+} from "../identity";
+import { sourcePolicyAllowsFieldDisplay } from "../policy-eligibility";
+import {
+  APPROVED_PROMOTION_PROPOSALS,
+  assertPromotionEvidenceEligibility,
+  DIAGNOSTIC_FIVE_PROMOTION_VERSION,
+  promotionEvidenceRows,
+  verifyApprovedPromotionReport,
+} from "./diagnostic-five-promotion";
+
+type SqliteDatabase = InstanceType<typeof Database>;
+
+export type DiagnosticFivePromotionInput = {
+  reportBytes: Uint8Array;
+  approvalId: string;
+  proposalIds: readonly string[];
+  actorRef: string;
+  executionTarget: "disposable";
+  promotedAt?: number;
+  failAfter?: "evidence" | "resolution";
+};
+
+export type DiagnosticFivePromotionResult = {
+  changed: boolean;
+  resolutionIds: readonly string[];
+  publicProjectionHash: string;
+};
+
+type CurrentResolution = {
+  id: string;
+  selectedObservationId: string | null;
+  state: string;
+  resolverVersion: string;
+};
+
+const FIELD_KEY = "work.first_publication_date";
+
+const protectedSqliteHash = (raw: SqliteDatabase): string =>
+  hashCanonicalJson({
+    covers: raw
+      .prepare(
+        `select edition_id, cover_asset_id, position, is_primary
+         from edition_covers order by edition_id, position, cover_asset_id`,
+      )
+      .all(),
+    coverAssets: raw
+      .prepare(
+        `select id, object_key, state, checksum from cover_assets order by id`,
+      )
+      .all(),
+    descriptions: raw
+      .prepare(
+        `select id, preferred_title, sort_title, description, preferred_edition_id
+         from works order by id`,
+      )
+      .all(),
+    otherHeads: raw
+      .prepare(
+        `select entity_type, entity_id, field_key, resolution_id
+         from field_resolution_heads
+         where field_key <> 'work.first_publication_date'
+         order by entity_type, entity_id, field_key`,
+      )
+      .all(),
+  });
+
+const publicProjectionSqliteHash = (raw: SqliteDatabase): string =>
+  hashCanonicalJson(
+    raw
+      .prepare(
+        `select id, first_publication_date, first_publication_precision,
+                first_publication_sort_date
+         from works order by id`,
+      )
+      .all(),
+  );
+
+const assertExactSqliteRow = (
+  raw: SqliteDatabase,
+  statement: string,
+  parameters: readonly unknown[],
+  message: string,
+): void => {
+  const row = raw.prepare(statement).get(...parameters);
+  if (!row) throw new Error(`Catalog promotion refused: ${message}`);
+};
+
+const currentResolutionSqlite = (
+  raw: SqliteDatabase,
+  workId: string,
+): CurrentResolution | undefined =>
+  raw
+    .prepare(
+      `select r.id,
+              r.selected_observation_id as "selectedObservationId",
+              r.state,
+              r.resolver_version as "resolverVersion"
+       from field_resolution_heads h
+       join field_resolutions r on r.id = h.resolution_id
+       where h.entity_type = 'work' and h.entity_id = ?
+         and h.field_key = 'work.first_publication_date'`,
+    )
+    .get(workId) as CurrentResolution | undefined;
+
+const ensureCurrentResolutionSqlite = (
+  raw: SqliteDatabase,
+  workId: string,
+  createdAt: number,
+): CurrentResolution => {
+  const existing = currentResolutionSqlite(raw, workId);
+  if (existing) return existing;
+  const id = deterministicCatalogId(
+    "field_resolution",
+    `${DIAGNOSTIC_FIVE_PROMOTION_VERSION}:baseline`,
+    workId,
+  );
+  raw
+    .prepare(
+      `insert into field_resolutions (
+         id, entity_type, entity_id, field_key, selected_observation_id,
+         state, reason, previous_resolution_id, actor_ref,
+         resolver_version, resolved_at
+       ) values (?, 'work', ?, ?, null, 'missing', ?, null, ?, ?, ?)`,
+    )
+    .run(
+      id,
+      workId,
+      FIELD_KEY,
+      "No eligible approved observation before issue #143 promotion",
+      "system:catalog-promotion",
+      `${DIAGNOSTIC_FIVE_PROMOTION_VERSION}:baseline`,
+      createdAt,
+    );
+  raw
+    .prepare(
+      `insert into field_resolution_heads (
+         entity_type, entity_id, field_key, resolution_id
+       ) values ('work', ?, ?, ?)`,
+    )
+    .run(workId, FIELD_KEY, id);
+  return {
+    id,
+    selectedObservationId: null,
+    state: "missing",
+    resolverVersion: `${DIAGNOSTIC_FIVE_PROMOTION_VERSION}:baseline`,
+  };
+};
+
+const nextResolutionId = (
+  previousResolutionId: string,
+  proposalId: string,
+  selectedObservationId: string,
+): string =>
+  deterministicCatalogId(
+    "field_resolution",
+    DIAGNOSTIC_FIVE_PROMOTION_VERSION,
+    hashCanonicalJson({
+      previousResolutionId,
+      proposalId,
+      selectedObservationId,
+    }),
+  );
+
+const persistAndRevalidateSqlite = (
+  raw: SqliteDatabase,
+): ReturnType<typeof promotionEvidenceRows> => {
+  const rows = promotionEvidenceRows();
+  assertPromotionEvidenceEligibility(rows);
+  raw
+    .prepare(
+      `insert into metadata_sources (
+         id, key, name, terms_url, attribution_url, reviewed_at,
+         approval_state, metadata_policy, asset_policy, payload_policy,
+         refresh_interval_ms
+       ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       on conflict(id) do nothing`,
+    )
+    .run(...Object.values(rows.metadataSource));
+  for (const entry of rows.entries) {
+    raw
+      .prepare(
+        `insert into source_records (
+           id, source_id, record_key, source_revision, source_modified_at,
+           retrieved_at, payload_json, payload_hash, importer_version,
+           source_row_hash, state
+         ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         on conflict(id) do nothing`,
+      )
+      .run(...Object.values(entry.sourceRecord));
+    raw
+      .prepare(
+        `insert into source_record_links (
+           source_record_id, entity_type, entity_id, match_kind,
+           mapping_confidence, state, actor_ref, reason, created_at
+         ) values (?, ?, ?, ?, ?, ?, ?, ?, ?)
+         on conflict(source_record_id, entity_type, entity_id) do nothing`,
+      )
+      .run(...Object.values(entry.sourceRecordLink));
+    raw
+      .prepare(
+        `insert into field_observations (
+           id, source_record_id, entity_type, entity_id, field_key,
+           value_json, comparison_hash, provenance_kind, source_path,
+           source_modified_at, retrieved_at, mapping_confidence, state,
+           actor_ref, reason, derivation_name, derivation_version,
+           parent_ids_json
+         ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         on conflict(id) do nothing`,
+      )
+      .run(...Object.values(entry.fieldObservation));
+  }
+
+  const source = raw
+    .prepare(
+      `select approval_state as "approvalState",
+              metadata_policy as "metadataPolicy",
+              asset_policy as "assetPolicy"
+       from metadata_sources where id = ?`,
+    )
+    .get(rows.metadataSource.id) as
+    | {
+        approvalState: string;
+        metadataPolicy: string;
+        assetPolicy: string;
+      }
+    | undefined;
+  if (
+    source?.approvalState !== "approved" ||
+    canonicalJson(JSON.parse(source.metadataPolicy)) !==
+      canonicalJson(JSON.parse(rows.metadataSource.metadataPolicy)) ||
+    canonicalJson(JSON.parse(source.assetPolicy)) !==
+      canonicalJson(JSON.parse(rows.metadataSource.assetPolicy)) ||
+    !sourcePolicyAllowsFieldDisplay(source.metadataPolicy, FIELD_KEY) ||
+    sourcePolicyAllowsFieldDisplay(source.assetPolicy, "edition.covers")
+  ) {
+    throw new Error(
+      "Catalog promotion refused: source policy or rights eligibility drifted",
+    );
+  }
+  for (const entry of rows.entries) {
+    assertExactSqliteRow(
+      raw,
+      `select 1
+       from source_records sr
+       join source_record_links sl on sl.source_record_id = sr.id
+       join field_observations o on o.source_record_id = sr.id
+       where sr.id = ? and sr.source_id = ? and sr.source_revision = ?
+         and sr.payload_json = ? and sr.payload_hash = ?
+         and sr.source_row_hash = ? and sr.state = 'active'
+         and sl.entity_type = 'work' and sl.entity_id = ?
+         and sl.match_kind = 'source_relationship'
+         and sl.mapping_confidence = 1 and sl.state = 'active'
+         and sl.actor_ref = ? and sl.reason = ?
+         and o.id = ? and o.entity_id = ? and o.field_key = ?
+         and o.value_json = ? and o.comparison_hash = ?
+         and o.provenance_kind = ? and o.source_path = ?
+         and o.mapping_confidence = 1
+         and o.state = 'active'`,
+      [
+        entry.sourceRecord.id,
+        entry.sourceRecord.sourceId,
+        entry.sourceRecord.sourceRevision,
+        entry.sourceRecord.payloadJson,
+        entry.sourceRecord.payloadHash,
+        entry.sourceRecord.sourceRowHash,
+        entry.proposal.workId,
+        entry.sourceRecordLink.actorRef,
+        entry.sourceRecordLink.reason,
+        entry.fieldObservation.id,
+        entry.proposal.workId,
+        FIELD_KEY,
+        entry.fieldObservation.valueJson,
+        entry.fieldObservation.comparisonHash,
+        entry.fieldObservation.provenanceKind,
+        entry.fieldObservation.sourcePath,
+      ],
+      `identity, withdrawal, quality, or observation eligibility drifted for ${entry.proposal.title}`,
+    );
+  }
+  return rows;
+};
+
+export const promoteDiagnosticFiveSqlite = (
+  raw: SqliteDatabase,
+  input: DiagnosticFivePromotionInput,
+): DiagnosticFivePromotionResult => {
+  if (input.executionTarget !== "disposable") {
+    throw new Error(
+      "Catalog promotion refused: production database execution is not approved",
+    );
+  }
+  verifyApprovedPromotionReport(input.reportBytes, input);
+  if (!input.actorRef.trim()) {
+    throw new Error("Catalog promotion refused: actor reference is required");
+  }
+  const protectedBefore = protectedSqliteHash(raw);
+  const apply = raw.transaction(() => {
+    // Approval and allow-list are deliberately checked again after the write
+    // transaction begins so callers cannot swap mutable input between checks.
+    verifyApprovedPromotionReport(input.reportBytes, input);
+    const rows = persistAndRevalidateSqlite(raw);
+    if (input.failAfter === "evidence") {
+      throw new Error(
+        "Forced diagnostic-five promotion failure after evidence",
+      );
+    }
+    const resolutionIds: string[] = [];
+    let changed = false;
+    for (const entry of rows.entries) {
+      const work = raw
+        .prepare(
+          `select preferred_title as title, description,
+                  first_publication_date as "firstPublicationDate"
+           from works where id = ?`,
+        )
+        .get(entry.proposal.workId) as
+        | {
+            title: string;
+            description: string | null;
+            firstPublicationDate: string | null;
+          }
+        | undefined;
+      if (!work || work.title !== entry.proposal.title) {
+        throw new Error(
+          `Catalog promotion refused: work identity drifted for ${entry.proposal.title}`,
+        );
+      }
+      const current = ensureCurrentResolutionSqlite(
+        raw,
+        entry.proposal.workId,
+        input.promotedAt ?? Date.now(),
+      );
+      if (
+        current.resolverVersion === DIAGNOSTIC_FIVE_PROMOTION_VERSION &&
+        current.selectedObservationId === entry.fieldObservation.id &&
+        current.state === "present"
+      ) {
+        if (work.firstPublicationDate !== entry.proposal.value.date) {
+          throw new Error(
+            `Catalog promotion refused: projection drifted for ${entry.proposal.title}`,
+          );
+        }
+        resolutionIds.push(current.id);
+        continue;
+      }
+      const resolutionId = nextResolutionId(
+        current.id,
+        entry.proposal.proposalId,
+        entry.fieldObservation.id,
+      );
+      raw
+        .prepare(
+          `insert into field_resolutions (
+             id, entity_type, entity_id, field_key, selected_observation_id,
+             state, reason, previous_resolution_id, actor_ref,
+             resolver_version, resolved_at
+           ) values (?, 'work', ?, ?, ?, 'present', ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          resolutionId,
+          entry.proposal.workId,
+          FIELD_KEY,
+          entry.fieldObservation.id,
+          `Explicitly reviewed issue #143 proposal ${entry.proposal.proposalId}`,
+          current.id,
+          input.actorRef,
+          DIAGNOSTIC_FIVE_PROMOTION_VERSION,
+          input.promotedAt ?? Date.now(),
+        );
+      raw
+        .prepare(
+          `update field_resolution_heads set resolution_id = ?
+           where entity_type = 'work' and entity_id = ? and field_key = ?`,
+        )
+        .run(resolutionId, entry.proposal.workId, FIELD_KEY);
+      raw
+        .prepare(
+          `update works set first_publication_date = ?,
+                            first_publication_precision = 'year',
+                            first_publication_sort_date = ?,
+                            updated_at = ?
+           where id = ?`,
+        )
+        .run(
+          entry.proposal.value.date,
+          `${entry.proposal.value.date}-01-01`,
+          input.promotedAt ?? Date.now(),
+          entry.proposal.workId,
+        );
+      resolutionIds.push(resolutionId);
+      changed = true;
+    }
+    if (input.failAfter === "resolution") {
+      throw new Error(
+        "Forced diagnostic-five promotion failure after resolution",
+      );
+    }
+    if (protectedSqliteHash(raw) !== protectedBefore) {
+      throw new Error(
+        "Catalog promotion isolation failed: a non-approved public projection changed",
+      );
+    }
+    return {
+      changed,
+      resolutionIds: resolutionIds.sort(),
+      publicProjectionHash: publicProjectionSqliteHash(raw),
+    };
+  });
+  return apply.immediate();
+};
+
+export const rollbackDiagnosticFiveSqlite = (
+  raw: SqliteDatabase,
+  input: {
+    actorRef: string;
+    reason: string;
+    executionTarget: "disposable";
+    rolledBackAt?: number;
+    failAfter?: "resolution";
+  },
+): DiagnosticFivePromotionResult => {
+  if (input.executionTarget !== "disposable") {
+    throw new Error(
+      "Catalog rollback refused: production database execution is not approved",
+    );
+  }
+  if (!input.actorRef.trim() || !input.reason.trim()) {
+    throw new Error("Catalog rollback refused: actor and reason are required");
+  }
+  const protectedBefore = protectedSqliteHash(raw);
+  return raw
+    .transaction(() => {
+      const resolutionIds: string[] = [];
+      let changed = false;
+      for (const proposal of APPROVED_PROMOTION_PROPOSALS) {
+        const current = currentResolutionSqlite(raw, proposal.workId);
+        if (!current) {
+          throw new Error(
+            `Catalog rollback refused: current promotion head missing for ${proposal.title}`,
+          );
+        }
+        if (
+          current.resolverVersion ===
+          `${DIAGNOSTIC_FIVE_PROMOTION_VERSION}:rollback`
+        ) {
+          resolutionIds.push(current.id);
+          continue;
+        }
+        if (
+          current.resolverVersion !== DIAGNOSTIC_FIVE_PROMOTION_VERSION ||
+          !current.selectedObservationId
+        ) {
+          throw new Error(
+            `Catalog rollback refused: current promotion head drifted for ${proposal.title}`,
+          );
+        }
+        const prior = raw
+          .prepare(
+            `select p.id, p.state,
+                    p.selected_observation_id as "selectedObservationId"
+             from field_resolutions c
+             join field_resolutions p on p.id = c.previous_resolution_id
+             where c.id = ?`,
+          )
+          .get(current.id) as
+          | { id: string; state: string; selectedObservationId: string | null }
+          | undefined;
+        if (
+          !prior ||
+          prior.selectedObservationId !== null ||
+          prior.state !== "missing"
+        ) {
+          throw new Error(
+            `Catalog rollback refused: retained prior head is not the reviewed missing state for ${proposal.title}`,
+          );
+        }
+        const resolutionId = deterministicCatalogId(
+          "field_resolution",
+          `${DIAGNOSTIC_FIVE_PROMOTION_VERSION}:rollback`,
+          hashCanonicalJson({
+            currentResolutionId: current.id,
+            priorResolutionId: prior.id,
+            reason: input.reason,
+          }),
+        );
+        raw
+          .prepare(
+            `insert into field_resolutions (
+               id, entity_type, entity_id, field_key,
+               selected_observation_id, state, reason,
+               previous_resolution_id, actor_ref, resolver_version,
+               resolved_at
+             ) values (?, 'work', ?, ?, null, 'missing', ?, ?, ?, ?, ?)`,
+          )
+          .run(
+            resolutionId,
+            proposal.workId,
+            FIELD_KEY,
+            input.reason,
+            current.id,
+            input.actorRef,
+            `${DIAGNOSTIC_FIVE_PROMOTION_VERSION}:rollback`,
+            input.rolledBackAt ?? Date.now(),
+          );
+        raw
+          .prepare(
+            `update field_resolution_heads set resolution_id = ?
+             where entity_type = 'work' and entity_id = ? and field_key = ?`,
+          )
+          .run(resolutionId, proposal.workId, FIELD_KEY);
+        raw
+          .prepare(
+            `update works set first_publication_date = null,
+                              first_publication_precision = null,
+                              first_publication_sort_date = null,
+                              updated_at = ?
+             where id = ?`,
+          )
+          .run(input.rolledBackAt ?? Date.now(), proposal.workId);
+        resolutionIds.push(resolutionId);
+        changed = true;
+      }
+      if (input.failAfter === "resolution") {
+        throw new Error(
+          "Forced diagnostic-five rollback failure after resolution",
+        );
+      }
+      if (protectedSqliteHash(raw) !== protectedBefore) {
+        throw new Error(
+          "Catalog rollback isolation failed: a non-approved public projection changed",
+        );
+      }
+      return {
+        changed,
+        resolutionIds: resolutionIds.sort(),
+        publicProjectionHash: publicProjectionSqliteHash(raw),
+      };
+    })
+    .immediate();
+};
+
+const postgresProtectedHash = async (
+  sql: postgres.TransactionSql,
+): Promise<string> => {
+  const [covers, coverAssets, descriptions, otherHeads] = await Promise.all([
+    sql.unsafe(
+      `select edition_id, cover_asset_id, position, is_primary
+       from edition_covers order by edition_id, position, cover_asset_id`,
+    ),
+    sql.unsafe(
+      `select id, object_key, state, checksum from cover_assets order by id`,
+    ),
+    sql.unsafe(
+      `select id, preferred_title, sort_title, description, preferred_edition_id
+       from works order by id`,
+    ),
+    sql.unsafe(
+      `select entity_type, entity_id, field_key, resolution_id
+       from field_resolution_heads
+       where field_key <> 'work.first_publication_date'
+       order by entity_type, entity_id, field_key`,
+    ),
+  ]);
+  return hashCanonicalJson({
+    covers: [...covers],
+    coverAssets: [...coverAssets],
+    descriptions: [...descriptions],
+    otherHeads: [...otherHeads],
+  });
+};
+
+const postgresProjectionHash = async (
+  sql: postgres.TransactionSql,
+): Promise<string> =>
+  hashCanonicalJson([
+    ...(await sql.unsafe(
+      `select id, first_publication_date, first_publication_precision,
+              first_publication_sort_date from works order by id`,
+    )),
+  ]);
+
+export const promoteDiagnosticFivePostgres = async (
+  url: string,
+  input: DiagnosticFivePromotionInput,
+): Promise<DiagnosticFivePromotionResult> => {
+  if (input.executionTarget !== "disposable") {
+    throw new Error(
+      "Catalog promotion refused: production database execution is not approved",
+    );
+  }
+  const databaseName = decodeURIComponent(new URL(url).pathname)
+    .replace(/^\/+/u, "")
+    .toLowerCase();
+  if (
+    !/(?:^|[-_])(test|testing|isolated|disposable|issue[-_]?143)(?:$|[-_])/u.test(
+      databaseName,
+    )
+  ) {
+    throw new Error(
+      "Catalog promotion refused: production database execution is not approved",
+    );
+  }
+  verifyApprovedPromotionReport(input.reportBytes, input);
+  if (!input.actorRef.trim()) {
+    throw new Error("Catalog promotion refused: actor reference is required");
+  }
+  const client = postgres(url, { max: 1 });
+  try {
+    return await client.begin(async (sql) => {
+      verifyApprovedPromotionReport(input.reportBytes, input);
+      const rows = promotionEvidenceRows();
+      assertPromotionEvidenceEligibility(rows);
+      const protectedBefore = await postgresProtectedHash(sql);
+      await sql.unsafe(
+        `insert into metadata_sources (
+           id, key, name, terms_url, attribution_url, reviewed_at,
+           approval_state, metadata_policy, asset_policy, payload_policy,
+           refresh_interval_ms
+         ) values ($1,$2,$3,$4,$5,to_timestamp($6 / 1000.0),$7,$8::jsonb,$9::jsonb,$10,$11)
+         on conflict(id) do nothing`,
+        Object.values(rows.metadataSource),
+      );
+      for (const entry of rows.entries) {
+        await sql.unsafe(
+          `insert into source_records (
+             id, source_id, record_key, source_revision, source_modified_at,
+             retrieved_at, payload_json, payload_hash, importer_version,
+             source_row_hash, state
+           ) values ($1,$2,$3,$4,null,to_timestamp($6 / 1000.0),$7::jsonb,$8,$9,$10,$11)
+           on conflict(id) do nothing`,
+          Object.values(entry.sourceRecord),
+        );
+        await sql.unsafe(
+          `insert into source_record_links (
+             source_record_id, entity_type, entity_id, match_kind,
+             mapping_confidence, state, actor_ref, reason, created_at
+           ) values ($1,$2,$3,$4,$5,$6,$7,$8,to_timestamp($9 / 1000.0))
+           on conflict(source_record_id, entity_type, entity_id) do nothing`,
+          Object.values(entry.sourceRecordLink),
+        );
+        const observation = Object.values(entry.fieldObservation);
+        await sql.unsafe(
+          `insert into field_observations (
+             id, source_record_id, entity_type, entity_id, field_key,
+             value_json, comparison_hash, provenance_kind, source_path,
+             source_modified_at, retrieved_at, mapping_confidence, state,
+             actor_ref, reason, derivation_name, derivation_version,
+             parent_ids_json
+           ) values (
+             $1,$2,$3,$4,$5,$6::jsonb,$7,$8,$9,null,
+             to_timestamp($11 / 1000.0),$12,$13,$14,$15,$16,$17,$18::jsonb
+           ) on conflict(id) do nothing`,
+          observation,
+        );
+      }
+      const sourceRows = await sql.unsafe<
+        Array<{
+          approvalState: string;
+          metadataPolicy: Record<string, unknown>;
+          assetPolicy: Record<string, unknown>;
+        }>
+      >(
+        `select approval_state as "approvalState",
+                metadata_policy as "metadataPolicy",
+                asset_policy as "assetPolicy"
+         from metadata_sources where id = $1`,
+        [rows.metadataSource.id],
+      );
+      const source = sourceRows[0];
+      if (
+        source?.approvalState !== "approved" ||
+        canonicalJson(source.metadataPolicy) !==
+          canonicalJson(JSON.parse(rows.metadataSource.metadataPolicy)) ||
+        canonicalJson(source.assetPolicy) !==
+          canonicalJson(JSON.parse(rows.metadataSource.assetPolicy)) ||
+        !sourcePolicyAllowsFieldDisplay(source.metadataPolicy, FIELD_KEY) ||
+        sourcePolicyAllowsFieldDisplay(source.assetPolicy, "edition.covers")
+      ) {
+        throw new Error(
+          "Catalog promotion refused: source policy or rights eligibility drifted",
+        );
+      }
+      for (const entry of rows.entries) {
+        const eligible = await sql.unsafe<Array<{ eligible: number }>>(
+          `select 1 as eligible
+           from source_records sr
+           join source_record_links sl on sl.source_record_id = sr.id
+           join field_observations o on o.source_record_id = sr.id
+           where sr.id = $1 and sr.source_id = $2
+             and sr.source_revision = $3 and sr.payload_json = $4::jsonb
+             and sr.payload_hash = $5 and sr.source_row_hash = $6
+             and sr.state = 'active'
+             and sl.entity_type = 'work' and sl.entity_id = $7
+             and sl.match_kind = 'source_relationship'
+             and sl.mapping_confidence = 1 and sl.state = 'active'
+             and sl.actor_ref = $8 and sl.reason = $9
+             and o.id = $10 and o.entity_id = $7 and o.field_key = $11
+             and o.value_json = $12::jsonb and o.comparison_hash = $13
+             and o.provenance_kind = $14 and o.source_path = $15
+             and o.mapping_confidence = 1 and o.state = 'active'`,
+          [
+            entry.sourceRecord.id,
+            entry.sourceRecord.sourceId,
+            entry.sourceRecord.sourceRevision,
+            entry.sourceRecord.payloadJson,
+            entry.sourceRecord.payloadHash,
+            entry.sourceRecord.sourceRowHash,
+            entry.proposal.workId,
+            entry.sourceRecordLink.actorRef,
+            entry.sourceRecordLink.reason,
+            entry.fieldObservation.id,
+            FIELD_KEY,
+            entry.fieldObservation.valueJson,
+            entry.fieldObservation.comparisonHash,
+            entry.fieldObservation.provenanceKind,
+            entry.fieldObservation.sourcePath,
+          ],
+        );
+        if (!eligible[0]) {
+          throw new Error(
+            `Catalog promotion refused: identity, withdrawal, quality, or observation eligibility drifted for ${entry.proposal.title}`,
+          );
+        }
+      }
+      if (input.failAfter === "evidence") {
+        throw new Error(
+          "Forced diagnostic-five promotion failure after evidence",
+        );
+      }
+      const resolutionIds: string[] = [];
+      let changed = false;
+      for (const entry of rows.entries) {
+        const workRows = await sql.unsafe<
+          Array<{ title: string; firstPublicationDate: string | null }>
+        >(
+          `select preferred_title as title,
+                  first_publication_date as "firstPublicationDate"
+           from works where id = $1 for update`,
+          [entry.proposal.workId],
+        );
+        if (workRows[0]?.title !== entry.proposal.title) {
+          throw new Error(
+            `Catalog promotion refused: work identity drifted for ${entry.proposal.title}`,
+          );
+        }
+        const currentRows = await sql.unsafe<CurrentResolution[]>(
+          `select r.id,
+                  r.selected_observation_id as "selectedObservationId",
+                  r.state, r.resolver_version as "resolverVersion"
+           from field_resolution_heads h
+           join field_resolutions r on r.id = h.resolution_id
+           where h.entity_type = 'work' and h.entity_id = $1
+             and h.field_key = $2 for update`,
+          [entry.proposal.workId, FIELD_KEY],
+        );
+        let current = currentRows[0];
+        if (!current) {
+          const baselineId = deterministicCatalogId(
+            "field_resolution",
+            `${DIAGNOSTIC_FIVE_PROMOTION_VERSION}:baseline`,
+            entry.proposal.workId,
+          );
+          await sql.unsafe(
+            `insert into field_resolutions (
+               id, entity_type, entity_id, field_key,
+               selected_observation_id, state, reason,
+               previous_resolution_id, actor_ref, resolver_version,
+               resolved_at
+             ) values (
+               $1,'work',$2,$3,null,'missing',$4,null,$5,$6,
+               to_timestamp($7 / 1000.0)
+             )`,
+            [
+              baselineId,
+              entry.proposal.workId,
+              FIELD_KEY,
+              "No eligible approved observation before issue #143 promotion",
+              "system:catalog-promotion",
+              `${DIAGNOSTIC_FIVE_PROMOTION_VERSION}:baseline`,
+              input.promotedAt ?? Date.now(),
+            ],
+          );
+          await sql.unsafe(
+            `insert into field_resolution_heads (
+               entity_type, entity_id, field_key, resolution_id
+             ) values ('work',$1,$2,$3)`,
+            [entry.proposal.workId, FIELD_KEY, baselineId],
+          );
+          current = {
+            id: baselineId,
+            selectedObservationId: null,
+            state: "missing",
+            resolverVersion: `${DIAGNOSTIC_FIVE_PROMOTION_VERSION}:baseline`,
+          };
+        }
+        if (
+          current.resolverVersion === DIAGNOSTIC_FIVE_PROMOTION_VERSION &&
+          current.selectedObservationId === entry.fieldObservation.id &&
+          current.state === "present"
+        ) {
+          if (workRows[0]?.firstPublicationDate !== entry.proposal.value.date) {
+            throw new Error(
+              `Catalog promotion refused: projection drifted for ${entry.proposal.title}`,
+            );
+          }
+          resolutionIds.push(current.id);
+          continue;
+        }
+        const resolutionId = nextResolutionId(
+          current.id,
+          entry.proposal.proposalId,
+          entry.fieldObservation.id,
+        );
+        await sql.unsafe(
+          `insert into field_resolutions (
+             id, entity_type, entity_id, field_key, selected_observation_id,
+             state, reason, previous_resolution_id, actor_ref,
+             resolver_version, resolved_at
+           ) values ($1,'work',$2,$3,$4,'present',$5,$6,$7,$8,to_timestamp($9 / 1000.0))`,
+          [
+            resolutionId,
+            entry.proposal.workId,
+            FIELD_KEY,
+            entry.fieldObservation.id,
+            `Explicitly reviewed issue #143 proposal ${entry.proposal.proposalId}`,
+            current.id,
+            input.actorRef,
+            DIAGNOSTIC_FIVE_PROMOTION_VERSION,
+            input.promotedAt ?? Date.now(),
+          ],
+        );
+        await sql.unsafe(
+          `update field_resolution_heads set resolution_id = $1
+           where entity_type = 'work' and entity_id = $2 and field_key = $3`,
+          [resolutionId, entry.proposal.workId, FIELD_KEY],
+        );
+        await sql.unsafe(
+          `update works set first_publication_date = $1,
+                            first_publication_precision = 'year',
+                            first_publication_sort_date = $2,
+                            updated_at = to_timestamp($3 / 1000.0)
+           where id = $4`,
+          [
+            entry.proposal.value.date,
+            `${entry.proposal.value.date}-01-01`,
+            input.promotedAt ?? Date.now(),
+            entry.proposal.workId,
+          ],
+        );
+        resolutionIds.push(resolutionId);
+        changed = true;
+      }
+      if (input.failAfter === "resolution") {
+        throw new Error(
+          "Forced diagnostic-five promotion failure after resolution",
+        );
+      }
+      if ((await postgresProtectedHash(sql)) !== protectedBefore) {
+        throw new Error(
+          "Catalog promotion isolation failed: a non-approved public projection changed",
+        );
+      }
+      return {
+        changed,
+        resolutionIds: resolutionIds.sort(),
+        publicProjectionHash: await postgresProjectionHash(sql),
+      };
+    });
+  } finally {
+    await client.end({ timeout: 5_000 });
+  }
+};
+
+export const rollbackDiagnosticFivePostgres = async (
+  url: string,
+  input: {
+    actorRef: string;
+    reason: string;
+    executionTarget: "disposable";
+    rolledBackAt?: number;
+    failAfter?: "resolution";
+  },
+): Promise<DiagnosticFivePromotionResult> => {
+  if (input.executionTarget !== "disposable") {
+    throw new Error(
+      "Catalog rollback refused: production database execution is not approved",
+    );
+  }
+  const databaseName = decodeURIComponent(new URL(url).pathname)
+    .replace(/^\/+/u, "")
+    .toLowerCase();
+  if (
+    !/(?:^|[-_])(test|testing|isolated|disposable|issue[-_]?143)(?:$|[-_])/u.test(
+      databaseName,
+    )
+  ) {
+    throw new Error(
+      "Catalog rollback refused: production database execution is not approved",
+    );
+  }
+  if (!input.actorRef.trim() || !input.reason.trim()) {
+    throw new Error("Catalog rollback refused: actor and reason are required");
+  }
+  const client = postgres(url, { max: 1 });
+  try {
+    return await client.begin(async (sql) => {
+      const protectedBefore = await postgresProtectedHash(sql);
+      const resolutionIds: string[] = [];
+      let changed = false;
+      for (const proposal of APPROVED_PROMOTION_PROPOSALS) {
+        const currentRows = await sql.unsafe<CurrentResolution[]>(
+          `select r.id,
+                  r.selected_observation_id as "selectedObservationId",
+                  r.state, r.resolver_version as "resolverVersion"
+           from field_resolution_heads h
+           join field_resolutions r on r.id = h.resolution_id
+           where h.entity_type = 'work' and h.entity_id = $1
+             and h.field_key = $2 for update`,
+          [proposal.workId, FIELD_KEY],
+        );
+        const current = currentRows[0];
+        if (
+          current?.resolverVersion ===
+          `${DIAGNOSTIC_FIVE_PROMOTION_VERSION}:rollback`
+        ) {
+          resolutionIds.push(current.id);
+          continue;
+        }
+        if (
+          current?.resolverVersion !== DIAGNOSTIC_FIVE_PROMOTION_VERSION ||
+          !current.selectedObservationId
+        ) {
+          throw new Error(
+            `Catalog rollback refused: current promotion head drifted for ${proposal.title}`,
+          );
+        }
+        const priorRows = await sql.unsafe<
+          Array<{
+            id: string;
+            state: string;
+            selectedObservationId: string | null;
+          }>
+        >(
+          `select p.id, p.state,
+                  p.selected_observation_id as "selectedObservationId"
+           from field_resolutions c
+           join field_resolutions p on p.id = c.previous_resolution_id
+           where c.id = $1`,
+          [current.id],
+        );
+        const prior = priorRows[0];
+        if (
+          !prior ||
+          prior.state !== "missing" ||
+          prior.selectedObservationId !== null
+        ) {
+          throw new Error(
+            `Catalog rollback refused: retained prior head is not the reviewed missing state for ${proposal.title}`,
+          );
+        }
+        const resolutionId = deterministicCatalogId(
+          "field_resolution",
+          `${DIAGNOSTIC_FIVE_PROMOTION_VERSION}:rollback`,
+          hashCanonicalJson({
+            currentResolutionId: current.id,
+            priorResolutionId: prior.id,
+            reason: input.reason,
+          }),
+        );
+        await sql.unsafe(
+          `insert into field_resolutions (
+             id, entity_type, entity_id, field_key,
+             selected_observation_id, state, reason,
+             previous_resolution_id, actor_ref, resolver_version,
+             resolved_at
+           ) values (
+             $1,'work',$2,$3,null,'missing',$4,$5,$6,$7,
+             to_timestamp($8 / 1000.0)
+           )`,
+          [
+            resolutionId,
+            proposal.workId,
+            FIELD_KEY,
+            input.reason,
+            current.id,
+            input.actorRef,
+            `${DIAGNOSTIC_FIVE_PROMOTION_VERSION}:rollback`,
+            input.rolledBackAt ?? Date.now(),
+          ],
+        );
+        await sql.unsafe(
+          `update field_resolution_heads set resolution_id = $1
+           where entity_type = 'work' and entity_id = $2 and field_key = $3`,
+          [resolutionId, proposal.workId, FIELD_KEY],
+        );
+        await sql.unsafe(
+          `update works set first_publication_date = null,
+                            first_publication_precision = null,
+                            first_publication_sort_date = null,
+                            updated_at = to_timestamp($1 / 1000.0)
+           where id = $2`,
+          [input.rolledBackAt ?? Date.now(), proposal.workId],
+        );
+        resolutionIds.push(resolutionId);
+        changed = true;
+      }
+      if (input.failAfter === "resolution") {
+        throw new Error(
+          "Forced diagnostic-five rollback failure after resolution",
+        );
+      }
+      if ((await postgresProtectedHash(sql)) !== protectedBefore) {
+        throw new Error(
+          "Catalog rollback isolation failed: a non-approved public projection changed",
+        );
+      }
+      return {
+        changed,
+        resolutionIds: resolutionIds.sort(),
+        publicProjectionHash: await postgresProjectionHash(sql),
+      };
+    });
+  } finally {
+    await client.end({ timeout: 5_000 });
+  }
+};

--- a/src/db/catalog/enrichment/diagnostic-five-promotion-repository.ts
+++ b/src/db/catalog/enrichment/diagnostic-five-promotion-repository.ts
@@ -36,7 +36,7 @@ export type DiagnosticFivePromotionInput = {
     vercelDeploymentId: string;
     gitBranch: "feat/catalog-enrichment-promotion";
     pullRequest: 144;
-    neonBranchId: string;
+    neonBranchId?: string;
     databaseHost: string;
   };
   promotedAt?: number;
@@ -59,7 +59,8 @@ type CurrentResolution = {
 
 const FIELD_KEY = "work.first_publication_date";
 
-const assertPostgresExecutionTarget = (
+// Distinct Neon branching is not required; neonBranchId is optional metadata.
+export const assertPostgresExecutionTarget = (
   url: string,
   input: Pick<
     DiagnosticFivePromotionInput,
@@ -89,7 +90,6 @@ const assertPostgresExecutionTarget = (
     proof.pullRequest !== 144 ||
     proof.gitBranch !== "feat/catalog-enrichment-promotion" ||
     !proof.vercelDeploymentId.trim() ||
-    !proof.neonBranchId.trim() ||
     proof.databaseHost !== parsed.hostname ||
     !parsed.hostname.endsWith(".neon.tech")
   ) {

--- a/src/db/catalog/enrichment/diagnostic-five-promotion-repository.ts
+++ b/src/db/catalog/enrichment/diagnostic-five-promotion-repository.ts
@@ -686,29 +686,18 @@ export const promoteDiagnosticFivePostgres = async (
           ],
         );
       }
-      const sourceRows = await sql.unsafe<
-        Array<{
-          approvalState: string;
-          metadataPolicy: Record<string, unknown>;
-          assetPolicy: Record<string, unknown>;
-        }>
-      >(
-        `select approval_state as "approvalState",
-                metadata_policy as "metadataPolicy",
-                asset_policy as "assetPolicy"
-         from metadata_sources where id = $1`,
-        [rows.metadataSource.id],
+      const sourceRows = await sql.unsafe<Array<{ eligible: number }>>(
+        `select 1 as eligible
+         from metadata_sources
+         where id = $1 and approval_state = 'approved'
+           and metadata_policy = $2::jsonb and asset_policy = $3::jsonb`,
+        [
+          rows.metadataSource.id,
+          rows.metadataSource.metadataPolicy,
+          rows.metadataSource.assetPolicy,
+        ],
       );
-      const source = sourceRows[0];
-      if (
-        source?.approvalState !== "approved" ||
-        canonicalJson(source.metadataPolicy) !==
-          canonicalJson(JSON.parse(rows.metadataSource.metadataPolicy)) ||
-        canonicalJson(source.assetPolicy) !==
-          canonicalJson(JSON.parse(rows.metadataSource.assetPolicy)) ||
-        !sourcePolicyAllowsFieldDisplay(source.metadataPolicy, FIELD_KEY) ||
-        sourcePolicyAllowsFieldDisplay(source.assetPolicy, "edition.covers")
-      ) {
+      if (!sourceRows[0]) {
         throw new Error(
           "Catalog promotion refused: source policy or rights eligibility drifted",
         );

--- a/src/db/catalog/enrichment/diagnostic-five-promotion-repository.ts
+++ b/src/db/catalog/enrichment/diagnostic-five-promotion-repository.ts
@@ -1181,40 +1181,90 @@ const persistAndRevalidateCoversPostgres = async (
       entry.proposal.representationType === "selected_edition"
         ? "edition.covers"
         : "work.covers";
-    if (
-      !audit ||
-      auditRows.length !== 1 ||
-      audit.projectionState !== "selected" ||
-      audit.projectedCandidateId !== entry.coverCandidate.id ||
-      audit.previousProjectionId !== entry.coverProjections[0].id ||
-      audit.projectionPolicyVersion !== COVER_POLICY_VERSION ||
-      audit.decisionState !== "eligible" ||
-      audit.reviewerRef !== entry.coverDecisions[1].reviewerRef ||
-      audit.previousDecisionId !== entry.coverDecisions[0].id ||
-      canonicalJson(audit.gateCodes) !== canonicalJson([]) ||
-      audit.decisionPolicyVersion !== COVER_POLICY_VERSION ||
-      audit.checksum !== entry.coverInspection.checksum ||
-      audit.decodeResult !== "decoded" ||
-      Number(audit.qualityScore) < 60 ||
-      audit.candidateWorkId !== entry.proposal.workId ||
-      audit.candidateEditionId !== entry.coverCandidate.editionId ||
-      audit.representationType !== entry.proposal.representationType ||
-      audit.permissionState !== "pending" ||
-      audit.rightsBasis !== null ||
-      audit.candidateSourceRevision !== entry.sourceRecord.sourceRevision ||
-      audit.sourcePolicyVersion !== POC_COVER_SOURCE_POLICY_VERSION ||
-      audit.sourceRevision !== entry.sourceRecord.sourceRevision ||
-      audit.sourceState !== "active" ||
-      audit.linkState !== "active" ||
-      Number(audit.mappingConfidence) !== 1 ||
-      audit.sourceApproval !== "approved" ||
-      canonicalJson(persistedAssetPolicy) !== rows.metadataSource.assetPolicy ||
-      !sourcePolicyAllowsFieldDisplay(persistedAssetPolicy, requiredField) ||
-      audit.assetState !== "available" ||
-      audit.assetChecksum !== entry.coverAsset.checksum
-    ) {
+    const driftedChecks = !audit
+      ? ["joined_evidence"]
+      : [
+          [auditRows.length !== 1, "unique_evidence"],
+          [audit.projectionState !== "selected", "projection_state"],
+          [
+            audit.projectedCandidateId !== entry.coverCandidate.id,
+            "projection_candidate",
+          ],
+          [
+            audit.previousProjectionId !== entry.coverProjections[0].id,
+            "projection_predecessor",
+          ],
+          [
+            audit.projectionPolicyVersion !== COVER_POLICY_VERSION,
+            "projection_policy",
+          ],
+          [audit.decisionState !== "eligible", "review_state"],
+          [
+            audit.reviewerRef !== entry.coverDecisions[1].reviewerRef,
+            "reviewer",
+          ],
+          [
+            audit.previousDecisionId !== entry.coverDecisions[0].id,
+            "decision_predecessor",
+          ],
+          [canonicalJson(audit.gateCodes) !== canonicalJson([]), "hard_gates"],
+          [
+            audit.decisionPolicyVersion !== COVER_POLICY_VERSION,
+            "decision_policy",
+          ],
+          [
+            audit.checksum !== entry.coverInspection.checksum,
+            "inspection_hash",
+          ],
+          [audit.decodeResult !== "decoded", "decode"],
+          [Number(audit.qualityScore) < 60, "quality"],
+          [audit.candidateWorkId !== entry.proposal.workId, "work_identity"],
+          [
+            audit.candidateEditionId !== entry.coverCandidate.editionId,
+            "edition_identity",
+          ],
+          [
+            audit.representationType !== entry.proposal.representationType,
+            "identity_scope",
+          ],
+          [audit.permissionState !== "pending", "rights_state"],
+          [audit.rightsBasis !== null, "rights_basis"],
+          [
+            audit.candidateSourceRevision !== entry.sourceRecord.sourceRevision,
+            "candidate_revision",
+          ],
+          [
+            audit.sourcePolicyVersion !== POC_COVER_SOURCE_POLICY_VERSION,
+            "candidate_source_policy",
+          ],
+          [
+            audit.sourceRevision !== entry.sourceRecord.sourceRevision,
+            "source_revision",
+          ],
+          [audit.sourceState !== "active", "source_withdrawal"],
+          [audit.linkState !== "active", "identity_link"],
+          [Number(audit.mappingConfidence) !== 1, "identity_confidence"],
+          [audit.sourceApproval !== "approved", "source_approval"],
+          [
+            canonicalJson(persistedAssetPolicy) !==
+              rows.metadataSource.assetPolicy,
+            "source_policy",
+          ],
+          [
+            !sourcePolicyAllowsFieldDisplay(
+              persistedAssetPolicy,
+              requiredField,
+            ),
+            "source_field_policy",
+          ],
+          [audit.assetState !== "available", "asset_withdrawal"],
+          [audit.assetChecksum !== entry.coverAsset.checksum, "asset_hash"],
+        ]
+          .filter(([drifted]) => drifted)
+          .map(([, code]) => String(code));
+    if (driftedChecks.length > 0) {
       throw new Error(
-        `Catalog cover promotion refused: source, identity, rights, withdrawal, quality, or review eligibility drifted for ${entry.proposal.title}`,
+        `Catalog cover promotion refused: source, identity, rights, withdrawal, quality, or review eligibility drifted for ${entry.proposal.title} (${driftedChecks.join(", ")})`,
       );
     }
   }

--- a/src/db/catalog/enrichment/diagnostic-five-promotion-repository.ts
+++ b/src/db/catalog/enrichment/diagnostic-five-promotion-repository.ts
@@ -622,7 +622,7 @@ export const promoteDiagnosticFivePostgres = async (
            id, key, name, terms_url, attribution_url, reviewed_at,
            approval_state, metadata_policy, asset_policy, payload_policy,
            refresh_interval_ms
-         ) values ($1,$2,$3,$4,$5,to_timestamp($6 / 1000.0),$7,$8::jsonb,$9::jsonb,$10,$11)
+         ) values ($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9::jsonb,$10,$11)
          on conflict(id) do nothing`,
         Object.values(rows.metadataSource),
       );
@@ -632,7 +632,7 @@ export const promoteDiagnosticFivePostgres = async (
              id, source_id, record_key, source_revision, source_modified_at,
              retrieved_at, payload_json, payload_hash, importer_version,
              source_row_hash, state
-           ) values ($1,$2,$3,$4,null,to_timestamp($6 / 1000.0),$7::jsonb,$8,$9,$10,$11)
+           ) values ($1,$2,$3,$4,null,$6,$7::jsonb,$8,$9,$10,$11)
            on conflict(id) do nothing`,
           Object.values(entry.sourceRecord),
         );
@@ -640,7 +640,7 @@ export const promoteDiagnosticFivePostgres = async (
           `insert into source_record_links (
              source_record_id, entity_type, entity_id, match_kind,
              mapping_confidence, state, actor_ref, reason, created_at
-           ) values ($1,$2,$3,$4,$5,$6,$7,$8,to_timestamp($9 / 1000.0))
+           ) values ($1,$2,$3,$4,$5,$6,$7,$8,$9)
            on conflict(source_record_id, entity_type, entity_id) do nothing`,
           Object.values(entry.sourceRecordLink),
         );
@@ -654,7 +654,7 @@ export const promoteDiagnosticFivePostgres = async (
              parent_ids_json
            ) values (
              $1,$2,$3,$4,$5,$6::jsonb,$7,$8,$9,null,
-             to_timestamp($11 / 1000.0),$12,$13,$14,$15,$16,$17,$18::jsonb
+             $11,$12,$13,$14,$15,$16,$17,$18::jsonb
            ) on conflict(id) do nothing`,
           observation,
         );
@@ -774,7 +774,7 @@ export const promoteDiagnosticFivePostgres = async (
                resolved_at
              ) values (
                $1,'work',$2,$3,null,'missing',$4,null,$5,$6,
-               to_timestamp($7 / 1000.0)
+               $7
              )`,
             [
               baselineId,
@@ -822,7 +822,7 @@ export const promoteDiagnosticFivePostgres = async (
              id, entity_type, entity_id, field_key, selected_observation_id,
              state, reason, previous_resolution_id, actor_ref,
              resolver_version, resolved_at
-           ) values ($1,'work',$2,$3,$4,'present',$5,$6,$7,$8,to_timestamp($9 / 1000.0))`,
+           ) values ($1,'work',$2,$3,$4,'present',$5,$6,$7,$8,$9)`,
           [
             resolutionId,
             entry.proposal.workId,
@@ -844,7 +844,7 @@ export const promoteDiagnosticFivePostgres = async (
           `update works set first_publication_date = $1,
                             first_publication_precision = 'year',
                             first_publication_sort_date = $2,
-                            updated_at = to_timestamp($3 / 1000.0)
+                            updated_at = $3
            where id = $4`,
           [
             entry.proposal.value.date,
@@ -981,7 +981,7 @@ export const rollbackDiagnosticFivePostgres = async (
              resolved_at
            ) values (
              $1,'work',$2,$3,null,'missing',$4,$5,$6,$7,
-             to_timestamp($8 / 1000.0)
+             $8
            )`,
           [
             resolutionId,
@@ -1003,7 +1003,7 @@ export const rollbackDiagnosticFivePostgres = async (
           `update works set first_publication_date = null,
                             first_publication_precision = null,
                             first_publication_sort_date = null,
-                            updated_at = to_timestamp($1 / 1000.0)
+                            updated_at = $1
            where id = $2`,
           [input.rolledBackAt ?? Date.now(), proposal.workId],
         );

--- a/src/db/catalog/enrichment/diagnostic-five-promotion-repository.ts
+++ b/src/db/catalog/enrichment/diagnostic-five-promotion-repository.ts
@@ -629,12 +629,23 @@ export const promoteDiagnosticFivePostgres = async (
       for (const entry of rows.entries) {
         await sql.unsafe(
           `insert into source_records (
-             id, source_id, record_key, source_revision, source_modified_at,
-             retrieved_at, payload_json, payload_hash, importer_version,
-             source_row_hash, state
-           ) values ($1,$2,$3,$4,null,$6,$7::jsonb,$8,$9,$10,$11)
+           id, source_id, record_key, source_revision, source_modified_at,
+           retrieved_at, payload_json, payload_hash, importer_version,
+           source_row_hash, state
+           ) values ($1,$2,$3,$4,null,$5,$6::jsonb,$7,$8,$9,$10)
            on conflict(id) do nothing`,
-          Object.values(entry.sourceRecord),
+          [
+            entry.sourceRecord.id,
+            entry.sourceRecord.sourceId,
+            entry.sourceRecord.recordKey,
+            entry.sourceRecord.sourceRevision,
+            entry.sourceRecord.retrievedAt,
+            entry.sourceRecord.payloadJson,
+            entry.sourceRecord.payloadHash,
+            entry.sourceRecord.importerVersion,
+            entry.sourceRecord.sourceRowHash,
+            entry.sourceRecord.state,
+          ],
         );
         await sql.unsafe(
           `insert into source_record_links (
@@ -644,7 +655,6 @@ export const promoteDiagnosticFivePostgres = async (
            on conflict(source_record_id, entity_type, entity_id) do nothing`,
           Object.values(entry.sourceRecordLink),
         );
-        const observation = Object.values(entry.fieldObservation);
         await sql.unsafe(
           `insert into field_observations (
              id, source_record_id, entity_type, entity_id, field_key,
@@ -654,9 +664,26 @@ export const promoteDiagnosticFivePostgres = async (
              parent_ids_json
            ) values (
              $1,$2,$3,$4,$5,$6::jsonb,$7,$8,$9,null,
-             $11,$12,$13,$14,$15,$16,$17,$18::jsonb
+             $10,$11,$12,$13,$14,$15,$16,null
            ) on conflict(id) do nothing`,
-          observation,
+          [
+            entry.fieldObservation.id,
+            entry.fieldObservation.sourceRecordId,
+            entry.fieldObservation.entityType,
+            entry.fieldObservation.entityId,
+            entry.fieldObservation.fieldKey,
+            entry.fieldObservation.valueJson,
+            entry.fieldObservation.comparisonHash,
+            entry.fieldObservation.provenanceKind,
+            entry.fieldObservation.sourcePath,
+            entry.fieldObservation.retrievedAt,
+            entry.fieldObservation.mappingConfidence,
+            entry.fieldObservation.state,
+            entry.fieldObservation.actorRef,
+            entry.fieldObservation.reason,
+            entry.fieldObservation.derivationName,
+            entry.fieldObservation.derivationVersion,
+          ],
         );
       }
       const sourceRows = await sql.unsafe<

--- a/src/db/catalog/enrichment/diagnostic-five-promotion-repository.ts
+++ b/src/db/catalog/enrichment/diagnostic-five-promotion-repository.ts
@@ -12,6 +12,7 @@ import {
   assertDiagnosticFiveCoverEligibility,
   assertExactCoverProposalAllowlist,
   diagnosticFiveCoverRows,
+  POC_COVER_SOURCE_POLICY_VERSION,
 } from "./diagnostic-five-cover-promotion";
 import {
   APPROVED_PROMOTION_PROPOSALS,
@@ -1093,8 +1094,65 @@ const persistAndRevalidateCoversPostgres = async (
     changed ||= !currentProjectionHeads[0];
     projectionIds.push(entry.coverProjectionHead.projectionId);
 
-    const eligible = await sql.unsafe<Array<{ eligible: number }>>(
-      `select 1 as eligible
+    const auditRows = await sql.unsafe<
+      Array<{
+        projectionState: string;
+        projectedCandidateId: string | null;
+        previousProjectionId: string | null;
+        projectionPolicyVersion: string;
+        decisionState: string;
+        reviewerRef: string | null;
+        previousDecisionId: string | null;
+        gateCodes: unknown;
+        decisionPolicyVersion: string;
+        checksum: string;
+        decodeResult: string;
+        qualityScore: number;
+        candidateWorkId: string;
+        candidateEditionId: string | null;
+        representationType: string;
+        permissionState: string;
+        rightsBasis: string | null;
+        candidateSourceRevision: string;
+        sourcePolicyVersion: string;
+        sourceRevision: string | null;
+        sourceState: string;
+        linkState: string;
+        mappingConfidence: number;
+        sourceApproval: string;
+        assetPolicy: unknown;
+        assetState: string;
+        assetChecksum: string | null;
+      }>
+    >(
+      `select
+         p.state as "projectionState",
+         p.candidate_id as "projectedCandidateId",
+         p.previous_projection_id as "previousProjectionId",
+         p.policy_version as "projectionPolicyVersion",
+         d.state as "decisionState",
+         d.reviewer_ref as "reviewerRef",
+         d.previous_decision_id as "previousDecisionId",
+         d.gate_codes_json as "gateCodes",
+         d.policy_version as "decisionPolicyVersion",
+         i.checksum,
+         i.decode_result as "decodeResult",
+         i.quality_score as "qualityScore",
+         c.work_id as "candidateWorkId",
+         c.edition_id as "candidateEditionId",
+         c.representation_type as "representationType",
+         c.permission_state as "permissionState",
+         c.rights_basis as "rightsBasis",
+         c.source_revision as "candidateSourceRevision",
+         c.source_policy_version as "sourcePolicyVersion",
+         sr.source_revision as "sourceRevision",
+         sr.state as "sourceState",
+         sl.state as "linkState",
+         sl.mapping_confidence as "mappingConfidence",
+         ms.approval_state as "sourceApproval",
+         ms.asset_policy as "assetPolicy",
+         ca.state as "assetState",
+         ca.checksum as "assetChecksum"
        from cover_projection_heads h
        join cover_projections p on p.id = h.projection_id
        join cover_candidates c on c.id = p.candidate_id
@@ -1106,35 +1164,55 @@ const persistAndRevalidateCoversPostgres = async (
          and sl.entity_type = $1 and sl.entity_id = $2
        join metadata_sources ms on ms.id = sr.source_id
        join cover_assets ca on ca.object_key = c.object_key
-       where h.work_id = $3 and h.projection_id = $4
-         and p.state = 'selected' and p.candidate_id = $5
-         and p.previous_projection_id = $6
-         and d.state = 'eligible' and d.reviewer_ref = $7
-         and d.previous_decision_id = $8 and d.gate_codes_json = '[]'::jsonb
-         and i.checksum = $9 and i.decode_result = 'decoded'
-         and i.quality_score >= 60
-         and c.permission_state = 'pending' and c.rights_basis is null
-         and c.source_revision = sr.source_revision
-         and sr.state = 'active' and sl.state = 'active'
-         and sl.mapping_confidence = 1
-         and ms.approval_state = 'approved'
-         and ms.asset_policy = $10::jsonb
-         and ca.state = 'available' and ca.checksum = $11`,
+       where h.work_id = $3 and h.projection_id = $4`,
       [
         entry.sourceRecordLink.entityType,
         entry.sourceRecordLink.entityId,
         entry.proposal.workId,
         entry.coverProjectionHead.projectionId,
-        entry.coverCandidate.id,
-        entry.coverProjections[0].id,
-        entry.coverDecisions[1].reviewerRef,
-        entry.coverDecisions[0].id,
-        entry.coverInspection.checksum,
-        rows.metadataSource.assetPolicy,
-        entry.coverAsset.checksum,
       ],
     );
-    if (!eligible[0]) {
+    const audit = auditRows[0];
+    const persistedAssetPolicy =
+      typeof audit?.assetPolicy === "string"
+        ? JSON.parse(audit.assetPolicy)
+        : audit?.assetPolicy;
+    const requiredField =
+      entry.proposal.representationType === "selected_edition"
+        ? "edition.covers"
+        : "work.covers";
+    if (
+      !audit ||
+      auditRows.length !== 1 ||
+      audit.projectionState !== "selected" ||
+      audit.projectedCandidateId !== entry.coverCandidate.id ||
+      audit.previousProjectionId !== entry.coverProjections[0].id ||
+      audit.projectionPolicyVersion !== COVER_POLICY_VERSION ||
+      audit.decisionState !== "eligible" ||
+      audit.reviewerRef !== entry.coverDecisions[1].reviewerRef ||
+      audit.previousDecisionId !== entry.coverDecisions[0].id ||
+      canonicalJson(audit.gateCodes) !== canonicalJson([]) ||
+      audit.decisionPolicyVersion !== COVER_POLICY_VERSION ||
+      audit.checksum !== entry.coverInspection.checksum ||
+      audit.decodeResult !== "decoded" ||
+      Number(audit.qualityScore) < 60 ||
+      audit.candidateWorkId !== entry.proposal.workId ||
+      audit.candidateEditionId !== entry.coverCandidate.editionId ||
+      audit.representationType !== entry.proposal.representationType ||
+      audit.permissionState !== "pending" ||
+      audit.rightsBasis !== null ||
+      audit.candidateSourceRevision !== entry.sourceRecord.sourceRevision ||
+      audit.sourcePolicyVersion !== POC_COVER_SOURCE_POLICY_VERSION ||
+      audit.sourceRevision !== entry.sourceRecord.sourceRevision ||
+      audit.sourceState !== "active" ||
+      audit.linkState !== "active" ||
+      Number(audit.mappingConfidence) !== 1 ||
+      audit.sourceApproval !== "approved" ||
+      canonicalJson(persistedAssetPolicy) !== rows.metadataSource.assetPolicy ||
+      !sourcePolicyAllowsFieldDisplay(persistedAssetPolicy, requiredField) ||
+      audit.assetState !== "available" ||
+      audit.assetChecksum !== entry.coverAsset.checksum
+    ) {
       throw new Error(
         `Catalog cover promotion refused: source, identity, rights, withdrawal, quality, or review eligibility drifted for ${entry.proposal.title}`,
       );

--- a/src/db/catalog/enrichment/diagnostic-five-promotion.pg.test.ts
+++ b/src/db/catalog/enrichment/diagnostic-five-promotion.pg.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../importer";
 import { rebuildCatalogPostgres } from "../postgres-rebuild";
 import { resolveRebuildTarget } from "../rebuild-safety";
+import { APPROVED_COVER_PROPOSAL_IDS } from "./diagnostic-five-cover-promotion";
 import {
   DIAGNOSTIC_FIVE_PROMOTION_APPROVAL,
   DIAGNOSTIC_FIVE_PROMOTION_APPROVAL_ID,
@@ -25,6 +26,7 @@ const promotionInput = {
   reportBytes,
   approvalId: DIAGNOSTIC_FIVE_PROMOTION_APPROVAL_ID,
   proposalIds: DIAGNOSTIC_FIVE_PROMOTION_APPROVAL.approvedProposalIds,
+  coverProposalIds: APPROVED_COVER_PROPOSAL_IDS,
   actorRef: "review:issue-143-postgres-test",
   executionTarget: "disposable",
   promotedAt: Date.UTC(2026, 6, 29, 18, 0, 0),

--- a/src/db/catalog/enrichment/diagnostic-five-promotion.pg.test.ts
+++ b/src/db/catalog/enrichment/diagnostic-five-promotion.pg.test.ts
@@ -1,0 +1,114 @@
+import { readFileSync } from "node:fs";
+import postgres from "postgres";
+import { describe, expect, it } from "vitest";
+import baseCatalog from "../../../../artifacts/catalog";
+import {
+  buildCatalogImportGraph,
+  legacyBooksToImportRecords,
+} from "../importer";
+import { rebuildCatalogPostgres } from "../postgres-rebuild";
+import { resolveRebuildTarget } from "../rebuild-safety";
+import {
+  DIAGNOSTIC_FIVE_PROMOTION_APPROVAL,
+  DIAGNOSTIC_FIVE_PROMOTION_APPROVAL_ID,
+} from "./diagnostic-five-promotion";
+import {
+  promoteDiagnosticFivePostgres,
+  rollbackDiagnosticFivePostgres,
+} from "./diagnostic-five-promotion-repository";
+
+const isolatedUrl = process.env.CATALOG_TEST_POSTGRES_URL;
+const reportBytes = readFileSync(
+  "docs/reports/catalog-enrichment-dry-run-2026-07-29.json",
+);
+const promotionInput = {
+  reportBytes,
+  approvalId: DIAGNOSTIC_FIVE_PROMOTION_APPROVAL_ID,
+  proposalIds: DIAGNOSTIC_FIVE_PROMOTION_APPROVAL.approvedProposalIds,
+  actorRef: "review:issue-143-postgres-test",
+  executionTarget: "disposable",
+  promotedAt: Date.UTC(2026, 6, 29, 18, 0, 0),
+} as const;
+
+describe.skipIf(!isolatedUrl)("diagnostic-five Postgres promotion", () => {
+  it("matches SQLite promotion, rollback, idempotency, and transaction semantics", async () => {
+    const target = resolveRebuildTarget({
+      rawTarget: `postgres:${isolatedUrl}`,
+      confirmDisposable: true,
+      env: { NODE_ENV: "test" },
+    });
+    if (target.driver !== "postgres") {
+      throw new Error("Expected an isolated Postgres target");
+    }
+    const graph = buildCatalogImportGraph(
+      legacyBooksToImportRecords(baseCatalog),
+      { includeApprovedPromotions: false },
+    );
+    await rebuildCatalogPostgres({ url: target.url, graph });
+
+    await expect(
+      promoteDiagnosticFivePostgres(target.url, {
+        ...promotionInput,
+        failAfter: "resolution",
+      }),
+    ).rejects.toThrow("failure after resolution");
+    const client = postgres(target.url, { max: 1 });
+    try {
+      expect(
+        Number(
+          (
+            await client<
+              Array<{ count: string }>
+            >`select count(*)::text as count from works where first_publication_date is not null`
+          )[0]?.count ?? -1,
+        ),
+      ).toBe(0);
+    } finally {
+      await client.end({ timeout: 5_000 });
+    }
+
+    const first = await promoteDiagnosticFivePostgres(
+      target.url,
+      promotionInput,
+    );
+    const second = await promoteDiagnosticFivePostgres(
+      target.url,
+      promotionInput,
+    );
+    expect(first.changed).toBe(true);
+    expect(second).toEqual({ ...first, changed: false });
+
+    const projectionClient = postgres(target.url, { max: 1 });
+    try {
+      expect(
+        await projectionClient<
+          Array<{ title: string; date: string }>
+        >`select preferred_title as title, first_publication_date as date
+          from works where first_publication_date is not null
+          order by preferred_title`,
+      ).toEqual([
+        { title: "Born a Crime", date: "2016" },
+        { title: "Faithful Place", date: "2010" },
+        { title: "Moby-Dick", date: "1851" },
+        { title: "The City and the Stars", date: "1956" },
+      ]);
+    } finally {
+      await projectionClient.end({ timeout: 5_000 });
+    }
+
+    const rolledBack = await rollbackDiagnosticFivePostgres(target.url, {
+      actorRef: "review:issue-143-postgres-rollback",
+      reason: "postgres_parity_rollback",
+      executionTarget: "disposable",
+      rolledBackAt: Date.UTC(2026, 6, 29, 19, 0, 0),
+    });
+    const rollbackRetry = await rollbackDiagnosticFivePostgres(target.url, {
+      actorRef: "review:issue-143-postgres-rollback",
+      reason: "postgres_parity_rollback",
+      executionTarget: "disposable",
+      rolledBackAt: Date.UTC(2026, 6, 29, 19, 0, 0),
+    });
+    expect(rolledBack.changed).toBe(true);
+    expect(rollbackRetry).toEqual({ ...rolledBack, changed: false });
+  }, 120_000);
+});

--- a/src/db/catalog/enrichment/diagnostic-five-promotion.test.ts
+++ b/src/db/catalog/enrichment/diagnostic-five-promotion.test.ts
@@ -69,7 +69,7 @@ describe("diagnostic-five promotion approval", () => {
     );
   });
 
-  it("keeps Dune, descriptions, and covers unresolved in deterministic inputs", () => {
+  it("keeps Dune's date and descriptions unresolved while retaining reviewed PoC covers", () => {
     const graph = buildCatalogImportGraph(
       legacyBooksToImportRecords(baseCatalog),
     );
@@ -90,10 +90,8 @@ describe("diagnostic-five promotion approval", () => {
       payloadPolicy: "full",
     });
     expect(
-      graph.fieldObservations.filter((observation) =>
-        ["work.description", "edition.covers"].includes(
-          String(observation.fieldKey),
-        ),
+      graph.fieldObservations.filter(
+        (observation) => observation.fieldKey === "work.description",
       ),
     ).not.toEqual(
       expect.arrayContaining([
@@ -102,6 +100,7 @@ describe("diagnostic-five promotion approval", () => {
         }),
       ]),
     );
+    expect(graph.coverProjectionHeads).toHaveLength(5);
     expect(
       DIAGNOSTIC_FIVE_PROMOTION_APPROVAL.productionDatabaseExecutionApproved,
     ).toBe(false);

--- a/src/db/catalog/enrichment/diagnostic-five-promotion.test.ts
+++ b/src/db/catalog/enrichment/diagnostic-five-promotion.test.ts
@@ -1,0 +1,136 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import baseCatalog from "../../../../artifacts/catalog";
+import {
+  buildCatalogImportGraph,
+  legacyBooksToImportRecords,
+} from "../importer";
+import {
+  APPROVED_DRY_RUN_MANIFEST_HASH,
+  APPROVED_PROMOTION_PROPOSALS,
+  assertApprovedPromotionReportContent,
+  DIAGNOSTIC_FIVE_PROMOTION_APPROVAL,
+  DIAGNOSTIC_FIVE_PROMOTION_APPROVAL_ID,
+  proposalId,
+  verifyApprovedPromotionReport,
+} from "./diagnostic-five-promotion";
+
+const reportBytes = readFileSync(
+  "docs/reports/catalog-enrichment-dry-run-2026-07-29.json",
+);
+
+describe("diagnostic-five promotion approval", () => {
+  it("accepts only the exact report, manifest, approval, and proposal allow-list", () => {
+    const report = verifyApprovedPromotionReport(reportBytes, {
+      approvalId: DIAGNOSTIC_FIVE_PROMOTION_APPROVAL_ID,
+      proposalIds: DIAGNOSTIC_FIVE_PROMOTION_APPROVAL.approvedProposalIds,
+    });
+
+    expect(report.manifest.contentHash).toBe(APPROVED_DRY_RUN_MANIFEST_HASH);
+    expect(
+      report.proposedResolutions
+        .filter((proposal) =>
+          DIAGNOSTIC_FIVE_PROMOTION_APPROVAL.approvedProposalIds.includes(
+            proposalId(proposal) as never,
+          ),
+        )
+        .map((proposal) => proposal.title)
+        .sort(),
+    ).toEqual(APPROVED_PROMOTION_PROPOSALS.map((entry) => entry.title).sort());
+  });
+
+  it("fails closed for stale reports and incomplete or expanded allow-lists", () => {
+    const stale = Buffer.from(reportBytes);
+    stale[100] = stale[100] === 32 ? 33 : 32;
+    expect(() =>
+      verifyApprovedPromotionReport(stale, {
+        approvalId: DIAGNOSTIC_FIVE_PROMOTION_APPROVAL_ID,
+        proposalIds: DIAGNOSTIC_FIVE_PROMOTION_APPROVAL.approvedProposalIds,
+      }),
+    ).toThrow("report hash is stale");
+    expect(() =>
+      verifyApprovedPromotionReport(reportBytes, {
+        approvalId: DIAGNOSTIC_FIVE_PROMOTION_APPROVAL_ID,
+        proposalIds:
+          DIAGNOSTIC_FIVE_PROMOTION_APPROVAL.approvedProposalIds.slice(1),
+      }),
+    ).toThrow("allow-list is not the exact approved set");
+    expect(() =>
+      verifyApprovedPromotionReport(reportBytes, {
+        approvalId: "inferred-from-passing-ci",
+        proposalIds: DIAGNOSTIC_FIVE_PROMOTION_APPROVAL.approvedProposalIds,
+      }),
+    ).toThrow("approval ID is not exact");
+
+    const staleManifest = JSON.parse(reportBytes.toString("utf8"));
+    staleManifest.manifest.contentHash = "0".repeat(64);
+    expect(() => assertApprovedPromotionReportContent(staleManifest)).toThrow(
+      "manifest or isolated-run identity drifted",
+    );
+  });
+
+  it("keeps Dune, descriptions, and covers unresolved in deterministic inputs", () => {
+    const graph = buildCatalogImportGraph(
+      legacyBooksToImportRecords(baseCatalog),
+    );
+    const promoted = graph.works.filter(
+      (work) => work.firstPublicationDate !== null,
+    );
+    expect(promoted).toHaveLength(4);
+    expect(
+      graph.works.find((work) => work.preferredTitle === "Dune"),
+    ).toMatchObject({ firstPublicationDate: null });
+    expect(
+      graph.metadataSources.find(
+        (source) =>
+          source.key === "wikidata_reviewed_first_publication_issue_143",
+      ),
+    ).toMatchObject({
+      approvalState: "approved",
+      payloadPolicy: "full",
+    });
+    expect(
+      graph.fieldObservations.filter((observation) =>
+        ["work.description", "edition.covers"].includes(
+          String(observation.fieldKey),
+        ),
+      ),
+    ).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sourcePath: "catalog-enrichment-promotion-issue-143",
+        }),
+      ]),
+    );
+    expect(
+      DIAGNOSTIC_FIVE_PROMOTION_APPROVAL.productionDatabaseExecutionApproved,
+    ).toBe(false);
+  });
+
+  it("retains the prior missing head behind every deterministic promotion", () => {
+    const graph = buildCatalogImportGraph(
+      legacyBooksToImportRecords(baseCatalog),
+    );
+    const resolutions = new Map(
+      graph.fieldResolutions.map((resolution) => [resolution.id, resolution]),
+    );
+    for (const proposal of APPROVED_PROMOTION_PROPOSALS) {
+      const head = graph.fieldResolutionHeads.find(
+        (candidate) =>
+          candidate.entityId === proposal.workId &&
+          candidate.fieldKey === "work.first_publication_date",
+      );
+      const current = resolutions.get(head?.resolutionId);
+      const previous = resolutions.get(current?.previousResolutionId);
+      expect(current).toMatchObject({
+        state: "present",
+        resolverVersion: "diagnostic-five-first-publication-2026-07-29.v1",
+      });
+      expect(previous).toMatchObject({
+        state: "missing",
+        selectedObservationId: null,
+        previousResolutionId: null,
+      });
+    }
+  });
+});

--- a/src/db/catalog/enrichment/diagnostic-five-promotion.test.ts
+++ b/src/db/catalog/enrichment/diagnostic-five-promotion.test.ts
@@ -105,7 +105,7 @@ describe("diagnostic-five promotion approval", () => {
     expect(
       DIAGNOSTIC_FIVE_PROMOTION_APPROVAL.productionDatabaseExecutionApproved,
     ).toBe(false);
-  });
+  }, 15_000);
 
   it("retains the prior missing head behind every deterministic promotion", () => {
     const graph = buildCatalogImportGraph(
@@ -132,5 +132,5 @@ describe("diagnostic-five promotion approval", () => {
         previousResolutionId: null,
       });
     }
-  });
+  }, 15_000);
 });

--- a/src/db/catalog/enrichment/diagnostic-five-promotion.ts
+++ b/src/db/catalog/enrichment/diagnostic-five-promotion.ts
@@ -8,6 +8,7 @@ import type { CatalogImportGraph } from "../importer";
 import { normalizeSortText } from "../normalize";
 import { sourcePolicyAllowsFieldDisplay } from "../policy-eligibility";
 import { validateCatalogImportGraph } from "../validate-graph";
+import { applyDiagnosticFiveCoverPromotionToGraph } from "./diagnostic-five-cover-promotion";
 
 export const DIAGNOSTIC_FIVE_PROMOTION_VERSION =
   "diagnostic-five-first-publication-2026-07-29.v1";
@@ -94,8 +95,6 @@ export const DIAGNOSTIC_FIVE_PROMOTION_APPROVAL = {
   repositoryInputApproved: true,
   productionDatabaseExecutionApproved: false,
   exclusions: {
-    covers:
-      "No candidate has both strong identity and display-rights evidence.",
     descriptions:
       "No candidate is review-eligible; queue overflow remains paused.",
     duneFirstPublication:
@@ -476,6 +475,7 @@ export const applyDiagnosticFivePromotionToGraph = (
     work.firstPublicationSortDate = `${entry.proposal.value.date}-01-01`;
     work.updatedAt = PROMOTED_AT;
   }
+  applyDiagnosticFiveCoverPromotionToGraph(graph);
   for (const key of Object.keys(graph) as Array<keyof CatalogImportGraph>) {
     graph[key].sort((left, right) =>
       canonicalJson(left).localeCompare(canonicalJson(right)),

--- a/src/db/catalog/enrichment/diagnostic-five-promotion.ts
+++ b/src/db/catalog/enrichment/diagnostic-five-promotion.ts
@@ -1,0 +1,485 @@
+import { createHash } from "node:crypto";
+import {
+  canonicalJson,
+  deterministicCatalogId,
+  hashCanonicalJson,
+} from "../identity";
+import type { CatalogImportGraph } from "../importer";
+import { normalizeSortText } from "../normalize";
+import { sourcePolicyAllowsFieldDisplay } from "../policy-eligibility";
+import { validateCatalogImportGraph } from "../validate-graph";
+
+export const DIAGNOSTIC_FIVE_PROMOTION_VERSION =
+  "diagnostic-five-first-publication-2026-07-29.v1";
+export const DIAGNOSTIC_FIVE_PROMOTION_APPROVAL_ID =
+  "github-issue-143-reviewed-slice-v1";
+export const APPROVED_DRY_RUN_REPORT_SHA256 =
+  "a85538c057e0b65696644e372f09f18a6da0daf0cefec0d42d641ee4ca6a1b0d";
+export const APPROVED_DRY_RUN_MANIFEST_HASH =
+  "7b7cc856a2c8e8a9aff35098491df49d8cce85c6a7f7639a0c4cecd25fcfa615";
+export const APPROVED_DRY_RUN_CONTENT_HASH =
+  "9b8e04b5cb005181b40e61b0185ed5a5d6b5d9eed902527b891e4d058baad5bd";
+
+const PROMOTED_AT = Date.UTC(2026, 6, 29, 18, 0, 0);
+const SOURCE_POLICY_VERSION =
+  "wikidata-cc0-first-publication-reviewed-2026-07-29";
+const SOURCE_ID = deterministicCatalogId(
+  "metadata_source",
+  "promotion",
+  SOURCE_POLICY_VERSION,
+);
+
+export type ApprovedPromotionProposal = {
+  proposalId: string;
+  workId: string;
+  title: string;
+  providerWorkId: string;
+  value: { date: string; precision: "year" };
+  selectedDryRunObservationId: string;
+  sourceRevision: string;
+};
+
+export const APPROVED_PROMOTION_PROPOSALS = [
+  {
+    proposalId:
+      "proposal:b92631fa785ae1c1f4ec5a67ba12a6a0b6edcff3c5342a3defcf17156f0b1cf8",
+    workId: "03ac5ae7-dcf1-5fe7-b6ac-b8f171459fb3",
+    title: "Born a Crime",
+    providerWorkId: "Q29831237",
+    value: { date: "2016", precision: "year" },
+    selectedDryRunObservationId: "88252688-cf38-574d-8f85-6e185fd30208",
+    sourceRevision: "catalog-dry-run-recorded-2026-07-28:Q29831237",
+  },
+  {
+    proposalId:
+      "proposal:472c8cdf692aaa817240aa01d97a0203c82924ad61ff7c263e46486a1975a5eb",
+    workId: "0100088c-3aca-5e52-9e7a-fb89192e9248",
+    title: "Faithful Place",
+    providerWorkId: "Q5431286",
+    value: { date: "2010", precision: "year" },
+    selectedDryRunObservationId: "b2d0f61d-0b95-5860-ab68-65174979585d",
+    sourceRevision: "catalog-dry-run-recorded-2026-07-28:Q5431286",
+  },
+  {
+    proposalId:
+      "proposal:92a0e3302f5c49026fe159664609e895128226fb5e6a399a4214ca4ef0b732cb",
+    workId: "00a218bd-3005-59cd-9c23-13efb48abe5a",
+    title: "Moby-Dick",
+    providerWorkId: "Q174596",
+    value: { date: "1851", precision: "year" },
+    selectedDryRunObservationId: "f0a6dcdb-fc4d-507a-83f1-1f4c49d6ddc8",
+    sourceRevision: "catalog-dry-run-recorded-2026-07-28:Q174596",
+  },
+  {
+    proposalId:
+      "proposal:382f58212798f70a535d812336067d2a4f986cad8f310177c2332d89aea02bf0",
+    workId: "00a01d7f-3f29-5c95-a292-c70a4e5dbb4f",
+    title: "The City and the Stars",
+    providerWorkId: "Q386544",
+    value: { date: "1956", precision: "year" },
+    selectedDryRunObservationId: "157693f1-d0d2-52cb-9519-387bea225573",
+    sourceRevision: "catalog-dry-run-recorded-2026-07-28:Q386544",
+  },
+] as const satisfies readonly ApprovedPromotionProposal[];
+
+export const DIAGNOSTIC_FIVE_PROMOTION_APPROVAL = {
+  id: DIAGNOSTIC_FIVE_PROMOTION_APPROVAL_ID,
+  issue: 143,
+  approvedManifestHash: APPROVED_DRY_RUN_MANIFEST_HASH,
+  approvedReportSha256: APPROVED_DRY_RUN_REPORT_SHA256,
+  approvedRunContentHash: APPROVED_DRY_RUN_CONTENT_HASH,
+  approvedProposalIds: APPROVED_PROMOTION_PROPOSALS.map(
+    (proposal) => proposal.proposalId,
+  ),
+  repositoryInputApproved: true,
+  productionDatabaseExecutionApproved: false,
+  exclusions: {
+    covers:
+      "No candidate has both strong identity and display-rights evidence.",
+    descriptions:
+      "No candidate is review-eligible; queue overflow remains paused.",
+    duneFirstPublication:
+      "The recorded Wikidata work identity remains ambiguous.",
+    preferredTitles:
+      "The proposed values are identical to current projections and add no narrow-slice value.",
+  },
+} as const;
+
+type DryRunProposal = {
+  workId: string;
+  title: string;
+  fieldKey: string;
+  state: string;
+  selectedObservationId: string | null;
+  reason: string;
+};
+
+type DryRunReport = {
+  formatVersion: string;
+  manifest: { contentHash: string };
+  run: { contentHash: string; promotionExecuted: boolean };
+  proposedResolutions: DryRunProposal[];
+  cases: Array<{
+    workId: string;
+    title: string;
+    match: string;
+    description: string;
+    cover: string;
+  }>;
+};
+
+export const proposalId = (proposal: DryRunProposal): string =>
+  `proposal:${hashCanonicalJson(proposal)}`;
+
+export const assertApprovedPromotionReportContent = (
+  report: DryRunReport,
+): void => {
+  if (
+    report.manifest.contentHash !== APPROVED_DRY_RUN_MANIFEST_HASH ||
+    report.run.contentHash !== APPROVED_DRY_RUN_CONTENT_HASH ||
+    report.run.promotionExecuted
+  ) {
+    throw new Error(
+      "Catalog promotion refused: manifest or isolated-run identity drifted",
+    );
+  }
+  const byId = new Map(
+    report.proposedResolutions.map((proposal) => [
+      proposalId(proposal),
+      proposal,
+    ]),
+  );
+  for (const approved of APPROVED_PROMOTION_PROPOSALS) {
+    const recorded = byId.get(approved.proposalId);
+    if (
+      !recorded ||
+      recorded.workId !== approved.workId ||
+      recorded.title !== approved.title ||
+      recorded.fieldKey !== "work.first_publication_date" ||
+      recorded.state !== "present" ||
+      recorded.selectedObservationId !== approved.selectedDryRunObservationId
+    ) {
+      throw new Error(
+        `Catalog promotion refused: approved proposal drifted for ${approved.title}`,
+      );
+    }
+  }
+  const dune = report.cases.find((entry) => entry.title === "Dune");
+  if (!dune || dune.match !== "ambiguous") {
+    throw new Error(
+      "Catalog promotion refused: Dune ambiguity is no longer represented",
+    );
+  }
+};
+
+export const verifyApprovedPromotionReport = (
+  reportBytes: Uint8Array,
+  input: {
+    approvalId: string;
+    proposalIds: readonly string[];
+  },
+): DryRunReport => {
+  if (input.approvalId !== DIAGNOSTIC_FIVE_PROMOTION_APPROVAL_ID) {
+    throw new Error("Catalog promotion refused: approval ID is not exact");
+  }
+  const requestedIds = [...new Set(input.proposalIds)].sort();
+  const approvedIds = DIAGNOSTIC_FIVE_PROMOTION_APPROVAL.approvedProposalIds
+    .slice()
+    .sort();
+  if (canonicalJson(requestedIds) !== canonicalJson(approvedIds)) {
+    throw new Error(
+      "Catalog promotion refused: proposal allow-list is not the exact approved set",
+    );
+  }
+  const reportHash = createHash("sha256").update(reportBytes).digest("hex");
+  if (reportHash !== APPROVED_DRY_RUN_REPORT_SHA256) {
+    throw new Error("Catalog promotion refused: dry-run report hash is stale");
+  }
+  const report = JSON.parse(
+    Buffer.from(reportBytes).toString("utf8"),
+  ) as DryRunReport;
+  assertApprovedPromotionReportContent(report);
+  return report;
+};
+
+const metadataPolicy = canonicalJson({
+  acquisition: "retained_recorded_snapshot",
+  attribution: {
+    required: false,
+    text: "Wikidata",
+    url: "https://www.wikidata.org/",
+  },
+  display: true,
+  fieldPermission: {
+    allowedFields: ["work.first_publication_date"],
+    cache: true,
+    display: true,
+    fetch: false,
+    retain: "full",
+    transform: true,
+  },
+  policySources: [
+    "https://www.wikidata.org/wiki/Wikidata:Licensing",
+    "https://www.wikidata.org/wiki/Wikidata:Data_access",
+  ],
+  proposedEvidenceOnly: false,
+  sourcePolicyVersion: SOURCE_POLICY_VERSION,
+  withdrawal: {
+    recomputeProposals: true,
+    tombstone: true,
+  },
+});
+
+const assetPolicy = canonicalJson({
+  display: false,
+  fieldPermission: {
+    allowedFields: [],
+    cache: false,
+    display: false,
+    fetch: false,
+    retain: "none",
+    transform: false,
+  },
+  proposedEvidenceOnly: true,
+  sourcePolicyVersion: SOURCE_POLICY_VERSION,
+});
+
+export type PromotionEvidenceRows = ReturnType<typeof promotionEvidenceRows>;
+
+export const promotionEvidenceRows = () => {
+  const metadataSource = {
+    id: SOURCE_ID,
+    key: "wikidata_reviewed_first_publication_issue_143",
+    name: "Reviewed Wikidata first-publication evidence for issue #143",
+    termsUrl: "https://www.wikidata.org/wiki/Wikidata:Licensing",
+    attributionUrl: "https://www.wikidata.org/",
+    reviewedAt: PROMOTED_AT,
+    approvalState: "approved",
+    metadataPolicy,
+    assetPolicy,
+    payloadPolicy: "full",
+    refreshIntervalMs: null,
+  };
+  const entries = APPROVED_PROMOTION_PROPOSALS.map((proposal) => {
+    const payload = {
+      approvedManifestHash: APPROVED_DRY_RUN_MANIFEST_HASH,
+      approvedReportSha256: APPROVED_DRY_RUN_REPORT_SHA256,
+      approvedProposalId: proposal.proposalId,
+      providerWorkId: proposal.providerWorkId,
+      selectedDryRunObservationId: proposal.selectedDryRunObservationId,
+      sourceRevision: proposal.sourceRevision,
+      value: proposal.value,
+    };
+    const sourceRecordId = deterministicCatalogId(
+      "source_record",
+      SOURCE_POLICY_VERSION,
+      proposal.providerWorkId,
+    );
+    const observationId = deterministicCatalogId(
+      "field_observation",
+      sourceRecordId,
+      `work:${proposal.workId}:work.first_publication_date:${hashCanonicalJson(proposal.value)}`,
+    );
+    return {
+      proposal,
+      sourceRecord: {
+        id: sourceRecordId,
+        sourceId: SOURCE_ID,
+        recordKey: proposal.providerWorkId,
+        sourceRevision: proposal.sourceRevision,
+        sourceModifiedAt: null,
+        retrievedAt: PROMOTED_AT,
+        payloadJson: canonicalJson(payload),
+        payloadHash: hashCanonicalJson(payload),
+        importerVersion: DIAGNOSTIC_FIVE_PROMOTION_VERSION,
+        sourceRowHash: hashCanonicalJson(payload),
+        state: "active",
+      },
+      sourceRecordLink: {
+        sourceRecordId,
+        entityType: "work",
+        entityId: proposal.workId,
+        matchKind: "source_relationship",
+        mappingConfidence: 1,
+        state: "active",
+        actorRef: "review:github-issue-143",
+        reason: `Reviewed provider-native work relation ${proposal.providerWorkId}`,
+        createdAt: PROMOTED_AT,
+      },
+      fieldObservation: {
+        id: observationId,
+        sourceRecordId,
+        entityType: "work",
+        entityId: proposal.workId,
+        fieldKey: "work.first_publication_date",
+        valueJson: canonicalJson(proposal.value),
+        comparisonHash: hashCanonicalJson(proposal.value),
+        provenanceKind: "imported",
+        sourcePath: "claims.P577.recordedValue",
+        sourceModifiedAt: null,
+        retrievedAt: PROMOTED_AT,
+        mappingConfidence: 1,
+        state: "active",
+        actorRef: null,
+        reason: null,
+        derivationName: null,
+        derivationVersion: null,
+        parentIdsJson: null,
+      },
+    };
+  });
+  return { metadataSource, entries };
+};
+
+export const assertPromotionEvidenceEligibility = (
+  rows: PromotionEvidenceRows,
+): void => {
+  if (
+    rows.metadataSource.approvalState !== "approved" ||
+    !sourcePolicyAllowsFieldDisplay(
+      rows.metadataSource.metadataPolicy,
+      "work.first_publication_date",
+    ) ||
+    sourcePolicyAllowsFieldDisplay(
+      rows.metadataSource.assetPolicy,
+      "edition.covers",
+    )
+  ) {
+    throw new Error(
+      "Catalog promotion refused: source or rights policy drifted",
+    );
+  }
+  for (const entry of rows.entries) {
+    if (
+      entry.sourceRecord.state !== "active" ||
+      entry.sourceRecord.sourceRevision !== entry.proposal.sourceRevision ||
+      entry.sourceRecordLink.state !== "active" ||
+      entry.sourceRecordLink.mappingConfidence !== 1 ||
+      entry.sourceRecordLink.entityId !== entry.proposal.workId ||
+      entry.fieldObservation.state !== "active" ||
+      entry.fieldObservation.mappingConfidence !== 1 ||
+      entry.fieldObservation.comparisonHash !==
+        hashCanonicalJson(entry.proposal.value)
+    ) {
+      throw new Error(
+        `Catalog promotion refused: eligibility drifted for ${entry.proposal.title}`,
+      );
+    }
+  }
+};
+
+export const applyDiagnosticFivePromotionToGraph = (
+  graph: CatalogImportGraph,
+): void => {
+  // This reviewed input belongs only to the complete deterministic artifact.
+  // Small fixtures and isolated enrichment targets must remain pre-promotion.
+  if (graph.works.length !== 500) return;
+  const rows = promotionEvidenceRows();
+  assertPromotionEvidenceEligibility(rows);
+  const diagnosticWorks = new Map(
+    graph.works
+      .filter((work) =>
+        [
+          ...APPROVED_PROMOTION_PROPOSALS.map((proposal) => proposal.workId),
+          "7adeda04-34e2-5a7d-a101-de0578138b29",
+        ].includes(String(work.id)),
+      )
+      .map((work) => [String(work.id), work]),
+  );
+  if (diagnosticWorks.size !== 5) {
+    throw new Error(
+      "Catalog promotion refused: diagnostic-five scope is incomplete",
+    );
+  }
+  graph.metadataSources.push(rows.metadataSource);
+  for (const entry of rows.entries) {
+    const work = diagnosticWorks.get(entry.proposal.workId);
+    if (
+      !work ||
+      work.preferredTitle !== entry.proposal.title ||
+      work.sortTitle !== normalizeSortText(entry.proposal.title) ||
+      work.firstPublicationDate !== null
+    ) {
+      throw new Error(
+        `Catalog promotion refused: deterministic input drifted for ${entry.proposal.title}`,
+      );
+    }
+    let head = graph.fieldResolutionHeads.find(
+      (candidate) =>
+        candidate.entityType === "work" &&
+        candidate.entityId === entry.proposal.workId &&
+        candidate.fieldKey === "work.first_publication_date",
+    );
+    if (!head) {
+      const priorResolutionId = deterministicCatalogId(
+        "field_resolution",
+        `${DIAGNOSTIC_FIVE_PROMOTION_VERSION}:baseline`,
+        entry.proposal.workId,
+      );
+      graph.fieldResolutions.push({
+        id: priorResolutionId,
+        entityType: "work",
+        entityId: entry.proposal.workId,
+        fieldKey: "work.first_publication_date",
+        selectedObservationId: null,
+        state: "missing",
+        reason: "No eligible approved observation before issue #143 promotion",
+        previousResolutionId: null,
+        actorRef: "system:catalog-importer",
+        resolverVersion: `${DIAGNOSTIC_FIVE_PROMOTION_VERSION}:baseline`,
+        resolvedAt: PROMOTED_AT,
+      });
+      head = {
+        entityType: "work",
+        entityId: entry.proposal.workId,
+        fieldKey: "work.first_publication_date",
+        resolutionId: priorResolutionId,
+      };
+      graph.fieldResolutionHeads.push(head);
+    }
+    const previous = graph.fieldResolutions.find(
+      (candidate) => candidate.id === head?.resolutionId,
+    );
+    if (!head || !previous || previous.state !== "missing") {
+      throw new Error(
+        `Catalog promotion refused: prior head drifted for ${entry.proposal.title}`,
+      );
+    }
+    graph.sourceRecords.push(entry.sourceRecord);
+    graph.sourceRecordLinks.push(entry.sourceRecordLink);
+    graph.fieldObservations.push(entry.fieldObservation);
+    const resolutionId = deterministicCatalogId(
+      "field_resolution",
+      DIAGNOSTIC_FIVE_PROMOTION_VERSION,
+      hashCanonicalJson({
+        previousResolutionId: previous.id,
+        proposalId: entry.proposal.proposalId,
+        selectedObservationId: entry.fieldObservation.id,
+      }),
+    );
+    graph.fieldResolutions.push({
+      id: resolutionId,
+      entityType: "work",
+      entityId: entry.proposal.workId,
+      fieldKey: "work.first_publication_date",
+      selectedObservationId: entry.fieldObservation.id,
+      state: "present",
+      reason: `Explicitly reviewed issue #143 proposal ${entry.proposal.proposalId}`,
+      previousResolutionId: previous.id,
+      actorRef: "review:github-issue-143",
+      resolverVersion: DIAGNOSTIC_FIVE_PROMOTION_VERSION,
+      resolvedAt: PROMOTED_AT,
+    });
+    head.resolutionId = resolutionId;
+    work.firstPublicationDate = entry.proposal.value.date;
+    work.firstPublicationPrecision = entry.proposal.value.precision;
+    work.firstPublicationSortDate = `${entry.proposal.value.date}-01-01`;
+    work.updatedAt = PROMOTED_AT;
+  }
+  for (const key of Object.keys(graph) as Array<keyof CatalogImportGraph>) {
+    graph[key].sort((left, right) =>
+      canonicalJson(left).localeCompare(canonicalJson(right)),
+    );
+  }
+  validateCatalogImportGraph(graph);
+};

--- a/src/db/catalog/importer.test.ts
+++ b/src/db/catalog/importer.test.ts
@@ -18,7 +18,7 @@ describe("normalized catalog importer", () => {
     expect(catalogGraphCounts(graph)).toMatchObject({
       works: 500,
       editions: 500,
-      sourceRecords: 1005,
+      sourceRecords: 1009,
       editionCovers: 500,
       coverAssets: 500,
     });
@@ -56,20 +56,37 @@ describe("normalized catalog importer", () => {
     ).toBe(true);
   });
 
-  it("never infers work first publication from imported edition dates", () => {
+  it("projects only the four explicitly approved first-publication observations", () => {
+    const projected = graph.works
+      .filter((work) => work.firstPublicationDate !== null)
+      .map((work) => [work.preferredTitle, work.firstPublicationDate])
+      .sort();
     expect(
       graph.works.every(
         (work) =>
-          work.firstPublicationDate === null &&
-          work.firstPublicationPrecision === null &&
-          work.firstPublicationSortDate === null,
+          work.firstPublicationDate === null ||
+          (work.firstPublicationPrecision === "year" &&
+            work.firstPublicationSortDate ===
+              `${String(work.firstPublicationDate)}-01-01`),
       ),
     ).toBe(true);
     expect(
-      graph.fieldObservations.some(
+      graph.fieldObservations.filter(
         (observation) => observation.fieldKey === "work.first_publication_date",
       ),
-    ).toBe(false);
+    ).toHaveLength(4);
+    expect(projected).toEqual(
+      [
+        ["Born a Crime", "2016"],
+        ["Faithful Place", "2010"],
+        ["Moby-Dick", "1851"],
+        ["The City and the Stars", "1956"],
+      ].sort(),
+    );
+    expect(
+      graph.works.find((work) => work.preferredTitle === "Dune")
+        ?.firstPublicationDate,
+    ).toBeNull();
   });
 
   it("preserves cover object keys independently of target IDs", () => {

--- a/src/db/catalog/importer.test.ts
+++ b/src/db/catalog/importer.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import baseCatalog from "@/../artifacts/catalog";
+import { APPROVED_COVER_PROMOTION_PROPOSALS } from "./enrichment/diagnostic-five-cover-promotion";
 import { ADR_REPRESENTATIVE_RECORDS } from "./fixtures";
 import { canonicalJson, hashCanonicalJson } from "./identity";
 import {
@@ -18,9 +19,9 @@ describe("normalized catalog importer", () => {
     expect(catalogGraphCounts(graph)).toMatchObject({
       works: 500,
       editions: 500,
-      sourceRecords: 1009,
+      sourceRecords: 1014,
       editionCovers: 500,
-      coverAssets: 500,
+      coverAssets: 505,
     });
     expect(new Set(graph.works.map((row) => row.id)).size).toBe(500);
     expect(
@@ -91,7 +92,12 @@ describe("normalized catalog importer", () => {
 
   it("preserves cover object keys independently of target IDs", () => {
     expect(new Set(graph.coverAssets.map((row) => row.objectKey))).toEqual(
-      new Set(baseCatalog.map((book) => book.cover)),
+      new Set([
+        ...baseCatalog.map((book) => book.cover),
+        ...APPROVED_COVER_PROMOTION_PROPOSALS.map(
+          (proposal) => proposal.objectKey,
+        ),
+      ]),
     );
     expect(
       graph.coverAssets.every(

--- a/src/db/catalog/importer.ts
+++ b/src/db/catalog/importer.ts
@@ -1,4 +1,5 @@
 import type { LegacyCatalogArtifactRecord } from "@/../artifacts/catalog/types";
+import { applyDiagnosticFivePromotionToGraph } from "./enrichment/diagnostic-five-promotion";
 import {
   canonicalJson,
   deterministicCatalogId,
@@ -210,6 +211,7 @@ export function legacyBooksToImportRecords(
 
 export function buildCatalogImportGraph(
   inputRecords: CatalogImportRecord[],
+  options: { includeApprovedPromotions?: boolean } = {},
 ): CatalogImportGraph {
   const records = [...inputRecords].sort((left, right) =>
     left.recordKey.localeCompare(right.recordKey),
@@ -924,6 +926,10 @@ export function buildCatalogImportGraph(
         parentIds: [],
       },
     });
+  }
+
+  if (options.includeApprovedPromotions !== false) {
+    applyDiagnosticFivePromotionToGraph(graph);
   }
 
   for (const key of Object.keys(graph) as Array<keyof CatalogImportGraph>) {

--- a/src/db/catalog/importer.ts
+++ b/src/db/catalog/importer.ts
@@ -80,6 +80,12 @@ export type CatalogImportGraph = {
   editionIdentifiers: Array<Record<string, unknown>>;
   coverAssets: Array<Record<string, unknown>>;
   editionCovers: Array<Record<string, unknown>>;
+  coverCandidates: Array<Record<string, unknown>>;
+  coverInspections: Array<Record<string, unknown>>;
+  coverDecisions: Array<Record<string, unknown>>;
+  coverDecisionHeads: Array<Record<string, unknown>>;
+  coverProjections: Array<Record<string, unknown>>;
+  coverProjectionHeads: Array<Record<string, unknown>>;
   sourceRecords: Array<Record<string, unknown>>;
   sourceRecordLinks: Array<Record<string, unknown>>;
   fieldObservations: Array<Record<string, unknown>>;
@@ -231,6 +237,12 @@ export function buildCatalogImportGraph(
     editionIdentifiers: [],
     coverAssets: [],
     editionCovers: [],
+    coverCandidates: [],
+    coverInspections: [],
+    coverDecisions: [],
+    coverDecisionHeads: [],
+    coverProjections: [],
+    coverProjectionHeads: [],
     sourceRecords: [],
     sourceRecordLinks: [],
     fieldObservations: [],

--- a/src/db/catalog/postgres-rebuild.ts
+++ b/src/db/catalog/postgres-rebuild.ts
@@ -9,6 +9,12 @@ import {
   catalogChangeEventsPg,
   categoriesPg,
   coverAssetsPg,
+  coverCandidatesPg,
+  coverDecisionHeadsPg,
+  coverDecisionsPg,
+  coverInspectionsPg,
+  coverProjectionHeadsPg,
+  coverProjectionsPg,
   editionCoversPg,
   editionIdentifiersPg,
   editionLanguagesPg,
@@ -242,6 +248,59 @@ export async function rebuildCatalogPostgres(input: {
           .onConflictDoNothing();
       }
       maybeFail("sourceRecordLinks");
+      for (const batch of chunks(
+        graph.coverCandidates.map((row) => ({
+          ...(row as typeof coverCandidatesPg.$inferInsert),
+          identityEvidenceJson: parseJson(row.identityEvidenceJson),
+          transformationHistoryJson: parseJson(row.transformationHistoryJson),
+        })),
+      )) {
+        await tx.insert(coverCandidatesPg).values(batch).onConflictDoNothing();
+      }
+      maybeFail("coverCandidates");
+      for (const batch of chunks(
+        graph.coverInspections.map((row) => ({
+          ...(row as typeof coverInspectionsPg.$inferInsert),
+          flagsJson: parseJson(row.flagsJson),
+        })),
+      )) {
+        await tx.insert(coverInspectionsPg).values(batch).onConflictDoNothing();
+      }
+      maybeFail("coverInspections");
+      for (const batch of chunks(
+        graph.coverDecisions.map((row) => ({
+          ...(row as typeof coverDecisionsPg.$inferInsert),
+          gateCodesJson: parseJson(row.gateCodesJson),
+          warningCodesJson: parseJson(row.warningCodesJson),
+        })),
+      )) {
+        await tx.insert(coverDecisionsPg).values(batch).onConflictDoNothing();
+      }
+      maybeFail("coverDecisions");
+      for (const batch of chunks(
+        graph.coverDecisionHeads as (typeof coverDecisionHeadsPg.$inferInsert)[],
+      )) {
+        await tx
+          .insert(coverDecisionHeadsPg)
+          .values(batch)
+          .onConflictDoNothing();
+      }
+      maybeFail("coverDecisionHeads");
+      for (const batch of chunks(
+        graph.coverProjections as (typeof coverProjectionsPg.$inferInsert)[],
+      )) {
+        await tx.insert(coverProjectionsPg).values(batch).onConflictDoNothing();
+      }
+      maybeFail("coverProjections");
+      for (const batch of chunks(
+        graph.coverProjectionHeads as (typeof coverProjectionHeadsPg.$inferInsert)[],
+      )) {
+        await tx
+          .insert(coverProjectionHeadsPg)
+          .values(batch)
+          .onConflictDoNothing();
+      }
+      maybeFail("coverProjectionHeads");
 
       for (const batch of chunks(
         graph.fieldObservations.map((row) => ({

--- a/src/db/catalog/repository.test.ts
+++ b/src/db/catalog/repository.test.ts
@@ -93,7 +93,7 @@ describe("normalized catalog repository", () => {
     );
     const beforeDetailQueries = queryCount;
     const detail = await repository.getWorkDetail(summary.id);
-    expect(queryCount - beforeDetailQueries).toBeLessThanOrEqual(10);
+    expect(queryCount - beforeDetailQueries).toBeLessThanOrEqual(11);
     expect(detail?.authors.map((author) => author.name)).toEqual([
       "Tomas Grey",
     ]);

--- a/src/db/catalog/repository.ts
+++ b/src/db/catalog/repository.ts
@@ -18,9 +18,11 @@ import type {
   EditionSummary,
   WorkAuthor,
   WorkCategory,
+  WorkCover,
   WorkDetail,
   WorkSummary,
 } from "@/features/books/types";
+import { COVER_POLICY_VERSION } from "./enrichment/covers/types";
 import { sourcePolicyAllowsFieldDisplay } from "./policy-eligibility";
 
 export type CatalogQueryExecutor = {
@@ -107,6 +109,23 @@ type CoverRow = {
   mediaType: string | null;
   width: number | null;
   height: number | null;
+};
+
+type WorkCoverRow = {
+  workId: string;
+  id: string;
+  objectKey: string;
+  representationType: "selected_edition" | "work_representative";
+  editionId: string | null;
+  permissionState: "approved" | "pending" | "denied";
+  mediaType: string | null;
+  width: number | null;
+  height: number | null;
+  sourceRecordState: "active" | "withdrawn" | "deleted";
+  sourceApproval: "pending" | "approved" | "suspended" | "retired";
+  assetPolicy: string | Record<string, unknown> | null;
+  decisionPolicyVersion: string;
+  projectionPolicyVersion: string;
 };
 
 type ProvenanceRow = {
@@ -595,10 +614,11 @@ export function createCatalogRepository(
       .map((row) => row.preferredEditionId)
       .filter((id): id is string => Boolean(id));
 
-    const [authorRows, categoryRows, editionRows] = await Promise.all([
-      queryInChunks<AuthorRow>(
-        workIds,
-        (values) => `
+    const [authorRows, categoryRows, editionRows, workCoverRows] =
+      await Promise.all([
+        queryInChunks<AuthorRow>(
+          workIds,
+          (values) => `
           select
             wa.work_id as "workId",
             a.id as "id",
@@ -610,10 +630,10 @@ export function createCatalogRepository(
           where wa.work_id in (${values})
           order by wa.work_id asc, wa.position asc, a.id asc
         `,
-      ),
-      queryInChunks<CategoryRow>(
-        workIds,
-        (values) => `
+        ),
+        queryInChunks<CategoryRow>(
+          workIds,
+          (values) => `
           select
             wc.work_id as "workId",
             c.id as "id",
@@ -626,11 +646,45 @@ export function createCatalogRepository(
           where wc.work_id in (${values}) and c.status = 'active'
           order by wc.work_id asc, wc.position asc, c.id asc
         `,
-      ),
-      options.includeAllEditions
-        ? loadEditionRowsByWorkIds(workIds)
-        : loadEditionRowsByIds(preferredEditionIds),
-    ]);
+        ),
+        options.includeAllEditions
+          ? loadEditionRowsByWorkIds(workIds)
+          : loadEditionRowsByIds(preferredEditionIds),
+        queryInChunks<WorkCoverRow>(
+          workIds,
+          (values) => `
+          select
+            p.work_id as "workId",
+            c.id as "id",
+            c.object_key as "objectKey",
+            c.representation_type as "representationType",
+            c.edition_id as "editionId",
+            c.permission_state as "permissionState",
+            i.media_type as "mediaType",
+            i.width as "width",
+            i.height as "height",
+            sr.state as "sourceRecordState",
+            ms.approval_state as "sourceApproval",
+            ms.asset_policy as "assetPolicy",
+            d.policy_version as "decisionPolicyVersion",
+            p.policy_version as "projectionPolicyVersion"
+          from cover_projection_heads h
+          join cover_projections p on p.id = h.projection_id
+          join cover_candidates c on c.id = p.candidate_id
+          join cover_decision_heads dh on dh.candidate_id = c.id
+          join cover_decisions d on d.id = dh.decision_id
+          join cover_inspections i on i.id = d.inspection_id
+          join source_records sr on sr.id = c.source_record_id
+          join metadata_sources ms on ms.id = sr.source_id
+          join cover_assets ca
+            on ca.object_key = c.object_key and ca.state = 'available'
+          where p.work_id in (${values})
+            and p.state in ('selected', 'rolled_back')
+            and d.state = 'eligible'
+          order by p.work_id asc, c.id asc
+        `,
+        ),
+      ]);
 
     const editionIds = editionRows.map((row) => row.id);
     const [publisherRows, languageRows, identifierRows, coverRows] =
@@ -762,6 +816,38 @@ export function createCatalogRepository(
       });
     }
 
+    const coversByWork = new Map<string, WorkCover>();
+    for (const row of workCoverRows) {
+      const requiredField =
+        row.representationType === "selected_edition"
+          ? "edition.covers"
+          : "work.covers";
+      if (
+        coversByWork.has(row.workId) ||
+        row.sourceRecordState !== "active" ||
+        row.sourceApproval !== "approved" ||
+        row.permissionState === "denied" ||
+        row.decisionPolicyVersion !== COVER_POLICY_VERSION ||
+        row.projectionPolicyVersion !== COVER_POLICY_VERSION ||
+        !sourcePolicyAllowsFieldDisplay(row.assetPolicy, requiredField)
+      ) {
+        continue;
+      }
+      coversByWork.set(row.workId, {
+        id: row.id,
+        objectKey: row.objectKey,
+        mediaType: optional(row.mediaType),
+        width: optional(row.width),
+        height: optional(row.height),
+        identityScope:
+          row.representationType === "selected_edition" ? "edition" : "work",
+        editionId: optional(row.editionId),
+        rightsStatus:
+          row.permissionState === "approved" ? "cleared" : "deferred_poc",
+        rightsCleared: row.permissionState === "approved",
+      });
+    }
+
     const editionsById = new Map<string, EditionSummary>();
     const editionsByWork = new Map<string, EditionSummary[]>();
     for (const row of editionRows) {
@@ -799,6 +885,7 @@ export function createCatalogRepository(
         authors: authorsByWork.get(row.id) ?? [],
         primaryCategory: categories.find((category) => category.isPrimary),
         preferredEdition,
+        cover: coversByWork.get(row.id),
       };
       if (!options.includeAllEditions) return summary;
       const allEditions = editionsByWork.get(row.id) ?? [];

--- a/src/db/catalog/sqlite-rebuild.test.ts
+++ b/src/db/catalog/sqlite-rebuild.test.ts
@@ -38,7 +38,7 @@ describe("SQLite normalized catalog rebuild", () => {
     expect(second.hash).toBe(first.hash);
     expect(second.tables.works).toHaveLength(500);
     expect(second.tables.editions).toHaveLength(500);
-    expect(second.tables.cover_assets).toHaveLength(500);
+    expect(second.tables.cover_assets).toHaveLength(505);
     expect(second.tables.field_resolution_heads).toHaveLength(8016);
   }, 30_000);
 
@@ -300,7 +300,7 @@ describe("SQLite normalized catalog rebuild", () => {
                  and length(source_row_hash) = 64`,
           )
           .get(),
-      ).toEqual({ count: 1004 });
+      ).toEqual({ count: 1009 });
 
       const workIndexes = raw
         .prepare("pragma index_list('works')")

--- a/src/db/catalog/sqlite-rebuild.test.ts
+++ b/src/db/catalog/sqlite-rebuild.test.ts
@@ -39,7 +39,7 @@ describe("SQLite normalized catalog rebuild", () => {
     expect(second.tables.works).toHaveLength(500);
     expect(second.tables.editions).toHaveLength(500);
     expect(second.tables.cover_assets).toHaveLength(500);
-    expect(second.tables.field_resolution_heads).toHaveLength(8012);
+    expect(second.tables.field_resolution_heads).toHaveLength(8016);
   }, 30_000);
 
   it("is retry-idempotent without a reset", () => {
@@ -300,7 +300,7 @@ describe("SQLite normalized catalog rebuild", () => {
                  and length(source_row_hash) = 64`,
           )
           .get(),
-      ).toEqual({ count: 1000 });
+      ).toEqual({ count: 1004 });
 
       const workIndexes = raw
         .prepare("pragma index_list('works')")

--- a/src/db/catalog/sqlite-rebuild.ts
+++ b/src/db/catalog/sqlite-rebuild.ts
@@ -10,6 +10,12 @@ import {
   catalogChangeEvents,
   categories,
   coverAssets,
+  coverCandidates,
+  coverDecisionHeads,
+  coverDecisions,
+  coverInspections,
+  coverProjectionHeads,
+  coverProjections,
   editionCovers,
   editionIdentifiers,
   editionLanguages,
@@ -242,6 +248,42 @@ export function importCatalogGraphSqlite(
     (batch) =>
       db.insert(sourceRecordLinks).values(batch).onConflictDoNothing().run(),
     "sourceRecordLinks",
+  );
+  insert(
+    graph.coverCandidates as (typeof coverCandidates.$inferInsert)[],
+    (batch) =>
+      db.insert(coverCandidates).values(batch).onConflictDoNothing().run(),
+    "coverCandidates",
+  );
+  insert(
+    graph.coverInspections as (typeof coverInspections.$inferInsert)[],
+    (batch) =>
+      db.insert(coverInspections).values(batch).onConflictDoNothing().run(),
+    "coverInspections",
+  );
+  insert(
+    graph.coverDecisions as (typeof coverDecisions.$inferInsert)[],
+    (batch) =>
+      db.insert(coverDecisions).values(batch).onConflictDoNothing().run(),
+    "coverDecisions",
+  );
+  insert(
+    graph.coverDecisionHeads as (typeof coverDecisionHeads.$inferInsert)[],
+    (batch) =>
+      db.insert(coverDecisionHeads).values(batch).onConflictDoNothing().run(),
+    "coverDecisionHeads",
+  );
+  insert(
+    graph.coverProjections as (typeof coverProjections.$inferInsert)[],
+    (batch) =>
+      db.insert(coverProjections).values(batch).onConflictDoNothing().run(),
+    "coverProjections",
+  );
+  insert(
+    graph.coverProjectionHeads as (typeof coverProjectionHeads.$inferInsert)[],
+    (batch) =>
+      db.insert(coverProjectionHeads).values(batch).onConflictDoNothing().run(),
+    "coverProjectionHeads",
   );
   insert(
     graph.fieldObservations as (typeof fieldObservations.$inferInsert)[],

--- a/src/db/catalog/validate-graph.ts
+++ b/src/db/catalog/validate-graph.ts
@@ -131,6 +131,88 @@ export function validateCatalogImportGraph(graph: CatalogImportGraph): void {
     );
   }
 
+  const coverAssetsByObjectKey = new Map(
+    graph.coverAssets.map((row) => [row.objectKey, row]),
+  );
+  const coverCandidates = new Map(
+    graph.coverCandidates.map((row) => [row.id, row]),
+  );
+  for (const candidate of graph.coverCandidates) {
+    requireInvariant(
+      entityIds.work.has(candidate.workId) &&
+        sourceRecords.has(candidate.sourceRecordId),
+      `cover candidate ${String(candidate.id)} lacks work or source evidence`,
+    );
+    requireInvariant(
+      candidate.representationType === "work_representative"
+        ? candidate.editionId === null
+        : editions.get(candidate.editionId)?.workId === candidate.workId,
+      `cover candidate ${String(candidate.id)} has a mismatched identity scope`,
+    );
+    requireInvariant(
+      coverAssetsByObjectKey.get(candidate.objectKey)?.state === "available",
+      `cover candidate ${String(candidate.id)} lacks an available asset`,
+    );
+  }
+  const coverInspections = new Map(
+    graph.coverInspections.map((row) => [row.id, row]),
+  );
+  for (const inspection of graph.coverInspections) {
+    requireInvariant(
+      coverCandidates.has(inspection.candidateId),
+      `cover inspection ${String(inspection.id)} lacks a candidate`,
+    );
+  }
+  const coverDecisions = new Map(
+    graph.coverDecisions.map((row) => [row.id, row]),
+  );
+  for (const decision of graph.coverDecisions) {
+    requireInvariant(
+      coverCandidates.has(decision.candidateId) &&
+        coverInspections.get(decision.inspectionId)?.candidateId ===
+          decision.candidateId,
+      `cover decision ${String(decision.id)} has mismatched evidence`,
+    );
+    if (decision.previousDecisionId) {
+      requireInvariant(
+        coverDecisions.get(decision.previousDecisionId)?.candidateId ===
+          decision.candidateId,
+        `cover decision ${String(decision.id)} has a mismatched predecessor`,
+      );
+    }
+  }
+  for (const head of graph.coverDecisionHeads) {
+    requireInvariant(
+      coverDecisions.get(head.decisionId)?.candidateId === head.candidateId,
+      `cover decision head ${String(head.candidateId)} is mismatched`,
+    );
+  }
+  const coverProjections = new Map(
+    graph.coverProjections.map((row) => [row.id, row]),
+  );
+  for (const projection of graph.coverProjections) {
+    requireInvariant(
+      entityIds.work.has(projection.workId) &&
+        (projection.candidateId === null ||
+          coverCandidates.get(projection.candidateId)?.workId ===
+            projection.workId),
+      `cover projection ${String(projection.id)} is mismatched`,
+    );
+    if (projection.previousProjectionId) {
+      requireInvariant(
+        coverProjections.get(projection.previousProjectionId)?.workId ===
+          projection.workId,
+        `cover projection ${String(projection.id)} has a mismatched predecessor`,
+      );
+    }
+  }
+  for (const head of graph.coverProjectionHeads) {
+    requireInvariant(
+      coverProjections.get(head.projectionId)?.workId === head.workId,
+      `cover projection head ${String(head.workId)} is mismatched`,
+    );
+  }
+
   for (const [name, rows, ownerKey] of [
     ["work category", graph.workCategories, "workId"],
     ["edition cover", graph.editionCovers, "editionId"],

--- a/src/features/books/BookCard.tsx
+++ b/src/features/books/BookCard.tsx
@@ -13,7 +13,9 @@ export function BookCard({ work, presentation = "grid" }: BookCardProps) {
   const isCompact = presentation === "compact";
   const authors = presentAuthors(work);
   const bibliographicMeta = presentBibliographicMeta(work);
-  const coverSrc = resolveBookCoverSrc(work.preferredEdition?.cover?.objectKey);
+  const coverSrc = resolveBookCoverSrc(
+    work.cover?.objectKey ?? work.preferredEdition?.cover?.objectKey,
+  );
 
   return (
     <article

--- a/src/features/books/BookDetails.test.tsx
+++ b/src/features/books/BookDetails.test.tsx
@@ -88,6 +88,32 @@ describe("BookDetails", () => {
     ).toHaveAttribute("data-src", "/api/media/covers/example.webp");
   });
 
+  it("uses an honestly work-scoped cover without attaching it to an edition", () => {
+    render(
+      <BookDetails
+        work={{
+          ...workDetailFixture,
+          cover: {
+            id: "cover-candidate",
+            objectKey: "/covers/work-representative.webp",
+            identityScope: "work",
+            rightsStatus: "deferred_poc",
+            rightsCleared: false,
+          },
+          preferredEdition: {
+            ...editionFixture,
+            cover: undefined,
+          },
+        }}
+      />,
+    );
+    expect(
+      screen.getByRole("img", {
+        name: /cover of example work by first author, second author/i,
+      }),
+    ).toHaveAttribute("data-src", "/api/media/covers/work-representative.webp");
+  });
+
   it("shows only informative alternate editions", () => {
     const alternate = {
       ...editionFixture,

--- a/src/features/books/BookDetails.tsx
+++ b/src/features/books/BookDetails.tsx
@@ -117,7 +117,7 @@ function editionFacts(edition: EditionSummary): EditionFact[] {
 export function BookDetails({ work }: BookDetailsProps) {
   const edition = work.preferredEdition;
   const authors = joinValues(work.authors.map(creatorLabel));
-  const cover = edition?.cover;
+  const cover = work.cover ?? edition?.cover;
   const coverSrc = resolveBookCoverSrc(cover?.objectKey);
   const coverAlt = cover
     ? authors

--- a/src/features/books/types.ts
+++ b/src/features/books/types.ts
@@ -42,6 +42,13 @@ export type EditionCover = {
   height?: number;
 };
 
+export type WorkCover = EditionCover & {
+  identityScope: "work" | "edition";
+  editionId?: string;
+  rightsStatus: "cleared" | "deferred_poc";
+  rightsCleared: boolean;
+};
+
 export type EditionSummary = {
   id: string;
   title?: string;
@@ -99,6 +106,7 @@ export type WorkSummary = {
   authors: WorkAuthor[];
   primaryCategory?: WorkCategory;
   preferredEdition?: EditionSummary;
+  cover?: WorkCover;
 };
 
 export type WorkDetail = WorkSummary & {

--- a/tests/book-item.spec.ts
+++ b/tests/book-item.spec.ts
@@ -275,12 +275,28 @@ test.describe("Book item page", () => {
         }
       | undefined;
     expect(previous).toBeTruthy();
+    const previousWorkCover = database
+      .prepare(
+        `select
+           h.projection_id as projectionId,
+           p.policy_version as policyVersion
+         from cover_projection_heads h
+         join cover_projections p on p.id = h.projection_id
+         where h.work_id = ?`,
+      )
+      .get(DUNE_ID) as
+      | {
+          projectionId: string;
+          policyVersion: string;
+        }
+      | undefined;
     if (!previous) {
       database.close();
       return;
     }
 
     const withdrawnResolutionId = `playwright-withdrawn-cover-${Date.now()}`;
+    const withdrawnProjectionId = `playwright-withdrawn-work-cover-${Date.now()}`;
     database.transaction(() => {
       database
         .prepare(
@@ -301,6 +317,24 @@ test.describe("Book item page", () => {
           previous.resolverVersion,
           Date.now(),
         );
+      if (previousWorkCover) {
+        database
+          .prepare(
+            `insert into cover_projections (
+               id, work_id, candidate_id, state, previous_projection_id,
+               reason_code, actor_ref, policy_version, projected_at
+             ) values (?, ?, null, 'withdrawn', ?, ?, ?, ?, ?)`,
+          )
+          .run(
+            withdrawnProjectionId,
+            DUNE_ID,
+            previousWorkCover.projectionId,
+            "playwright_isolated_withdrawal",
+            "system:playwright",
+            previousWorkCover.policyVersion,
+            Date.now(),
+          );
+      }
       database
         .prepare(
           `update field_resolution_heads
@@ -313,6 +347,19 @@ test.describe("Book item page", () => {
           previous.entityId,
           previous.fieldKey,
         );
+      if (previousWorkCover) {
+        database
+          .prepare(
+            `update cover_projection_heads
+             set projection_id = ?
+             where work_id = ? and projection_id = ?`,
+          )
+          .run(
+            withdrawnProjectionId,
+            DUNE_ID,
+            previousWorkCover.projectionId,
+          );
+      }
     })();
 
     try {
@@ -340,9 +387,27 @@ test.describe("Book item page", () => {
             previous.entityId,
             previous.fieldKey,
           );
+        if (previousWorkCover) {
+          database
+            .prepare(
+              `update cover_projection_heads
+               set projection_id = ?
+               where work_id = ? and projection_id = ?`,
+            )
+            .run(
+              previousWorkCover.projectionId,
+              DUNE_ID,
+              withdrawnProjectionId,
+            );
+        }
         database
           .prepare("delete from field_resolutions where id = ?")
           .run(withdrawnResolutionId);
+        if (previousWorkCover) {
+          database
+            .prepare("delete from cover_projections where id = ?")
+            .run(withdrawnProjectionId);
+        }
       })();
       database.close();
     }


### PR DESCRIPTION
## Summary

- Retains the four reviewed first-publication promotions: Moby-Dick (1851),
  The City and the Stars (1956), Born a Crime (2016), and Faithful Place (2010).
- Adds exactly five reviewed PoC covers with strong recorded identity and
  immutable provenance; display rights remain explicitly deferred, not cleared.
- Leaves Dune's ambiguous first-publication evidence unresolved and leaves
  description overflow paused.
- Adds a narrow work-cover public fallback so work-level evidence is never
  misrepresented as identifying an edition.

## Linked issue

- Closes #143
- Labels remain aligned: enhancement, backend, database, testing,
  data-curation, area: catalog

## Policy decision

For the PoC only, a cover may be eligible with:

- strong work- or edition-level identity;
- acceptable technical quality with findings retained;
- an explicitly approved source and complete immutable provenance;
- deterministic replacement, withdrawal, purge, and rollback support.

Eligible uncleared covers record `rightsStatus: deferred_poc`,
`rightsCleared: false`, policy `poc-cover-policy-2026-07.v1`, issue #143 as the
decision reference, and mandatory re-review before definitive production
launch. Denied sources remain ineligible. This exception does not affect
descriptions, metadata, previews, downloads, or other fields.

## Approved promotion manifest

| Work | First publication | Cover identity | Cover source | Review |
| --- | --- | --- | --- | --- |
| Dune | Unresolved | Exact selected edition, ISBN 9780441172719 | Open Library Covers | Eligible; tiny-dimension and upscaling warnings retained |
| Moby-Dick | 1851 | Work representative | Standard Ebooks | Eligible; no quality warnings |
| The City and the Stars | 1956 | Work representative | Hachette | Eligible; upscaling warning retained |
| Born a Crime | 2016 | Work representative | Penguin Random House | Eligible; tiny-dimension and upscaling warnings retained |
| Faithful Place | 2010 | Work representative | Penguin Random House | Eligible; tiny-dimension and upscaling warnings retained |

The five normalized WebP objects were uploaded once under new
`/covers/issue-143-*` keys in the configured R2 bucket. No existing object was
overwritten, and no runtime provider fetching or hotlinking was introduced.

## Implementation

- Pins the exact #135 report and date manifest plus an exact five-item cover
  manifest and proposal allow-list.
- Revalidates source approval/policy, identity scope, active links, permission
  state, withdrawal, checksums, decoding, quality score, review chain, and
  current heads inside the SQLite/PostgreSQL transaction.
- Appends automatic and human review decisions plus placeholder/selected cover
  projections, retaining predecessor links and immutable history.
- Adds deterministic, idempotent cover rollback to a placeholder without
  deleting evidence or prior projection heads.
- Includes cover evidence and projection history in deterministic SQLite and
  PostgreSQL rebuilds.
- Reapplies public source, asset, policy, decision, and projection gates when
  loading work covers.
- Adds an explicit PR-preview command that requires Vercel Preview metadata,
  PR #144, the exact branch, deployment ID, database host match, approval ID,
  report hash, and exact proposal allow-lists. A distinct Neon branch is no
  longer required: Preview and Production intentionally share one Neon
  database (no branch-per-deployment), so the repo owner authorized dropping
  only that check while every other proof requirement stays enforced. See
  `docs/catalog-enrichment-promotion-proposal.md` for the full authorization
  record.

## Validation

- [x] `bun run lint`
- [x] `bunx tsc --noEmit`
- [x] `bun run test` (301 passed; 9 environment-gated tests skipped locally)
- [x] `bun run build:ci`
- [x] `bun run test:storybook -- --run` (39 passed)
- [x] `bun run test:playwright` (28 passed)
- [x] deterministic SQLite rebuild and public-projection tests
- [x] service-backed PostgreSQL integration tests (GitHub Actions)
- [x] Markdown lint and offline local-link validation (GitHub Actions)
- [x] actual PR #144 deployment five-page review: promotion executed against
      the shared database; all five `/books/<id>` pages verified correct on
      the Preview deployment (promoted dates and new `issue-143-*` covers).
      Production already reflects the promoted dates (pre-existing column);
      Production will show the new covers once this PR merges and ships the
      cover-reading code that already exists on this branch.

## Preview publication status

The current Vercel deployment is a Preview for PR #144 and the expected branch.
Its injected PostgreSQL hostname matches the existing production Neon
endpoint (Preview and Production intentionally share one database). The repo
owner authorized promotion against that shared database without requiring a
distinct Neon branch; every other preview-proof check (exact PR number,
branch, `VERCEL_ENV=preview`, deployment ID, database host, `.neon.tech`
hostname) remained enforced.

The promotion transaction has run successfully against the shared database:
`{"changed":true,"coverProjectionCount":5,"dateResolutionCount":4}`, confirmed
idempotent on re-run. Shared-browser review of
`https://bukie-33j0fy6qa-amalvs-projects.vercel.app`:

| Work | Visible year | Visible cover | Issue #143 projection visible? |
| --- | --- | --- | --- |
| Dune | Unresolved (1965 shown, unchanged by design) | New `issue-143-dune-open-library` cover | Yes |
| Moby-Dick | 1851 | New `issue-143-moby-dick-standard-ebooks` cover | Yes |
| The City and the Stars | 1956 | New `issue-143-city-stars-hachette` cover | Yes |
| Born a Crime | 2016 | New `issue-143-born-crime-prh` cover | Yes |
| Faithful Place | 2010 | New `issue-143-faithful-place-prh` cover | Yes |

All five new issue-namespaced assets return HTTP 200 through the same
deployment with the exact reviewed byte sizes and dimensions. The browser
reported no console errors.

## Risk and merge readiness

- Medium-risk catalog/data change with exact allow-lists, stale-input
  rejection, in-transaction eligibility checks, failure injection, isolation
  hashes, idempotency, and deterministic rollback.
- Database promotion and Preview five-page verification are complete. The
  shared database is authorized and this promotion already updated it; merging
  this PR ships the code Production needs to display the new covers (dates
  already display correctly on Production today).

## Checklist

- [x] Scope matches the updated issue
- [x] Existing labels remain aligned
- [x] Tests cover the changed safety behavior
- [x] Documentation records the PoC exception and mandatory production re-review
- [x] Local-only source assets and pulled environment files remain excluded
- [x] No generalized promotion platform or schema migration was introduced
